### PR TITLE
Port popup frequency blur to Manabitan

### DIFF
--- a/ext/css/display.css
+++ b/ext/css/display.css
@@ -375,6 +375,7 @@ a:has(rt) {
 .content {
     flex: 1 1 auto;
     position: relative;
+    transition: filter 0.125s ease-in-out, opacity 0.125s ease-in-out;
 }
 .content-scroll {
     position: absolute;
@@ -434,6 +435,7 @@ a:has(rt) {
     display: flex;
     flex-flow: row nowrap;
     overflow: hidden;
+    position: relative;
     align-items: stretch;
     align-content: stretch;
     justify-content: center;
@@ -447,6 +449,62 @@ a:has(rt) {
     z-index: 10;
     position: relative;
     display: none;
+    transition: filter 0.125s ease-in-out, opacity 0.125s ease-in-out;
+}
+:root[data-popup-frequency-blur-state=blurred] .content,
+:root[data-popup-frequency-blur-state=blurred] .content-sidebar {
+    filter: blur(0.5rem);
+    opacity: 0.72;
+}
+.popup-frequency-blur-overlay {
+    position: absolute;
+    inset: 0;
+    z-index: 15;
+    padding: 1rem;
+    pointer-events: none;
+}
+.popup-frequency-blur-overlay:not([hidden]) {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.popup-frequency-blur-card {
+    display: flex;
+    flex-flow: column nowrap;
+    align-items: stretch;
+    gap: 0.25rem;
+    min-width: 13rem;
+    max-width: min(22rem, 100%);
+    padding: 0.625em 0.75em;
+    border: var(--thin-border-size) solid var(--separator-color1);
+    border-radius: var(--menu-border-radius);
+    background-color: var(--background-color-light);
+    box-shadow: var(--menu-shadow);
+    text-align: left;
+}
+.popup-frequency-blur-card-header {
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: center;
+    gap: 0.5em;
+}
+.popup-frequency-blur-card-icon {
+    flex: 0 0 auto;
+    width: calc(16em / var(--font-size-no-units));
+    height: calc(16em / var(--font-size-no-units));
+    background-color: var(--text-color-light1);
+}
+.popup-frequency-blur-card-label {
+    color: var(--text-color);
+    font-size: 1em;
+    font-weight: 600;
+    line-height: 1.35;
+}
+.popup-frequency-blur-card-sublabel {
+    color: var(--text-color-light1);
+    font-size: var(--font-size-small);
+    line-height: 1.3;
+    word-break: break-word;
 }
 :root[data-has-navigation-previous=true] .content-sidebar,
 :root[data-has-navigation-next=true] .content-sidebar,

--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -124,6 +124,11 @@
                                     "termDisplayMode",
                                     "sortFrequencyDictionary",
                                     "sortFrequencyDictionaryOrder",
+                                    "popupBlurByFrequencyEnabled",
+                                    "popupBlurByFrequencyDictionary",
+                                    "popupBlurByFrequencyThreshold",
+                                    "popupBlurByFrequencyOrder",
+                                    "popupBlurByFrequencyUnblurDelay",
                                     "stickySearchHeader",
                                     "fontFamily",
                                     "fontSize",
@@ -335,6 +340,28 @@
                                         "type": "string",
                                         "enum": ["ascending", "descending"],
                                         "default": "descending"
+                                    },
+                                    "popupBlurByFrequencyEnabled": {
+                                        "type": "boolean",
+                                        "default": false
+                                    },
+                                    "popupBlurByFrequencyDictionary": {
+                                        "type": ["string", "null"],
+                                        "default": null
+                                    },
+                                    "popupBlurByFrequencyThreshold": {
+                                        "type": "number",
+                                        "default": 10000
+                                    },
+                                    "popupBlurByFrequencyOrder": {
+                                        "type": "string",
+                                        "enum": ["ascending", "descending"],
+                                        "default": "descending"
+                                    },
+                                    "popupBlurByFrequencyUnblurDelay": {
+                                        "type": "number",
+                                        "minimum": 0,
+                                        "default": 0
                                     },
                                     "stickySearchHeader": {
                                         "type": "boolean",

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -588,6 +588,7 @@ export class OptionsUtil {
             this._updateVersion74,
             this._updateVersion75,
             this._updateVersion76,
+            this._updateVersion77,
         ];
         /* eslint-enable @typescript-eslint/unbound-method */
         if (typeof targetVersion === 'number' && targetVersion < result.length) {
@@ -1853,6 +1854,25 @@ export class OptionsUtil {
             options.global.database = {};
         }
         options.global.database.maxHeadwordLength = 0;
+    }
+
+    /**
+     *  - Added general.popupBlurByFrequencyEnabled
+     *  - Added general.popupBlurByFrequencyDictionary
+     *  - Added general.popupBlurByFrequencyThreshold
+     *  - Added general.popupBlurByFrequencyOrder
+     *  - Added general.popupBlurByFrequencyUnblurDelay
+     *  @type {import('options-util').UpdateFunction}
+     */
+    async _updateVersion77(options) {
+        for (const profile of options.profiles) {
+            const {general} = profile.options;
+            general.popupBlurByFrequencyEnabled = false;
+            general.popupBlurByFrequencyDictionary = null;
+            general.popupBlurByFrequencyThreshold = 10000;
+            general.popupBlurByFrequencyOrder = 'descending';
+            general.popupBlurByFrequencyUnblurDelay = 0;
+        }
     }
 
     /**

--- a/ext/js/display/popup-frequency-blur-controller.js
+++ b/ext/js/display/popup-frequency-blur-controller.js
@@ -1,0 +1,332 @@
+/*
+ * Copyright (C) 2025  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {querySelectorNotNull} from '../dom/query-selector.js';
+
+const numberPattern = /[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?/g;
+
+export class PopupFrequencyBlurController {
+    /**
+     * @param {import('./display.js').Display} display
+     */
+    constructor(display) {
+        /** @type {import('./display.js').Display} */
+        this._display = display;
+        /** @type {HTMLElement} */
+        this._contentOuter = querySelectorNotNull(document, '.content-outer');
+        /** @type {HTMLElement} */
+        this._overlay = querySelectorNotNull(document, '#popup-frequency-blur-overlay');
+        /** @type {HTMLElement} */
+        this._overlayLabel = querySelectorNotNull(document, '#popup-frequency-blur-overlay-label');
+        /** @type {HTMLElement} */
+        this._overlaySublabel = querySelectorNotNull(document, '#popup-frequency-blur-overlay-sublabel');
+        /** @type {boolean} */
+        this._enabled = false;
+        /** @type {?string} */
+        this._dictionary = null;
+        /** @type {number} */
+        this._threshold = 10000;
+        /** @type {import('settings').SortFrequencyDictionaryOrder} */
+        this._order = 'descending';
+        /** @type {number} */
+        this._unblurDelay = 0;
+        /** @type {boolean} */
+        this._pointerHovered = false;
+        /** @type {?number} */
+        this._autoRevealTimeout = null;
+        /** @type {?number} */
+        this._autoRevealCountdownTimeout = null;
+        /** @type {?number} */
+        this._autoRevealDeadline = null;
+        /** @type {boolean} */
+        this._autoRevealTriggered = false;
+        /** @type {'off'|'blurred'|'revealed'} */
+        this._state = 'off';
+    }
+
+    /** */
+    prepare() {
+        this._display.on('optionsUpdated', this._onOptionsUpdated.bind(this));
+        this._display.on('contentClear', this._onContentClear.bind(this));
+        this._display.on('contentUpdateComplete', this._onContentUpdateComplete.bind(this));
+
+        this._contentOuter.addEventListener('pointerenter', this._onPointerEnter.bind(this), false);
+        this._contentOuter.addEventListener('pointerleave', this._onPointerLeave.bind(this), false);
+
+        const options = this._display.getOptions();
+        if (options !== null) {
+            this._onOptionsUpdated({options});
+        } else {
+            this._setState('off');
+        }
+    }
+
+    /**
+     * @param {import('display').EventArgument<'optionsUpdated'>} details
+     */
+    _onOptionsUpdated({options}) {
+        const {
+            popupBlurByFrequencyEnabled,
+            popupBlurByFrequencyDictionary,
+            popupBlurByFrequencyThreshold,
+            popupBlurByFrequencyOrder,
+            popupBlurByFrequencyUnblurDelay,
+        } = options.general;
+        this._enabled = popupBlurByFrequencyEnabled;
+        this._dictionary = popupBlurByFrequencyDictionary;
+        this._threshold = popupBlurByFrequencyThreshold;
+        this._order = popupBlurByFrequencyOrder;
+        this._unblurDelay = popupBlurByFrequencyUnblurDelay;
+        this._resetAutoReveal();
+        this._updateOverlayText();
+        this._updateStateFromContent();
+    }
+
+    /** */
+    _onContentClear() {
+        this._resetAutoReveal();
+        this._setState('off');
+    }
+
+    /**
+     * @param {import('display').EventArgument<'contentUpdateComplete'>} details
+     */
+    _onContentUpdateComplete({type}) {
+        this._resetAutoReveal();
+        if (type !== 'terms') {
+            this._setState('off');
+            return;
+        }
+        this._updateStateFromContent();
+    }
+
+    /** */
+    _onPointerEnter() {
+        this._pointerHovered = true;
+        if (this._state === 'blurred') {
+            this._setState('revealed');
+        }
+    }
+
+    /** */
+    _onPointerLeave() {
+        this._pointerHovered = false;
+        this._updateStateFromContent();
+    }
+
+    /**
+     * @param {?number} [selectedFrequency]
+     */
+    _updateOverlayText(selectedFrequency = this._getFirstTermEntrySelectedFrequency()) {
+        this._overlayLabel.textContent = (
+            Number.isFinite(this._unblurDelay) && this._unblurDelay > 0 ?
+            `Hover or wait ${this._formatDelaySeconds(this._getOverlayDelaySeconds())} to reveal` :
+            'Hover to reveal'
+        );
+        this._overlaySublabel.textContent = (
+            this._enabled && this._dictionary !== null && selectedFrequency !== null ?
+            `${this._dictionary} · frequency ${selectedFrequency}` :
+            ''
+        );
+    }
+
+    /** */
+    _updateStateFromContent() {
+        const selectedFrequency = this._getFirstTermEntrySelectedFrequency();
+        this._updateOverlayText(selectedFrequency);
+        const desiredState = this._getDesiredState(selectedFrequency);
+        if (desiredState === 'blurred') {
+            this._scheduleAutoReveal();
+        } else if (desiredState === 'off') {
+            this._clearAutoRevealTimeout();
+        }
+        this._setState(desiredState);
+    }
+
+    /**
+     * @param {?number} [selectedFrequency]
+     * @returns {'off'|'blurred'|'revealed'}
+     */
+    _getDesiredState(selectedFrequency = this._getFirstTermEntrySelectedFrequency()) {
+        if (document.documentElement.dataset.pageType !== 'popup') { return 'off'; }
+        if (!this._enabled || this._dictionary === null || !Number.isFinite(this._threshold)) {
+            return 'off';
+        }
+        if (selectedFrequency === null) { return 'off'; }
+
+        const qualifies = (
+            this._order === 'ascending' ?
+            selectedFrequency <= this._threshold :
+            selectedFrequency >= this._threshold
+        );
+        if (!qualifies) { return 'off'; }
+
+        return (this._pointerHovered || this._autoRevealTriggered) ? 'revealed' : 'blurred';
+    }
+
+    /**
+     * @returns {?number}
+     */
+    _getFirstTermEntrySelectedFrequency() {
+        const {dictionaryEntries} = this._display;
+        if (dictionaryEntries.length === 0) { return null; }
+
+        const firstDictionaryEntry = dictionaryEntries[0];
+        return firstDictionaryEntry.type === 'term' ? this._getSelectedFrequency(firstDictionaryEntry) : null;
+    }
+
+    /**
+     * @param {import('dictionary').TermDictionaryEntry} dictionaryEntry
+     * @returns {?number}
+     */
+    _getSelectedFrequency(dictionaryEntry) {
+        if (this._dictionary === null) { return null; }
+
+        let result = null;
+        for (const frequency of dictionaryEntry.frequencies) {
+            if (frequency.dictionary !== this._dictionary) { continue; }
+            const value = this._getSelectedFrequencyValue(frequency);
+            if (value === null) { continue; }
+            if (result === null) {
+                result = value;
+            } else {
+                result = (
+                    this._order === 'ascending' ?
+                    Math.min(result, value) :
+                    Math.max(result, value)
+                );
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * @param {import('dictionary').TermFrequency} frequency
+     * @returns {?number}
+     */
+    _getSelectedFrequencyValue(frequency) {
+        const displayValue = this._getParsedDisplayFrequencyValue(frequency);
+        if (displayValue !== null) { return displayValue; }
+
+        const {frequency: value} = frequency;
+        return Number.isFinite(value) ? value : null;
+    }
+
+    /**
+     * @param {import('dictionary').TermFrequency} frequency
+     * @returns {?number}
+     */
+    _getParsedDisplayFrequencyValue({displayValue, displayValueParsed}) {
+        if (!displayValueParsed || typeof displayValue !== 'string') { return null; }
+
+        const matches = displayValue.match(numberPattern);
+        if (matches === null) { return null; }
+
+        let result = null;
+        for (const match of matches) {
+            const value = Number.parseFloat(match);
+            if (!Number.isFinite(value)) { continue; }
+            if (result === null) {
+                result = value;
+            } else {
+                result = (
+                    this._order === 'ascending' ?
+                    Math.min(result, value) :
+                    Math.max(result, value)
+                );
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * @param {'off'|'blurred'|'revealed'} state
+     */
+    _setState(state) {
+        this._state = state;
+        document.documentElement.dataset.popupFrequencyBlurState = state;
+        this._overlay.hidden = (state !== 'blurred');
+    }
+
+    /** */
+    _resetAutoReveal() {
+        this._autoRevealTriggered = false;
+        this._clearAutoRevealTimeout();
+    }
+
+    /** */
+    _scheduleAutoReveal() {
+        if (this._autoRevealTriggered || this._autoRevealTimeout !== null) { return; }
+        if (!Number.isFinite(this._unblurDelay) || this._unblurDelay <= 0) { return; }
+
+        this._autoRevealDeadline = Date.now() + (this._unblurDelay * 1000);
+        this._updateOverlayText();
+        this._scheduleOverlayCountdownUpdate();
+        this._autoRevealTimeout = window.setTimeout(() => {
+            this._clearAutoRevealTimeout();
+            this._autoRevealTriggered = true;
+            this._updateStateFromContent();
+        }, this._unblurDelay * 1000);
+    }
+
+    /** */
+    _scheduleOverlayCountdownUpdate() {
+        const delaySeconds = this._getOverlayDelaySeconds();
+        const displaySeconds = Math.ceil(delaySeconds);
+        if (displaySeconds <= 1) { return; }
+
+        const nextUpdateDelay = Math.max(Math.ceil((delaySeconds - (displaySeconds - 1)) * 1000), 1);
+        this._autoRevealCountdownTimeout = window.setTimeout(() => {
+            this._autoRevealCountdownTimeout = null;
+            this._updateOverlayText();
+            this._scheduleOverlayCountdownUpdate();
+        }, nextUpdateDelay);
+    }
+
+    /** */
+    _clearAutoRevealTimeout() {
+        if (this._autoRevealTimeout !== null) {
+            window.clearTimeout(this._autoRevealTimeout);
+            this._autoRevealTimeout = null;
+        }
+        if (this._autoRevealCountdownTimeout !== null) {
+            window.clearTimeout(this._autoRevealCountdownTimeout);
+            this._autoRevealCountdownTimeout = null;
+        }
+        this._autoRevealDeadline = null;
+    }
+
+    /**
+     * @param {number} delay
+     * @returns {string}
+     */
+    _formatDelaySeconds(delay) {
+        return `${Math.max(Math.ceil(delay), 0)}s`;
+    }
+
+    /**
+     * @returns {number}
+     */
+    _getOverlayDelaySeconds() {
+        if (this._autoRevealDeadline === null) {
+            return this._unblurDelay;
+        }
+        return Math.max((this._autoRevealDeadline - Date.now()) / 1000, 0);
+    }
+}

--- a/ext/js/display/popup-main.js
+++ b/ext/js/display/popup-main.js
@@ -22,6 +22,7 @@ import {HotkeyHandler} from '../input/hotkey-handler.js';
 import {DisplayAnki} from './display-anki.js';
 import {DisplayAudio} from './display-audio.js';
 import {DisplayProfileSelection} from './display-profile-selection.js';
+import {PopupFrequencyBlurController} from './popup-frequency-blur-controller.js';
 import {DisplayResizer} from './display-resizer.js';
 import {Display} from './display.js';
 
@@ -46,6 +47,9 @@ await Application.main(true, async (application) => {
 
     const displayResizer = new DisplayResizer(display);
     displayResizer.prepare();
+
+    const popupFrequencyBlurController = new PopupFrequencyBlurController(display);
+    popupFrequencyBlurController.prepare();
 
     display.initializeState();
 

--- a/ext/js/pages/settings/popup-frequency-blur-controller.js
+++ b/ext/js/pages/settings/popup-frequency-blur-controller.js
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2025  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {querySelectorNotNull} from '../../dom/query-selector.js';
+
+export class PopupFrequencyBlurController {
+    /**
+     * @param {import('./settings-controller.js').SettingsController} settingsController
+     */
+    constructor(settingsController) {
+        /** @type {import('./settings-controller.js').SettingsController} */
+        this._settingsController = settingsController;
+        /** @type {HTMLSelectElement} */
+        this._popupFrequencyBlurDictionarySelect = querySelectorNotNull(document, '#popup-frequency-blur-dictionary');
+        /** @type {?import('core').TokenObject} */
+        this._getDictionaryInfoToken = null;
+    }
+
+    /** */
+    async prepare() {
+        await this._onDatabaseUpdated();
+
+        this._settingsController.application.on('databaseUpdated', this._onDatabaseUpdated.bind(this));
+        this._settingsController.on('optionsChanged', this._onOptionsChanged.bind(this));
+    }
+
+    /** */
+    async _onDatabaseUpdated() {
+        /** @type {?import('core').TokenObject} */
+        const token = {};
+        this._getDictionaryInfoToken = token;
+        const dictionaries = await this._settingsController.getDictionaryInfo();
+        if (this._getDictionaryInfoToken !== token) { return; }
+        this._getDictionaryInfoToken = null;
+
+        this._updateDictionaryOptions(dictionaries);
+
+        const options = await this._settingsController.getOptions();
+        const optionsContext = this._settingsController.getOptionsContext();
+        this._onOptionsChanged({options, optionsContext});
+    }
+
+    /**
+     * @param {import('settings-controller').EventArgument<'optionsChanged'>} details
+     */
+    _onOptionsChanged({options}) {
+        const {popupBlurByFrequencyDictionary} = options.general;
+        this._popupFrequencyBlurDictionarySelect.value = (popupBlurByFrequencyDictionary !== null ? popupBlurByFrequencyDictionary : '');
+    }
+
+    /**
+     * @param {import('dictionary-importer').Summary[]} dictionaries
+     */
+    _updateDictionaryOptions(dictionaries) {
+        const fragment = document.createDocumentFragment();
+        let option = document.createElement('option');
+        option.value = '';
+        option.textContent = 'None';
+        fragment.appendChild(option);
+
+        for (const {title, counts} of dictionaries) {
+            if (counts && counts.termMeta && counts.termMeta.freq > 0) {
+                option = document.createElement('option');
+                option.value = title;
+                option.textContent = title;
+                fragment.appendChild(option);
+            }
+        }
+
+        this._popupFrequencyBlurDictionarySelect.textContent = '';
+        this._popupFrequencyBlurDictionarySelect.appendChild(fragment);
+    }
+}

--- a/ext/js/pages/settings/settings-main.js
+++ b/ext/js/pages/settings/settings-main.js
@@ -39,6 +39,7 @@ import {ModalController} from './modal-controller.js';
 import {NestedPopupsController} from './nested-popups-controller.js';
 import {PermissionsToggleController} from './permissions-toggle-controller.js';
 import {PersistentStorageController} from './persistent-storage-controller.js';
+import {PopupFrequencyBlurController} from './popup-frequency-blur-controller.js';
 import {PopupPreviewController} from './popup-preview-controller.js';
 import {PopupWindowController} from './popup-window-controller.js';
 import {ProfileController} from './profile-controller.js';
@@ -262,6 +263,13 @@ await Application.main(true, async (application) => {
         const startedAt = getNowMs();
         await nestedPopupsController.prepare();
         recordPhase(startupPhases, 'nestedPopupsController.prepare', startedAt);
+    })());
+
+    const popupFrequencyBlurController = new PopupFrequencyBlurController(settingsController);
+    preparePromises.push((async () => {
+        const startedAt = getNowMs();
+        await popupFrequencyBlurController.prepare();
+        recordPhase(startupPhases, 'popupFrequencyBlurController.prepare', startedAt);
     })());
 
     const permissionsToggleController = new PermissionsToggleController(settingsController);

--- a/ext/popup.html
+++ b/ext/popup.html
@@ -73,6 +73,15 @@
                 </div>
             </div>
         </div>
+        <div class="popup-frequency-blur-overlay" id="popup-frequency-blur-overlay" hidden>
+            <div class="popup-frequency-blur-card">
+                <div class="popup-frequency-blur-card-header">
+                    <span class="popup-frequency-blur-card-icon icon" data-icon="lock"></span>
+                    <div class="popup-frequency-blur-card-label" id="popup-frequency-blur-overlay-label">Hover to reveal</div>
+                </div>
+                <div class="popup-frequency-blur-card-sublabel" id="popup-frequency-blur-overlay-sublabel"></div>
+            </div>
+        </div>
     </div>
     <div class="content-sidebar scrollbar" id="content-sidebar">
         <div class="content-sidebar-inner">

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -717,6 +717,62 @@
                 </div></div>
             </div>
         </div>
+        <div class="settings-item">
+            <div class="settings-item-inner">
+                <div class="settings-item-left">
+                    <div class="settings-item-label">Blur popup by frequency</div>
+                    <div class="settings-item-description">Popup pages only. Blur the first term entry when the selected frequency dictionary crosses the configured threshold.</div>
+                </div>
+                <div class="settings-item-right">
+                    <label class="toggle"><input type="checkbox" id="popup-frequency-blur-enabled" data-setting="general.popupBlurByFrequencyEnabled"
+                        data-transform='{
+                            "type": "setVisibility",
+                            "selector": "#popup-frequency-blur-options",
+                            "condition": {"op": "===", "value": true}
+                        }'
+                    ><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
+                </div>
+            </div>
+            <div class="settings-item-children settings-item-children-group" id="popup-frequency-blur-options" hidden>
+                <div class="settings-item"><div class="settings-item-inner settings-item-inner-wrappable">
+                    <div class="settings-item-left">
+                        <div class="settings-item-label">Frequency dictionary</div>
+                        <div class="settings-item-description">Only installed dictionaries with term frequency data are available.</div>
+                    </div>
+                    <div class="settings-item-right">
+                        <select id="popup-frequency-blur-dictionary" data-setting="general.popupBlurByFrequencyDictionary"></select>
+                    </div>
+                </div></div>
+                <div class="settings-item"><div class="settings-item-inner settings-item-inner-wrappable">
+                    <div class="settings-item-left">
+                        <div class="settings-item-label">Frequency mode</div>
+                        <div class="settings-item-description">Occurrence-based treats higher values as more common; rank-based treats lower values as more common.</div>
+                    </div>
+                    <div class="settings-item-right">
+                        <select data-setting="general.popupBlurByFrequencyOrder">
+                            <option value="descending">Occurrence-based</option>
+                            <option value="ascending">Rank-based</option>
+                        </select>
+                    </div>
+                </div></div>
+                <div class="settings-item"><div class="settings-item-inner settings-item-inner-wrappable">
+                    <div class="settings-item-left">
+                        <div class="settings-item-label">Threshold</div>
+                    </div>
+                    <div class="settings-item-right">
+                        <input type="number" id="popup-frequency-blur-threshold" min="0" step="1" data-setting="general.popupBlurByFrequencyThreshold">
+                    </div>
+                </div></div>
+                <div class="settings-item"><div class="settings-item-inner settings-item-inner-wrappable">
+                    <div class="settings-item-left">
+                        <div class="settings-item-label">Unblur in <span class="light">(in seconds)</span></div>
+                    </div>
+                    <div class="settings-item-right">
+                        <input type="number" id="popup-frequency-blur-unblur-delay" min="0" step="0.1" data-setting="general.popupBlurByFrequencyUnblurDelay">
+                    </div>
+                </div></div>
+            </div>
+        </div>
         <div class="settings-item advanced-only">
             <div class="settings-item-inner">
                 <div class="settings-item-left">

--- a/test/data/html/popup-frequency-blur.html
+++ b/test/data/html/popup-frequency-blur.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Popup Frequency Blur Test</title>
+    <style>
+        body {
+            margin: 0;
+            padding: 48px;
+            font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+            background: linear-gradient(180deg, #f8fafc 0%, #eef2ff 100%);
+            color: #0f172a;
+        }
+
+        main {
+            display: grid;
+            gap: 24px;
+            max-width: 720px;
+        }
+
+        #outside-hover-target {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            width: 120px;
+            height: 48px;
+            border: 1px solid #cbd5e1;
+            border-radius: 999px;
+            background-color: rgba(255, 255, 255, 0.75);
+        }
+
+        .target-card {
+            display: grid;
+            gap: 6px;
+            padding: 20px 24px;
+            border: 1px solid #cbd5e1;
+            border-radius: 16px;
+            background-color: rgba(255, 255, 255, 0.9);
+            box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+        }
+
+        .target-label {
+            color: #475569;
+            font-size: 14px;
+        }
+
+        .hovertarget {
+            display: inline-block;
+            font-size: 48px;
+            line-height: 1;
+        }
+    </style>
+</head>
+<body>
+    <main>
+        <div id="outside-hover-target">Leave popup</div>
+        <div class="target-card">
+            <div class="target-label">Should blur in occurrence-based mode at threshold 1</div>
+            <div class="hovertarget" id="term-common">打</div>
+        </div>
+    </main>
+</body>
+</html>

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -312,6 +312,11 @@ function createProfileOptionsUpdatedTestData1() {
             termDisplayMode: 'ruby',
             sortFrequencyDictionary: null,
             sortFrequencyDictionaryOrder: 'descending',
+            popupBlurByFrequencyEnabled: false,
+            popupBlurByFrequencyDictionary: null,
+            popupBlurByFrequencyThreshold: 10000,
+            popupBlurByFrequencyOrder: 'descending',
+            popupBlurByFrequencyUnblurDelay: 0,
             stickySearchHeader: false,
             enableYomitanApi: false,
             yomitanApiServer: 'http://127.0.0.1:19633',
@@ -706,7 +711,7 @@ function createOptionsUpdatedTestData1() {
             },
         ],
         profileCurrent: 0,
-        version: 76,
+        version: 77,
         global: {
             database: {
                 prefixWildcardsSupported: false,
@@ -773,9 +778,38 @@ describe('OptionsUtil', () => {
         delete options.global.database.maxHeadwordLength;
 
         const optionsUpdated = structuredClone(await optionsUtil.update(options));
-        expect(optionsUpdated.version).toBe(76);
+        expect(optionsUpdated.version).toBe(77);
         expect(optionsUpdated.global.dictionaryAutoUpdates).toStrictEqual([]);
         expect(optionsUpdated.global.database.maxHeadwordLength).toBe(0);
+    });
+
+    test('PopupFrequencyBlurVersion77MigrationUsesDefaultsAndStaysDecoupled', async () => {
+        const optionsUtil = new OptionsUtil();
+        await optionsUtil.prepare();
+
+        const options = /** @type {import('settings').Options} */ (structuredClone(createOptionsUpdatedTestData1()));
+        options.version = 76;
+        const general = /** @type {import('core').SafeAny} */ (options.profiles[0].options.general);
+        general.sortFrequencyDictionary = 'Sort Dictionary';
+        general.sortFrequencyDictionaryOrder = 'ascending';
+        delete general.popupBlurByFrequencyEnabled;
+        delete general.popupBlurByFrequencyDictionary;
+        delete general.popupBlurByFrequencyThreshold;
+        delete general.popupBlurByFrequencyOrder;
+        delete general.popupBlurByFrequencyUnblurDelay;
+
+        const optionsUpdated = structuredClone(await optionsUtil.update(options));
+        const defaultGeneral = optionsUtil.getDefault().profiles[0].options.general;
+        expect(optionsUpdated.version).toBe(77);
+        expect(optionsUpdated.profiles[0].options.general).toMatchObject({
+            popupBlurByFrequencyEnabled: defaultGeneral.popupBlurByFrequencyEnabled,
+            popupBlurByFrequencyDictionary: defaultGeneral.popupBlurByFrequencyDictionary,
+            popupBlurByFrequencyThreshold: defaultGeneral.popupBlurByFrequencyThreshold,
+            popupBlurByFrequencyOrder: defaultGeneral.popupBlurByFrequencyOrder,
+            popupBlurByFrequencyUnblurDelay: defaultGeneral.popupBlurByFrequencyUnblurDelay,
+            sortFrequencyDictionary: 'Sort Dictionary',
+            sortFrequencyDictionaryOrder: 'ascending',
+        });
     });
 
     describe('Default', () => {

--- a/test/playwright/visual.spec.js
+++ b/test/playwright/visual.spec.js
@@ -19,6 +19,7 @@ import {existsSync, readFileSync} from 'fs';
 import path from 'path';
 import {pathToFileURL} from 'url';
 import {createDictionaryArchiveData} from '../../dev/dictionary-archive-util.js';
+import {parseJson} from '../../ext/js/core/json.js';
 import {expect, root, test} from './playwright-util.js';
 
 if (process.platform === 'win32') {
@@ -181,4 +182,93 @@ test.describe('popup', () => {
             await expect.soft(page).toHaveScreenshot(test_name + '.png');
         });
     }
+});
+test.describe('popup frequency blur', () => {
+    const popupFrequencyBlurTestsPath = path.join(root, 'test/data/html/popup-frequency-blur.html');
+
+    /**
+     * @param {import('@playwright/test').Page} page
+     * @param {Partial<import('settings').ProfileOptions['general']>} generalSettings
+     * @returns {Promise<void>}
+     */
+    async function updateGeneralOptions(page, generalSettings) {
+        const optionsString = /** @type {unknown} */ (await page.evaluate(() => new Promise((resolve, reject) => {
+            chrome.storage.local.get(['options'], ({options}) => {
+                if (typeof options !== 'string') {
+                    reject(new Error('Options were not loaded from storage.'));
+                    return;
+                }
+                resolve(options);
+            });
+        })));
+        if (typeof optionsString !== 'string') {
+            throw new Error('Options were not loaded from storage.');
+        }
+
+        const optionsData = /** @type {import('settings').Options} */ (parseJson(optionsString));
+        Object.assign(optionsData.profiles[0].options.general, generalSettings);
+        await page.evaluate((options) => new Promise((resolve, reject) => {
+            chrome.storage.local.set({options}, () => {
+                const error = chrome.runtime.lastError;
+                if (typeof error?.message === 'string') {
+                    reject(new Error(error.message));
+                    return;
+                }
+                resolve(null);
+            });
+        }), JSON.stringify(optionsData));
+    }
+
+    test.beforeEach(async ({page, extensionId}) => {
+        console.log('Open settings');
+        await page.goto(`chrome-extension://${extensionId}/settings.html`);
+        await expect.poll(async () => await page.evaluate(() => document.documentElement.dataset.loaded === 'true')).toBe(true);
+        await expect(page.locator('id=dictionaries')).toBeVisible();
+
+        const dictionary = await createDictionaryArchiveData(path.join(root, 'test/data/dictionaries/valid-dictionary1'), 'valid-dictionary1');
+        await page.locator('input[id="dictionary-import-file-input"]').setInputFiles({
+            name: 'valid-dictionary1.zip',
+            mimeType: 'application/x-zip',
+            buffer: Buffer.from(dictionary),
+        });
+        await expect(page.locator('id=dictionaries')).toHaveText('Dictionaries (1 installed, 1 enabled)', {timeout: 1 * 60 * 1000});
+        await updateGeneralOptions(page, {
+            popupBlurByFrequencyEnabled: true,
+            popupBlurByFrequencyDictionary: 'Test Dictionary',
+            popupBlurByFrequencyThreshold: 1,
+            popupBlurByFrequencyOrder: 'descending',
+            popupBlurByFrequencyUnblurDelay: 0,
+        });
+
+        console.log('Open popup-frequency-blur.html');
+        await page.goto(pathToFileURL(popupFrequencyBlurTestsPath).toString());
+        await page.setViewportSize({width: 900, height: 700});
+        await expect(page.locator('#term-common')).toBeVisible();
+        await page.keyboard.down('Shift');
+    });
+
+    test.afterEach(async ({page}) => {
+        await page.keyboard.up('Shift');
+    });
+
+    test('qualifying popup starts blurred, reveals on hover, and blurs again on leave', async ({page}) => {
+        const popupFramePromise = page.waitForEvent('frameattached', {timeout: 10000});
+
+        await page.locator('#term-common').hover();
+
+        const popupFrame = await popupFramePromise;
+        const overlay = popupFrame.locator('#popup-frequency-blur-overlay');
+        await expect.poll(async () => await popupFrame.evaluate(() => document.documentElement.dataset.popupFrequencyBlurState)).toBe('blurred');
+        await expect(overlay).toBeVisible();
+        await expect(popupFrame.locator('#popup-frequency-blur-overlay-sublabel')).toHaveText('Test Dictionary · frequency 1');
+        await expect.soft(popupFrame.locator('.popup-frequency-blur-card')).toHaveScreenshot('popup-frequency-blur-overlay-card.png');
+
+        await popupFrame.locator('.content-outer').hover();
+        await expect.poll(async () => await popupFrame.evaluate(() => document.documentElement.dataset.popupFrequencyBlurState)).toBe('revealed');
+        await expect(overlay).toBeHidden();
+
+        await page.locator('#outside-hover-target').hover();
+        await expect.poll(async () => await popupFrame.evaluate(() => document.documentElement.dataset.popupFrequencyBlurState)).toBe('blurred');
+        await expect(overlay).toBeVisible();
+    });
 });

--- a/test/popup-frequency-blur-controller.test.js
+++ b/test/popup-frequency-blur-controller.test.js
@@ -1,0 +1,240 @@
+/*
+ * Copyright (C) 2025  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {describe, expect, vi} from 'vitest';
+import {EventDispatcher} from '../ext/js/core/event-dispatcher.js';
+import {PopupFrequencyBlurController} from '../ext/js/display/popup-frequency-blur-controller.js';
+import {createDomTest} from './fixtures/dom-test.js';
+
+const test = createDomTest();
+
+/**
+ * @typedef {{
+ *     general: {
+ *         popupBlurByFrequencyEnabled: boolean;
+ *         popupBlurByFrequencyDictionary: string | null;
+ *         popupBlurByFrequencyThreshold: number;
+ *         popupBlurByFrequencyOrder: import('settings').SortFrequencyDictionaryOrder;
+ *         popupBlurByFrequencyUnblurDelay: number;
+ *     };
+ * }} PopupFrequencyBlurOptions
+ */
+
+/**
+ * @typedef {{
+ *     optionsUpdated: {options: PopupFrequencyBlurOptions};
+ *     contentClear: Record<string, never>;
+ *     contentUpdateComplete: {type: import('display').PageType};
+ * }} MockDisplayEvents
+ */
+
+/**
+ * @augments {EventDispatcher<MockDisplayEvents>}
+ */
+class MockDisplay extends EventDispatcher {
+    /**
+     * @param {PopupFrequencyBlurOptions} options
+     */
+    constructor(options) {
+        super();
+        /** @type {PopupFrequencyBlurOptions} */
+        this._options = options;
+        /** @type {import('dictionary').DictionaryEntry[]} */
+        this.dictionaryEntries = [];
+    }
+
+    /** @returns {PopupFrequencyBlurOptions} */
+    getOptions() {
+        return this._options;
+    }
+
+    /**
+     * @param {import('dictionary').DictionaryEntry[]} dictionaryEntries
+     * @param {import('display').PageType} [type]
+     */
+    setContent(dictionaryEntries, type = 'terms') {
+        this.dictionaryEntries = dictionaryEntries;
+        this.trigger('contentUpdateComplete', {type});
+    }
+}
+
+/**
+ * @param {import('jsdom').DOMWindow} window
+ */
+function setupPopupDom(window) {
+    const {document} = window;
+    document.documentElement.dataset.pageType = 'popup';
+    document.body.innerHTML = `
+        <div class="content-outer">
+            <div class="content"></div>
+            <div class="content-sidebar"></div>
+            <div id="popup-frequency-blur-overlay" hidden>
+                <div id="popup-frequency-blur-overlay-label"></div>
+                <div id="popup-frequency-blur-overlay-sublabel"></div>
+            </div>
+        </div>
+    `;
+}
+
+/**
+ * @param {{enabled?: boolean, dictionary?: string | null, threshold?: number, order?: import('settings').SortFrequencyDictionaryOrder, unblurDelay?: number}} [details]
+ * @returns {PopupFrequencyBlurOptions}
+ */
+function createOptions(details = {}) {
+    const {
+        enabled = true,
+        dictionary = 'Test Dictionary',
+        threshold = 1,
+        order = 'ascending',
+        unblurDelay = 0,
+    } = details;
+    return {
+        general: {
+            popupBlurByFrequencyEnabled: enabled,
+            popupBlurByFrequencyDictionary: dictionary,
+            popupBlurByFrequencyThreshold: threshold,
+            popupBlurByFrequencyOrder: order,
+            popupBlurByFrequencyUnblurDelay: unblurDelay,
+        },
+    };
+}
+
+/**
+ * @param {Array<{dictionary?: string, frequency: number, displayValue?: string | null, displayValueParsed?: boolean}>} frequencies
+ * @returns {import('dictionary').TermDictionaryEntry}
+ */
+function createTermEntry(frequencies) {
+    return {
+        type: 'term',
+        isPrimary: true,
+        textProcessorRuleChainCandidates: [],
+        inflectionRuleChainCandidates: [],
+        score: 0,
+        frequencyOrder: 0,
+        dictionaryIndex: 0,
+        dictionaryAlias: 'Test Dictionary',
+        sourceTermExactMatchCount: 1,
+        matchPrimaryReading: true,
+        maxOriginalTextLength: 1,
+        headwords: [],
+        definitions: [],
+        pronunciations: [],
+        frequencies: frequencies.map(({
+            dictionary = 'Test Dictionary',
+            frequency,
+            displayValue = null,
+            displayValueParsed = false,
+        }) => ({
+            index: 0,
+            dictionary,
+            headwordIndex: 0,
+            dictionaryIndex: 0,
+            dictionaryAlias: dictionary,
+            hasReading: false,
+            frequency,
+            displayValue,
+            displayValueParsed,
+        })),
+    };
+}
+
+/**
+ * @param {MockDisplay} display
+ * @returns {PopupFrequencyBlurController}
+ */
+function createController(display) {
+    return new PopupFrequencyBlurController(
+        /** @type {import('../ext/js/display/display.js').Display} */ (/** @type {unknown} */ (display)),
+    );
+}
+
+describe('PopupFrequencyBlurController', () => {
+    test('manual blur mode uses the selected threshold comparison for both frequency orders', ({window}) => {
+        setupPopupDom(window);
+        for (const {order, threshold, frequency} of [
+            {order: /** @type {const} */ ('ascending'), threshold: 3, frequency: 3},
+            {order: /** @type {const} */ ('descending'), threshold: 100, frequency: 100},
+        ]) {
+            const display = new MockDisplay(createOptions({order, threshold}));
+            createController(display).prepare();
+
+            display.setContent([createTermEntry([{frequency}])]);
+
+            expect(window.document.documentElement.dataset.popupFrequencyBlurState).toBe('blurred');
+            expect(window.document.querySelector('#popup-frequency-blur-overlay')?.hasAttribute('hidden')).toBe(false);
+            expect(window.document.querySelector('#popup-frequency-blur-overlay-sublabel')?.textContent).toBe(`Test Dictionary · frequency ${frequency}`);
+
+            window.document.body.innerHTML = '';
+            setupPopupDom(window);
+        }
+    });
+
+    test('positive unblur delay shows a countdown and auto-reveals', async ({window}) => {
+        vi.useFakeTimers();
+        try {
+            setupPopupDom(window);
+            const display = new MockDisplay(createOptions({threshold: 1, order: 'ascending', unblurDelay: 2}));
+            createController(display).prepare();
+
+            display.setContent([createTermEntry([{frequency: 1}])]);
+            expect(window.document.documentElement.dataset.popupFrequencyBlurState).toBe('blurred');
+            expect(window.document.querySelector('#popup-frequency-blur-overlay-label')?.textContent).toBe('Hover or wait 2s to reveal');
+
+            await vi.advanceTimersByTimeAsync(1000);
+            expect(window.document.querySelector('#popup-frequency-blur-overlay-label')?.textContent).toBe('Hover or wait 1s to reveal');
+
+            await vi.advanceTimersByTimeAsync(1000);
+            expect(window.document.documentElement.dataset.popupFrequencyBlurState).toBe('revealed');
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    test('blur stays off when the blur dictionary is unset or missing on the first term entry', ({window}) => {
+        setupPopupDom(window);
+        for (const {dictionary, frequencies} of [
+            {dictionary: null, frequencies: [{frequency: 1}]},
+            {dictionary: 'Test Dictionary', frequencies: [{dictionary: 'Other Dictionary', frequency: 1}]},
+        ]) {
+            const display = new MockDisplay(createOptions({dictionary}));
+            createController(display).prepare();
+
+            display.setContent([createTermEntry(frequencies)]);
+
+            expect(window.document.documentElement.dataset.popupFrequencyBlurState).toBe('off');
+            expect(window.document.querySelector('#popup-frequency-blur-overlay')?.hasAttribute('hidden')).toBe(true);
+
+            window.document.body.innerHTML = '';
+            setupPopupDom(window);
+        }
+    });
+
+    test('parsed display values fall back to numeric frequency when no numeric token is present', ({window}) => {
+        setupPopupDom(window);
+        const display = new MockDisplay(createOptions({threshold: 4}));
+        createController(display).prepare();
+
+        display.setContent([createTermEntry([{
+            frequency: 4,
+            displayValue: 'unusable',
+            displayValueParsed: true,
+        }])]);
+
+        expect(window.document.documentElement.dataset.popupFrequencyBlurState).toBe('blurred');
+        expect(window.document.querySelector('#popup-frequency-blur-overlay-sublabel')?.textContent).toBe('Test Dictionary · frequency 4');
+    });
+});

--- a/test/settings-popup-frequency-blur-controller.test.js
+++ b/test/settings-popup-frequency-blur-controller.test.js
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2025  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {describe, expect} from 'vitest';
+import {EventDispatcher} from '../ext/js/core/event-dispatcher.js';
+import {PopupFrequencyBlurController} from '../ext/js/pages/settings/popup-frequency-blur-controller.js';
+import {createDomTest} from './fixtures/dom-test.js';
+
+const test = createDomTest();
+
+/**
+ * @typedef {{
+ *     general: {
+ *         popupBlurByFrequencyDictionary: string | null;
+ *     };
+ * }} PopupFrequencyBlurOptions
+ */
+
+/**
+ * @typedef {{
+ *     databaseUpdated: Record<string, never>;
+ * }} MockApplicationEvents
+ */
+
+/**
+ * @returns {import('dictionary-importer').Summary[]}
+ */
+function createDictionaryInfo() {
+    return [
+        {
+            title: 'Test Dictionary',
+            revision: '1',
+            sequenced: false,
+            version: 3,
+            importDate: 0,
+            prefixWildcardsSupported: false,
+            styles: '',
+            sourceLanguage: 'ja',
+            counts: {
+                terms: {total: 0},
+                termMeta: {total: 0, freq: 1},
+                kanji: {total: 0},
+                kanjiMeta: {total: 0},
+                tagMeta: {total: 0},
+                media: {total: 0},
+            },
+        },
+        {
+            title: 'No Frequency Data',
+            revision: '1',
+            sequenced: false,
+            version: 3,
+            importDate: 0,
+            prefixWildcardsSupported: false,
+            styles: '',
+            sourceLanguage: 'ja',
+            counts: {
+                terms: {total: 0},
+                termMeta: {total: 0, freq: 0},
+                kanji: {total: 0},
+                kanjiMeta: {total: 0},
+                tagMeta: {total: 0},
+                media: {total: 0},
+            },
+        },
+    ];
+}
+
+/**
+ * @augments {EventDispatcher<MockApplicationEvents>}
+ */
+class MockApplication extends EventDispatcher {
+    constructor() {
+        super();
+        /** @type {Record<string, never>} */
+        this.api = {};
+    }
+}
+
+/**
+ * @augments {EventDispatcher<import('settings-controller').Events>}
+ */
+class MockSettingsController extends EventDispatcher {
+    /**
+     * @param {PopupFrequencyBlurOptions} options
+     */
+    constructor(options) {
+        super();
+        /** @type {MockApplication} */
+        this.application = new MockApplication();
+        /** @type {PopupFrequencyBlurOptions} */
+        this._options = options;
+    }
+
+    /** @returns {Promise<import('dictionary-importer').Summary[]>} */
+    async getDictionaryInfo() {
+        return createDictionaryInfo();
+    }
+
+    /** @returns {Promise<PopupFrequencyBlurOptions>} */
+    async getOptions() {
+        return this._options;
+    }
+
+    /** @returns {import('settings').OptionsContext} */
+    getOptionsContext() {
+        return {index: 0};
+    }
+}
+
+/**
+ * @param {import('jsdom').DOMWindow} window
+ */
+function setupSettingsDom(window) {
+    window.document.body.innerHTML = '<select id="popup-frequency-blur-dictionary" data-setting="general.popupBlurByFrequencyDictionary"></select>';
+}
+
+describe('PopupFrequencyBlurController (settings)', () => {
+    test('prepare populates only frequency dictionaries and restores the saved selection', async ({window}) => {
+        setupSettingsDom(window);
+        const settingsController = new MockSettingsController({
+            general: {
+                popupBlurByFrequencyDictionary: 'Test Dictionary',
+            },
+        });
+        await new PopupFrequencyBlurController(
+            /** @type {import('../ext/js/pages/settings/settings-controller.js').SettingsController} */ (/** @type {unknown} */ (settingsController)),
+        ).prepare();
+
+        const dictionarySelect = /** @type {HTMLSelectElement} */ (window.document.querySelector('#popup-frequency-blur-dictionary'));
+        const optionValues = Array.from(dictionarySelect.options, ({value}) => value);
+
+        expect(optionValues).toStrictEqual(['', 'Test Dictionary']);
+        expect(dictionarySelect.value).toBe('Test Dictionary');
+    });
+});

--- a/types/ext/settings.d.ts
+++ b/types/ext/settings.d.ts
@@ -153,6 +153,11 @@ export type GeneralOptions = {
     termDisplayMode: TermDisplayMode;
     sortFrequencyDictionary: string | null;
     sortFrequencyDictionaryOrder: SortFrequencyDictionaryOrder;
+    popupBlurByFrequencyEnabled: boolean;
+    popupBlurByFrequencyDictionary: string | null;
+    popupBlurByFrequencyThreshold: number;
+    popupBlurByFrequencyOrder: SortFrequencyDictionaryOrder;
+    popupBlurByFrequencyUnblurDelay: number;
     stickySearchHeader: boolean;
     enableYomitanApi: boolean;
     yomitanApiAllowCssSanitizationBypass: boolean;


### PR DESCRIPTION
## Summary
- port the upstream popup frequency blur feature into Manabitan as a standalone popup behavior setting
- add popup and settings controllers, schema/type/migration updates, and popup/settings UI
- add unit coverage plus the upstream-style visual harness/test scaffold

## Testing
- npm run test:unit -- test/options-util.test.js test/popup-frequency-blur-controller.test.js test/settings-popup-frequency-blur-controller.test.js
- npm run test:build
- npx eslint ext/js/display/popup-frequency-blur-controller.js ext/js/pages/settings/popup-frequency-blur-controller.js ext/js/display/popup-main.js ext/js/pages/settings/settings-main.js test/popup-frequency-blur-controller.test.js test/settings-popup-frequency-blur-controller.test.js test/playwright/visual.spec.js test/options-util.test.js
- npx stylelint ext/css/display.css
- npx html-validate ext/popup.html ext/settings.html test/data/html/popup-frequency-blur.html
- npm run test:ts:main
- npm run test:ts:test

## Notes
- Playwright visual execution still failed locally because Chromium crashed during launch in this environment before the new popup-frequency-blur case could complete or generate a snapshot baseline.