### PR TITLE
Port Yomitan dictionary startup updates and Update All UI

### DIFF
--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -1393,15 +1393,15 @@
             "type": "object",
             "required": [
                 "database",
-                "dataTransmissionConsentShown",
-                "dictionaryAutoUpdates"
+                "dataTransmissionConsentShown"
             ],
             "properties": {
                 "database": {
                     "type": "object",
                     "required": [
                         "prefixWildcardsSupported",
-                        "maxHeadwordLength"
+                        "maxHeadwordLength",
+                        "autoUpdateDictionariesOnStartup"
                     ],
                     "properties": {
                         "prefixWildcardsSupported": {
@@ -1412,19 +1412,16 @@
                             "type": "integer",
                             "minimum": 0,
                             "default": 0
+                        },
+                        "autoUpdateDictionariesOnStartup": {
+                            "type": "boolean",
+                            "default": false
                         }
                     }
                 },
                 "dataTransmissionConsentShown": {
                     "type": "boolean",
                     "default": false
-                },
-                "dictionaryAutoUpdates": {
-                    "type": "array",
-                    "default": [],
-                    "items": {
-                        "type": "string"
-                    }
                 }
             }
         }

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -32,12 +32,15 @@ import {reportDiagnostics} from '../core/diagnostics-reporter.js';
 import {safePerformance} from '../core/safe-performance.js';
 import {clone, deferPromise, promiseTimeout} from '../core/utilities.js';
 import {generateAnkiNoteMediaFileName, INVALID_NOTE_ID, isNoteDataValid} from '../data/anki-util.js';
-import {getKebabCase} from '../data/anki-template-util.js';
 import {arrayBufferToBase64, base64ToArrayBuffer} from '../data/array-buffer-util.js';
 import {JsonSchema} from '../data/json-schema.js';
 import {OptionsUtil} from '../data/options-util.js';
 import {getAllPermissions, hasPermissions, hasRequiredPermissionsForOptions} from '../data/permissions-util.js';
 import {compareRevisions} from '../dictionary/dictionary-data-util.js';
+import {
+    createDefaultDictionarySettings,
+    updateDictionaryAnkiFieldTemplates,
+} from '../dictionary/dictionary-update-util.js';
 import {DictionaryDatabase} from '../dictionary/dictionary-database.js';
 import {DictionaryWorker} from '../dictionary/dictionary-worker.js';
 import {Environment} from '../extension/environment.js';
@@ -52,11 +55,10 @@ import {ClipboardReaderProxy, DictionaryDatabaseProxy, OffscreenProxy, Translato
 import {createSchema, normalizeContext} from './profile-conditions-util.js';
 import {RequestBuilder} from './request-builder.js';
 import {injectStylesheet} from './script-manager.js';
+import {StartupDictionaryUpdater} from './startup-dictionary-updater.js';
 
 const STARTUP_DIAGNOSTICS_STORAGE_KEY = 'manabitanStartupDiagnostics';
-const DICTIONARY_AUTO_UPDATE_STATE_STORAGE_KEY = 'manabitanDictionaryAutoUpdateState';
-const DICTIONARY_AUTO_UPDATE_ALARM_NAME = 'manabitanDictionaryAutoUpdateHourly';
-const DICTIONARY_AUTO_UPDATE_INTERVAL_MS = 60 * 60 * 1000;
+const STARTUP_DICTIONARY_UPDATES_RUN_SESSION_KEY = 'startupDictionaryUpdatesRun';
 const SCAN_LENGTH_INFLECTION_BUFFER = 8;
 
 /**
@@ -159,8 +161,8 @@ export class Backend {
         this._dictionaryMutationPromise = null;
         /** @type {boolean} */
         this._dictionaryMutationActive = false;
-        /** @type {Promise<void>|null} */
-        this._dictionaryAutoUpdatePassPromise = null;
+        /** @type {boolean} */
+        this._startupDictionaryUpdatesRun = false;
 
         /** @type {boolean} */
         this._isPrepared = false;
@@ -328,11 +330,6 @@ export class Backend {
             chrome.permissions.onRemoved.addListener(onPermissionsChanged);
         }
 
-        if (isObjectNotArray(chrome.alarms) && isObjectNotArray(chrome.alarms.onAlarm)) {
-            const onAlarm = this._onWebExtensionEventWrapper(this._onAlarm.bind(this));
-            chrome.alarms.onAlarm.addListener(onAlarm);
-        }
-
         const onStartup = this._onWebExtensionEventWrapper(this._onStartup.bind(this));
         chrome.runtime.onStartup.addListener(onStartup);
         chrome.runtime.onInstalled.addListener(this._onInstalled.bind(this));
@@ -465,9 +462,6 @@ export class Backend {
             const dictionaryOptionsPruneSummary = await measureAsyncPhase('pruneStaleProfileDictionaryOptions', async () => (
                 await this._pruneStaleProfileDictionaryOptions()
             ));
-            await measureAsyncPhase('pruneStaleDictionaryAutoUpdates', async () => {
-                await this._pruneStaleDictionaryAutoUpdates();
-            });
             await measureAsyncPhase('captureStartupCleanupDiagnostics', async () => {
                 await this._captureStartupCleanupDiagnostics(dictionaryOptionsPruneSummary);
             });
@@ -481,16 +475,15 @@ export class Backend {
                 recordPhase('applyOptions(background)', startedAt);
             }
 
+            await measureAsyncPhase('updateDictionariesOnStartup', async () => {
+                await this._updateDictionariesOnStartup();
+            });
+
             {
                 const startedAt = safePerformance.now();
                 this._attachOmniboxListener();
                 recordPhase('attachOmniboxListener', startedAt);
             }
-
-            await measureAsyncPhase('ensureDictionaryAutoUpdateAlarm', async () => {
-                await this._ensureDictionaryAutoUpdateAlarm();
-            });
-            void this._runDictionaryAutoUpdatePass('prepare');
 
             const optionsStartedAt = safePerformance.now();
             const options = this._getProfileOptions({current: true}, false);
@@ -692,22 +685,11 @@ export class Backend {
         if (reason === 'install') {
             void this._requestPersistentStorage();
         }
-        void this._ensureDictionaryAutoUpdateAlarm();
-        void this._runDictionaryAutoUpdatePass('install');
     }
 
     /** */
     _onStartup() {
-        void this._ensureDictionaryAutoUpdateAlarm();
-        void this._runDictionaryAutoUpdatePass('startup');
-    }
-
-    /**
-     * @param {chrome.alarms.Alarm} alarm
-     */
-    _onAlarm(alarm) {
-        if (alarm.name !== DICTIONARY_AUTO_UPDATE_ALARM_NAME) { return; }
-        void this._runDictionaryAutoUpdatePass('alarm');
+        void this._updateDictionariesOnStartup();
     }
 
     // Message handlers
@@ -3250,30 +3232,6 @@ export class Backend {
     }
 
     /**
-     * @returns {Promise<void>}
-     */
-    async _ensureDictionaryAutoUpdateAlarm() {
-        const alarms = chrome.alarms;
-        if (!isObjectNotArray(alarms) || typeof alarms.get !== 'function' || typeof alarms.create !== 'function') {
-            return;
-        }
-        const alarm = /** @type {?chrome.alarms.Alarm} */ (await new Promise((resolve, reject) => {
-            alarms.get(DICTIONARY_AUTO_UPDATE_ALARM_NAME, (result) => {
-                const runtimeError = chrome.runtime.lastError;
-                if (runtimeError) {
-                    reject(new Error(runtimeError.message || 'alarms.get failed'));
-                    return;
-                }
-                resolve(result);
-            });
-        }));
-        if (alarm !== null) {
-            return;
-        }
-        void alarms.create(DICTIONARY_AUTO_UPDATE_ALARM_NAME, {periodInMinutes: 60});
-    }
-
-    /**
      * @returns {Promise<JsonSchema>}
      */
     async _getDictionaryIndexSchema() {
@@ -3286,69 +3244,77 @@ export class Backend {
     }
 
     /**
-     * @param {'prepare'|'install'|'startup'|'alarm'} reason
      * @returns {Promise<void>}
      */
-    async _runDictionaryAutoUpdatePass(reason) {
-        if (this._dictionaryAutoUpdatePassPromise !== null) {
-            await this._dictionaryAutoUpdatePassPromise;
+    async _updateDictionariesOnStartup() {
+        const updater = new StartupDictionaryUpdater({
+            isEnabled: async () => this._getOptionsFull(false).global.database.autoUpdateDictionariesOnStartup,
+            hasRunThisSession: this._hasRunStartupDictionaryUpdatesThisSession.bind(this),
+            markRunThisSession: this._markStartupDictionaryUpdatesThisSession.bind(this),
+            getDictionaryInfo: async () => {
+                await this._ensureDictionaryDatabaseReady();
+                return await this._dictionaryDatabase.getDictionaryInfo();
+            },
+            checkForUpdate: async (dictionaryInfo) => {
+                const [checkResult] = await this._checkDictionaryUpdates([dictionaryInfo.title]);
+                return (typeof checkResult !== 'undefined' && checkResult.hasUpdate) ? checkResult : null;
+            },
+            updateDictionary: this._updateDictionaryOnStartup.bind(this),
+            onError: this._onStartupDictionaryUpdateError.bind(this),
+        });
+        try {
+            await updater.run();
+        } catch (e) {
+            log.error(e);
+        }
+    }
+
+    /**
+     * @returns {Promise<boolean>}
+     */
+    async _hasRunStartupDictionaryUpdatesThisSession() {
+        if (!isObjectNotArray(chrome.storage?.session) || typeof chrome.storage.session.get !== 'function') {
+            return this._startupDictionaryUpdatesRun;
+        }
+        const result = await chrome.storage.session.get([STARTUP_DICTIONARY_UPDATES_RUN_SESSION_KEY]);
+        return !!result[STARTUP_DICTIONARY_UPDATES_RUN_SESSION_KEY];
+    }
+
+    /**
+     * @returns {Promise<void>}
+     */
+    async _markRunStartupDictionaryUpdatesThisSession() {
+        this._startupDictionaryUpdatesRun = true;
+        if (!isObjectNotArray(chrome.storage?.session) || typeof chrome.storage.session.set !== 'function') {
             return;
         }
-        this._dictionaryAutoUpdatePassPromise = (async () => {
-            if (this._dictionaryImportModeActive) {
-                return;
-            }
-            const options = this._options;
-            if (options === null) {
-                return;
-            }
-            const enabledIndexUrls = new Set(options.global.dictionaryAutoUpdates);
-            if (enabledIndexUrls.size === 0) {
-                return;
-            }
+        await chrome.storage.session.set({[STARTUP_DICTIONARY_UPDATES_RUN_SESSION_KEY]: true});
+    }
 
-            await this._ensureDictionaryDatabaseReady();
-            const dictionaries = await this._dictionaryDatabase.getDictionaryInfo();
-            const state = await this._getDictionaryAutoUpdateState();
-            const now = Date.now();
-            const dueDictionaries = dictionaries
-                .filter((dictionary) => {
-                    const indexUrl = dictionary.indexUrl;
-                    if (
-                        dictionary.isUpdatable !== true ||
-                        typeof indexUrl !== 'string' ||
-                        indexUrl.length === 0 ||
-                        !enabledIndexUrls.has(indexUrl)
-                    ) {
-                        return false;
-                    }
-                    const lastAttemptAt = state[indexUrl]?.lastAttemptAt ?? 0;
-                    return (now - lastAttemptAt) >= DICTIONARY_AUTO_UPDATE_INTERVAL_MS;
-                })
-                .sort((a, b) => a.title.localeCompare(b.title));
+    /**
+     * @param {unknown} error
+     * @param {{dictionaryTitle: string, phase: 'check' | 'update'}} details
+     */
+    _onStartupDictionaryUpdateError(error, {dictionaryTitle, phase}) {
+        log.error(`Startup dictionary ${phase} failed for ${dictionaryTitle}`);
+        log.error(error);
+    }
 
-            reportDiagnostics('dictionary-auto-update-pass-begin', {
-                reason,
-                enabledCount: enabledIndexUrls.size,
-                dueCount: dueDictionaries.length,
-            });
-
-            for (const dictionary of dueDictionaries) {
-                if (this._dictionaryImportModeActive) {
-                    break;
-                }
-                const [checkResult] = await this._checkDictionaryUpdates([dictionary.title]);
-                if (typeof checkResult === 'undefined' || !checkResult.hasUpdate) {
-                    continue;
-                }
-                await this._updateDictionaryByTitle(dictionary.title, false, checkResult);
-            }
-        })();
-        try {
-            await this._dictionaryAutoUpdatePassPromise;
-        } finally {
-            this._dictionaryAutoUpdatePassPromise = null;
+    /**
+     * @param {string} dictionaryTitle
+     * @param {unknown} updateCandidate
+     * @returns {Promise<boolean>}
+     */
+    async _updateDictionaryOnStartup(dictionaryTitle, updateCandidate) {
+        const result = await this._updateDictionaryByTitle(
+            dictionaryTitle,
+            false,
+            /** @type {import('backend').DictionaryUpdateCheckResult} */ (updateCandidate),
+        );
+        if (typeof result.error === 'string' && result.error.length > 0) {
+            throw new Error(result.error);
         }
+        return result.status === 'updated';
     }
 
     /**
@@ -3359,25 +3325,22 @@ export class Backend {
         await this._ensureDictionaryDatabaseReady();
         const dictionaries = await this._dictionaryDatabase.getDictionaryInfo();
         const titleFilter = new Set(dictionaryTitles);
-        const state = await this._getDictionaryAutoUpdateState();
         /** @type {import('backend').DictionaryUpdateCheckResult[]} */
         const results = [];
         for (const dictionary of dictionaries) {
             if (titleFilter.size > 0 && !titleFilter.has(dictionary.title)) {
                 continue;
             }
-            results.push(await this._checkDictionaryUpdate(dictionary, state));
+            results.push(await this._checkDictionaryUpdate(dictionary));
         }
-        await this._setDictionaryAutoUpdateState(state);
         return results;
     }
 
     /**
      * @param {import('dictionary-importer').Summary} dictionary
-     * @param {Record<string, {lastAttemptAt?: number, lastSuccessfulCheckAt?: number, lastSuccessfulUpdateAt?: number, lastSeenRevision?: string, etag?: string|null, lastModified?: string|null, lastError?: string|null}>} state
      * @returns {Promise<import('backend').DictionaryUpdateCheckResult>}
      */
-    async _checkDictionaryUpdate(dictionary, state) {
+    async _checkDictionaryUpdate(dictionary) {
         /** @type {import('backend').DictionaryUpdateCheckResult} */
         const result = {
             dictionaryTitle: dictionary.title,
@@ -3392,75 +3355,17 @@ export class Backend {
             return result;
         }
 
-        const entry = state[indexUrl] ?? {};
-        state[indexUrl] = entry;
-        entry.lastAttemptAt = Date.now();
-
-        /** @type {HeadersInit} */
-        const validatorHeaders = {};
-        if (typeof entry.etag === 'string' && entry.etag.length > 0) {
-            validatorHeaders['If-None-Match'] = entry.etag;
-        }
-        if (typeof entry.lastModified === 'string' && entry.lastModified.length > 0) {
-            validatorHeaders['If-Modified-Since'] = entry.lastModified;
-        }
-
-        /**
-         * @param {Response} response
-         * @returns {void}
-         */
-        const updateValidatorsFromResponse = (response) => {
-            const etag = response.headers.get('ETag');
-            const lastModified = response.headers.get('Last-Modified');
-            entry.etag = etag;
-            entry.lastModified = lastModified;
-        };
-
         try {
-            let headResponse = null;
-            try {
-                headResponse = await this._requestBuilder.fetchAnonymous(indexUrl, {
-                    method: 'HEAD',
-                    headers: validatorHeaders,
-                    cache: 'no-store',
-                    credentials: 'omit',
-                    redirect: 'follow',
-                    referrerPolicy: 'no-referrer',
-                });
-                if (headResponse.status === 304) {
-                    updateValidatorsFromResponse(headResponse);
-                    entry.lastSuccessfulCheckAt = Date.now();
-                    entry.lastSeenRevision = dictionary.revision;
-                    entry.lastError = null;
-                    return result;
-                }
-                if (!headResponse.ok) {
-                    throw new Error(`HTTP ${String(headResponse.status)}`);
-                }
-                updateValidatorsFromResponse(headResponse);
-            } catch (_) {
-                headResponse = null;
-            }
-
             const getResponse = await this._requestBuilder.fetchAnonymous(indexUrl, {
                 method: 'GET',
-                headers: (headResponse === null ? validatorHeaders : {}),
                 cache: 'no-store',
                 credentials: 'omit',
                 redirect: 'follow',
                 referrerPolicy: 'no-referrer',
             });
-            if (getResponse.status === 304) {
-                updateValidatorsFromResponse(getResponse);
-                entry.lastSuccessfulCheckAt = Date.now();
-                entry.lastSeenRevision = dictionary.revision;
-                entry.lastError = null;
-                return result;
-            }
             if (!getResponse.ok) {
                 throw new Error(`HTTP ${String(getResponse.status)}`);
             }
-            updateValidatorsFromResponse(getResponse);
 
             const index = /** @type {unknown} */ (await readResponseJson(getResponse));
             const dictionaryIndexSchema = await this._getDictionaryIndexSchema();
@@ -3470,15 +3375,11 @@ export class Backend {
             const validIndex = /** @type {import('dictionary-data').Index} */ (index);
             const latestRevision = validIndex.revision;
             const downloadUrl = typeof validIndex.downloadUrl === 'string' ? validIndex.downloadUrl : dictionary.downloadUrl;
-            entry.lastSuccessfulCheckAt = Date.now();
-            entry.lastSeenRevision = latestRevision;
-            entry.lastError = null;
             result.latestRevision = latestRevision;
             result.downloadUrl = typeof downloadUrl === 'string' ? downloadUrl : null;
             result.hasUpdate = compareRevisions(dictionary.revision, latestRevision);
         } catch (e) {
             const error = e instanceof Error ? e : new Error(String(e));
-            entry.lastError = error.message;
             result.error = error.message;
         }
 
@@ -3527,7 +3428,6 @@ export class Backend {
         });
         if (!archiveResponse.ok) {
             const error = `Failed to download dictionary archive: HTTP ${String(archiveResponse.status)}`;
-            await this._setDictionaryAutoUpdateError(currentDictionary.indexUrl, error);
             return {dictionaryTitle, status: 'skipped', latestRevision: checkResult.latestRevision, error};
         }
         const archiveContent = RequestBuilder.readFetchResponseArrayBuffer(archiveResponse, null);
@@ -3547,12 +3447,6 @@ export class Backend {
             }
             if (latestDictionary.revision !== currentDictionary.revision) {
                 return /** @type {import('backend').DictionaryUpdateResult} */ ({dictionaryTitle, status: 'skipped', latestRevision: checkResult.latestRevision, error: null});
-            }
-            if (!waitForLock) {
-                const enabledIndexUrls = new Set(this._options?.global.dictionaryAutoUpdates ?? []);
-                if (!enabledIndexUrls.has(latestDictionary.indexUrl)) {
-                    return /** @type {import('backend').DictionaryUpdateResult} */ ({dictionaryTitle, status: 'skipped', latestRevision: checkResult.latestRevision, error: null});
-                }
             }
             return await this._performDictionaryUpdate(latestDictionary, await archiveContent, checkResult.latestRevision);
         }, {wait: waitForLock});
@@ -3593,11 +3487,9 @@ export class Backend {
             }
 
             await this._applyImportedDictionarySettings(dictionary, importedSummary, updateContext);
-            await this._updateDictionaryAutoUpdateStateAfterSuccess(dictionary, importedSummary);
             updateSucceeded = true;
         } catch (e) {
             const error = e instanceof Error ? e : new Error(String(e));
-            await this._setDictionaryAutoUpdateError(dictionary.indexUrl ?? '', error.message);
             failureMessage = error.message;
         } finally {
             if (importModeEnabled) {
@@ -3614,7 +3506,6 @@ export class Backend {
         }
         if (failureMessage !== null) {
             await this._pruneStaleProfileDictionaryOptions();
-            await this._pruneStaleDictionaryAutoUpdates();
         }
         return {dictionaryTitle: dictionary.title, status: 'skipped', latestRevision, error: failureMessage};
     }
@@ -3710,7 +3601,7 @@ export class Backend {
             ));
             const profileSettings = profilesDictionarySettings?.[profile.id];
             if (typeof profileSettings === 'undefined') {
-                dictionaries.push(this._createDefaultDictionarySettings(importedSummary.title, i === options.profileCurrent, importedSummary.styles));
+                dictionaries.push(createDefaultDictionarySettings(importedSummary.title, i === options.profileCurrent, importedSummary.styles));
             } else {
                 const {index, alias, name, ...currentSettings} = profileSettings;
                 const newAlias = alias === name ? importedSummary.title : alias;
@@ -3735,195 +3626,11 @@ export class Backend {
             if (sortFrequencyDictionaryProfileIds.has(profile.id) || profile.options.general.sortFrequencyDictionary === previousSummary.title) {
                 profile.options.general.sortFrequencyDictionary = importedSummary.title;
             }
-
-            if (typeof profileSettings === 'undefined') {
-                continue;
-            }
-            const oldFieldSegmentRegex = new RegExp(getKebabCase(profileSettings.name), 'g');
-            const newFieldSegment = getKebabCase(importedSummary.title);
-            for (const cardFormat of profile.options.anki.cardFormats) {
-                const ankiTermFields = cardFormat.fields;
-                for (const key of Object.keys(ankiTermFields)) {
-                    ankiTermFields[key].value = ankiTermFields[key].value.replace(oldFieldSegmentRegex, newFieldSegment);
-                }
-            }
         }
 
-        const oldIndexUrl = previousSummary.indexUrl;
-        const newIndexUrl = importedSummary.indexUrl;
-        if (typeof oldIndexUrl === 'string') {
-            const enabledIndexUrls = new Set(options.global.dictionaryAutoUpdates);
-            if (enabledIndexUrls.delete(oldIndexUrl) && typeof newIndexUrl === 'string' && importedSummary.isUpdatable === true) {
-                enabledIndexUrls.add(newIndexUrl);
-            }
-            options.global.dictionaryAutoUpdates = [...enabledIndexUrls].sort((a, b) => a.localeCompare(b));
-        }
+        updateDictionaryAnkiFieldTemplates(options, profilesDictionarySettings, importedSummary.title);
 
         await this._saveOptions('background');
-    }
-
-    /**
-     * @param {string} name
-     * @param {boolean} enabled
-     * @param {string} styles
-     * @returns {import('settings').DictionaryOptions}
-     */
-    _createDefaultDictionarySettings(name, enabled, styles) {
-        return {
-            name,
-            alias: name,
-            enabled,
-            allowSecondarySearches: false,
-            definitionsCollapsible: 'not-collapsible',
-            partsOfSpeechFilter: true,
-            useDeinflections: true,
-            styles: styles ?? '',
-        };
-    }
-
-    /**
-     * @returns {Promise<void>}
-     */
-    async _pruneStaleDictionaryAutoUpdates() {
-        const options = this._options;
-        if (options === null) {
-            return;
-        }
-        await this._ensureDictionaryDatabaseReady();
-        const dictionaries = await this._dictionaryDatabase.getDictionaryInfo();
-        const validIndexUrls = new Set(
-            dictionaries
-                .filter((dictionary) => dictionary.isUpdatable === true && typeof dictionary.indexUrl === 'string')
-                .map((dictionary) => /** @type {string} */ (dictionary.indexUrl)),
-        );
-        const nextIndexUrls = options.global.dictionaryAutoUpdates.filter((indexUrl) => validIndexUrls.has(indexUrl));
-        if (nextIndexUrls.length !== options.global.dictionaryAutoUpdates.length) {
-            options.global.dictionaryAutoUpdates = nextIndexUrls;
-            await this._saveOptions('background');
-        }
-
-        const state = await this._getDictionaryAutoUpdateState();
-        let stateChanged = false;
-        for (const indexUrl of Object.keys(state)) {
-            if (validIndexUrls.has(indexUrl)) {
-                continue;
-            }
-            delete state[indexUrl];
-            stateChanged = true;
-        }
-        if (stateChanged) {
-            await this._setDictionaryAutoUpdateState(state);
-        }
-    }
-
-    /**
-     * @returns {Promise<Record<string, {lastAttemptAt?: number, lastSuccessfulCheckAt?: number, lastSuccessfulUpdateAt?: number, lastSeenRevision?: string, etag?: string|null, lastModified?: string|null, lastError?: string|null}>>}
-     */
-    async _getDictionaryAutoUpdateState() {
-        const value = await this._getLocalStorageRecord(DICTIONARY_AUTO_UPDATE_STATE_STORAGE_KEY);
-        if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-            return {};
-        }
-        return /** @type {Record<string, {lastAttemptAt?: number, lastSuccessfulCheckAt?: number, lastSuccessfulUpdateAt?: number, lastSeenRevision?: string, etag?: string|null, lastModified?: string|null, lastError?: string|null}>} */ (value);
-    }
-
-    /**
-     * @param {Record<string, unknown>} state
-     * @returns {Promise<void>}
-     */
-    async _setDictionaryAutoUpdateState(state) {
-        await this._setLocalStorageRecord(DICTIONARY_AUTO_UPDATE_STATE_STORAGE_KEY, state);
-    }
-
-    /**
-     * @param {import('dictionary-importer').Summary} previousSummary
-     * @param {import('dictionary-importer').Summary} importedSummary
-     * @returns {Promise<void>}
-     */
-    async _updateDictionaryAutoUpdateStateAfterSuccess(previousSummary, importedSummary) {
-        const previousIndexUrl = previousSummary.indexUrl;
-        if (typeof previousIndexUrl !== 'string') {
-            return;
-        }
-        const state = await this._getDictionaryAutoUpdateState();
-        const previousState = state[previousIndexUrl] ?? {};
-        if (!(importedSummary.isUpdatable === true && typeof importedSummary.indexUrl === 'string')) {
-            delete state[previousIndexUrl];
-            await this._setDictionaryAutoUpdateState(state);
-            return;
-        }
-        const nextIndexUrl = importedSummary.indexUrl;
-        state[nextIndexUrl] = {
-            ...previousState,
-            lastSuccessfulUpdateAt: Date.now(),
-            lastSeenRevision: importedSummary.revision,
-            lastError: null,
-            etag: nextIndexUrl === previousIndexUrl ? previousState.etag ?? null : null,
-            lastModified: nextIndexUrl === previousIndexUrl ? previousState.lastModified ?? null : null,
-        };
-        if (nextIndexUrl !== previousIndexUrl) {
-            delete state[previousIndexUrl];
-        }
-        await this._setDictionaryAutoUpdateState(state);
-    }
-
-    /**
-     * @param {string} indexUrl
-     * @param {string} message
-     * @returns {Promise<void>}
-     */
-    async _setDictionaryAutoUpdateError(indexUrl, message) {
-        if (typeof indexUrl !== 'string' || indexUrl.length === 0) {
-            return;
-        }
-        const state = await this._getDictionaryAutoUpdateState();
-        const entry = state[indexUrl] ?? {};
-        entry.lastError = message;
-        state[indexUrl] = entry;
-        await this._setDictionaryAutoUpdateState(state);
-    }
-
-    /**
-     * @param {string} key
-     * @returns {Promise<unknown>}
-     */
-    async _getLocalStorageRecord(key) {
-        const localStorageArea = chrome.storage?.local;
-        if (!isObjectNotArray(localStorageArea) || typeof localStorageArea.get !== 'function') {
-            return void 0;
-        }
-        return await new Promise((resolve, reject) => {
-            localStorageArea.get([key], (items) => {
-                const runtimeError = chrome.runtime.lastError;
-                if (runtimeError) {
-                    reject(new Error(runtimeError.message || 'storage.local.get failed'));
-                    return;
-                }
-                resolve(Reflect.get(items, key));
-            });
-        });
-    }
-
-    /**
-     * @param {string} key
-     * @param {unknown} value
-     * @returns {Promise<void>}
-     */
-    async _setLocalStorageRecord(key, value) {
-        const localStorageArea = chrome.storage?.local;
-        if (!isObjectNotArray(localStorageArea) || typeof localStorageArea.set !== 'function') {
-            return;
-        }
-        await new Promise((resolve, reject) => {
-            localStorageArea.set({[key]: value}, () => {
-                const runtimeError = chrome.runtime.lastError;
-                if (runtimeError) {
-                    reject(new Error(runtimeError.message || 'storage.local.set failed'));
-                    return;
-                }
-                resolve(void 0);
-            });
-        });
     }
 
     /**

--- a/ext/js/background/startup-dictionary-updater.js
+++ b/ext/js/background/startup-dictionary-updater.js
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2023-2026  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+export class StartupDictionaryUpdater {
+    /**
+     * @param {{
+     *   isEnabled: () => Promise<boolean>,
+     *   hasRunThisSession: () => Promise<boolean>,
+     *   markRunThisSession: () => Promise<void>,
+     *   getDictionaryInfo: () => Promise<import('dictionary-importer').Summary[]>,
+     *   checkForUpdate: (dictionaryInfo: import('dictionary-importer').Summary) => Promise<unknown | null>,
+     *   updateDictionary: (dictionaryTitle: string, updateCandidate: unknown) => Promise<boolean>,
+     *   onError: (error: unknown, details: {dictionaryTitle: string, phase: 'check' | 'update'}) => void
+     * }} dependencies
+     */
+    constructor({
+        isEnabled,
+        hasRunThisSession,
+        markRunThisSession,
+        getDictionaryInfo,
+        checkForUpdate,
+        updateDictionary,
+        onError,
+    }) {
+        /** @type {() => Promise<boolean>} */
+        this._isEnabled = isEnabled;
+        /** @type {() => Promise<boolean>} */
+        this._hasRunThisSession = hasRunThisSession;
+        /** @type {() => Promise<void>} */
+        this._markRunThisSession = markRunThisSession;
+        /** @type {() => Promise<import('dictionary-importer').Summary[]>} */
+        this._getDictionaryInfo = getDictionaryInfo;
+        /** @type {(dictionaryInfo: import('dictionary-importer').Summary) => Promise<unknown | null>} */
+        this._checkForUpdate = checkForUpdate;
+        /** @type {(dictionaryTitle: string, updateCandidate: unknown) => Promise<boolean>} */
+        this._updateDictionary = updateDictionary;
+        /** @type {(error: unknown, details: {dictionaryTitle: string, phase: 'check' | 'update'}) => void} */
+        this._onError = onError;
+    }
+
+    /**
+     * @returns {Promise<number>}
+     */
+    async run() {
+        if (!await this._isEnabled()) { return 0; }
+        if (await this._hasRunThisSession()) { return 0; }
+
+        await this._markRunThisSession();
+
+        let updateCount = 0;
+        const dictionaries = await this._getDictionaryInfo();
+        for (const dictionaryInfo of dictionaries) {
+            let updateCandidate;
+            try {
+                updateCandidate = await this._checkForUpdate(dictionaryInfo);
+            } catch (e) {
+                this._onError(e, {dictionaryTitle: dictionaryInfo.title, phase: 'check'});
+                continue;
+            }
+
+            if (updateCandidate === null) { continue; }
+
+            try {
+                if (await this._updateDictionary(dictionaryInfo.title, updateCandidate)) {
+                    ++updateCount;
+                }
+            } catch (e) {
+                this._onError(e, {dictionaryTitle: dictionaryInfo.title, phase: 'update'});
+            }
+        }
+
+        return updateCount;
+    }
+}

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -588,6 +588,7 @@ export class OptionsUtil {
             this._updateVersion74,
             this._updateVersion75,
             this._updateVersion76,
+            this._updateVersion77,
         ];
         /* eslint-enable @typescript-eslint/unbound-method */
         if (typeof targetVersion === 'number' && targetVersion < result.length) {
@@ -1853,6 +1854,22 @@ export class OptionsUtil {
             options.global.database = {};
         }
         options.global.database.maxHeadwordLength = 0;
+    }
+
+    /**
+     *  - Added global.database.autoUpdateDictionariesOnStartup
+     *  - Removed global.dictionaryAutoUpdates
+     *  @type {import('options-util').UpdateFunction}
+     */
+    async _updateVersion77(options) {
+        if (!isObjectNotArray(options.global)) {
+            options.global = {};
+        }
+        if (!isObjectNotArray(options.global.database)) {
+            options.global.database = {};
+        }
+        options.global.database.autoUpdateDictionariesOnStartup = false;
+        delete options.global.dictionaryAutoUpdates;
     }
 
     /**

--- a/ext/js/dictionary/dictionary-update-util.js
+++ b/ext/js/dictionary/dictionary-update-util.js
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2023-2026  Yomitan Authors
+ * Copyright (C) 2020-2022  Yomichan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {getKebabCase} from '../data/anki-template-util.js';
+
+/**
+ * @param {string} name
+ * @param {boolean} enabled
+ * @param {string} styles
+ * @returns {import('settings').DictionaryOptions}
+ */
+export function createDefaultDictionarySettings(name, enabled, styles) {
+    return {
+        name,
+        alias: name,
+        enabled,
+        allowSecondarySearches: false,
+        definitionsCollapsible: 'not-collapsible',
+        partsOfSpeechFilter: true,
+        useDeinflections: true,
+        styles: styles ?? '',
+    };
+}
+
+/**
+ * @param {import('settings').Options} optionsFull
+ * @param {string} dictionaryTitle
+ * @returns {import('settings-controller').ProfilesDictionarySettings}
+ */
+export function getProfilesDictionarySettings(optionsFull, dictionaryTitle) {
+    /** @type {import('settings-controller').ProfilesDictionarySettings} */
+    const profilesDictionarySettings = {};
+    for (const profile of optionsFull.profiles) {
+        const dictionaries = profile.options.dictionaries;
+        for (let i = 0; i < dictionaries.length; ++i) {
+            if (dictionaries[i].name === dictionaryTitle) {
+                profilesDictionarySettings[profile.id] = {...dictionaries[i], index: i};
+                break;
+            }
+        }
+    }
+    return profilesDictionarySettings;
+}
+
+/**
+ * @param {import('settings').Options} optionsFull
+ * @param {import('dictionary-importer').Summary} summary
+ * @param {import('settings-controller').ProfilesDictionarySettings} profilesDictionarySettings
+ * @param {number} [activeProfileIndex]
+ * @returns {void}
+ */
+export function applyImportedDictionarySettings(optionsFull, summary, profilesDictionarySettings, activeProfileIndex = optionsFull.profileCurrent) {
+    const {title, sequenced, styles} = summary;
+    const profileIndex = (
+        activeProfileIndex >= 0 &&
+        activeProfileIndex < optionsFull.profiles.length
+    ) ?
+        activeProfileIndex :
+        optionsFull.profileCurrent;
+
+    for (let i = 0; i < optionsFull.profiles.length; ++i) {
+        const profile = optionsFull.profiles[i];
+        const {options, id: profileId} = profile;
+        const savedDictionarySettings = profilesDictionarySettings?.[profileId];
+
+        if (typeof savedDictionarySettings === 'undefined') {
+            const enabled = (profileIndex === i);
+            const defaultSettings = createDefaultDictionarySettings(title, enabled, styles);
+            const existingIndex = options.dictionaries.findIndex((dictionary) => dictionary.name === title);
+            if (existingIndex >= 0) {
+                options.dictionaries.splice(existingIndex, 1, defaultSettings);
+            } else {
+                options.dictionaries.push(defaultSettings);
+            }
+        } else {
+            const {index, alias, name, ...currentSettings} = savedDictionarySettings;
+            const newAlias = alias === name ? title : alias;
+            const nextSettings = {
+                ...currentSettings,
+                styles,
+                name: title,
+                alias: newAlias,
+            };
+            const existingIndex = options.dictionaries.findIndex((dictionary) => dictionary.name === name || dictionary.name === title);
+            if (existingIndex >= 0) {
+                options.dictionaries.splice(existingIndex, 1, nextSettings);
+            } else {
+                const targetIndex = Math.max(0, Math.min(index, options.dictionaries.length));
+                options.dictionaries.splice(targetIndex, 0, nextSettings);
+            }
+            if (options.general.mainDictionary === name) {
+                options.general.mainDictionary = title;
+            }
+        }
+
+        if (sequenced && options.general.mainDictionary === '') {
+            options.general.mainDictionary = title;
+        }
+    }
+}
+
+/**
+ * @param {import('settings').Options} optionsFull
+ * @param {import('settings-controller').ProfilesDictionarySettings} profilesDictionarySettings
+ * @param {string} newTitle
+ * @returns {boolean}
+ */
+export function updateDictionaryAnkiFieldTemplates(optionsFull, profilesDictionarySettings, newTitle) {
+    if (profilesDictionarySettings === null) { return false; }
+
+    const newFieldSegment = getKebabCase(newTitle);
+    let modified = false;
+
+    for (const profile of optionsFull.profiles) {
+        const savedDictionarySettings = profilesDictionarySettings[profile.id];
+        if (typeof savedDictionarySettings === 'undefined') { continue; }
+
+        const oldFieldSegment = getKebabCase(savedDictionarySettings.name);
+        if (oldFieldSegment === newFieldSegment || oldFieldSegment.length === 0) { continue; }
+
+        const oldFieldSegmentRegex = new RegExp(oldFieldSegment, 'g');
+        for (const cardFormat of profile.options.anki.cardFormats) {
+            const ankiTermFields = cardFormat.fields;
+            for (const key of Object.keys(ankiTermFields)) {
+                const {value} = ankiTermFields[key];
+                const nextValue = value.replace(oldFieldSegmentRegex, newFieldSegment);
+                if (nextValue !== value) {
+                    ankiTermFields[key].value = nextValue;
+                    modified = true;
+                }
+            }
+        }
+    }
+
+    return modified;
+}

--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -19,6 +19,10 @@
 import {EventListenerCollection} from '../../core/event-listener-collection.js';
 import {log} from '../../core/log.js';
 import {deferPromise} from '../../core/utilities.js';
+import {
+    createDefaultDictionarySettings,
+    getProfilesDictionarySettings,
+} from '../../dictionary/dictionary-update-util.js';
 import {querySelectorNotNull} from '../../dom/query-selector.js';
 
 class DictionaryEntry {
@@ -277,8 +281,8 @@ class DictionaryEntry {
     }
 
     /** */
-    async _showDetails() {
-        const {title, revision, version, counts, prefixWildcardsSupported, isUpdatable, indexUrl, downloadUrl} = this._dictionaryInfo;
+    _showDetails() {
+        const {title, revision, version, counts, prefixWildcardsSupported} = this._dictionaryInfo;
 
         const modal = this._dictionaryController.modalController.getModal('dictionary-details');
         if (modal === null) { return; }
@@ -301,10 +305,6 @@ class DictionaryEntry {
         const useDeinflectionsSetting = querySelectorNotNull(modal.node, '.dictionary-use-deinflections-setting');
         /** @type {HTMLElement} */
         const useDeinflectionsToggle = querySelectorNotNull(useDeinflectionsSetting, '.dictionary-use-deinflections-toggle');
-        /** @type {HTMLElement} */
-        const autoUpdateSetting = querySelectorNotNull(modal.node, '.dictionary-auto-update-setting');
-        /** @type {HTMLInputElement} */
-        const autoUpdateToggle = querySelectorNotNull(autoUpdateSetting, '.dictionary-auto-update-toggle');
 
         titleElement.textContent = title;
         versionElement.textContent = `rev.${revision}`;
@@ -315,16 +315,6 @@ class DictionaryEntry {
 
         useDeinflectionsSetting.hidden = !counts?.terms.total;
         useDeinflectionsToggle.dataset.setting = `dictionaries[${this._index}].useDeinflections`;
-
-        const canAutoUpdate = (isUpdatable === true && typeof indexUrl === 'string' && typeof downloadUrl === 'string');
-        autoUpdateSetting.hidden = !canAutoUpdate;
-        autoUpdateToggle.checked = false;
-        delete autoUpdateToggle.dataset.indexUrl;
-        if (canAutoUpdate) {
-            const optionsFull = await this._dictionaryController.settingsController.getOptionsFull();
-            autoUpdateToggle.checked = optionsFull.global.dictionaryAutoUpdates.includes(indexUrl);
-            autoUpdateToggle.dataset.indexUrl = indexUrl;
-        }
 
         this._setupDetails(detailsTableElement);
 
@@ -603,6 +593,8 @@ export class DictionaryController {
         /** @type {?HTMLButtonElement} */
         this._checkUpdatesButton = document.querySelector('#dictionary-check-updates');
         /** @type {?HTMLButtonElement} */
+        this._updateAllButton = document.querySelector('#dictionary-update-all');
+        /** @type {?HTMLButtonElement} */
         this._checkIntegrityButton = document.querySelector('#dictionary-check-integrity');
         /** @type {HTMLElement} */
         this._dictionaryEntryContainer = querySelectorNotNull(document, '#dictionary-list');
@@ -618,12 +610,16 @@ export class DictionaryController {
         this._deleteDictionaryModal = null;
         /** @type {?import('./modal.js').Modal} */
         this._updateDictionaryModal = null;
+        /** @type {?import('./modal.js').Modal} */
+        this._updateAllDictionaryModal = null;
         /** @type {HTMLInputElement} */
         this._allCheckbox = querySelectorNotNull(document, '#all-dictionaries-enabled');
         /** @type {?DictionaryExtraInfo} */
         this._extraInfo = null;
         /** @type {import('dictionary-controller.js').DictionaryTask[]} */
         this._dictionaryTaskQueue = [];
+        /** @type {import('dictionary-controller.js').DictionaryTask[]} */
+        this._pendingUpdateTasks = [];
         /** @type {boolean} */
         this._isTaskQueueRunning = false;
         /** @type {(() => void) | null} */
@@ -651,10 +647,13 @@ export class DictionaryController {
         this._noDictionariesEnabledWarnings = /** @type {NodeListOf<HTMLElement>} */ (document.querySelectorAll('.no-dictionaries-enabled-warning'));
         this._deleteDictionaryModal = this._modalController.getModal('dictionary-confirm-delete');
         this._updateDictionaryModal = this._modalController.getModal('dictionary-confirm-update');
+        this._updateAllDictionaryModal = this._modalController.getModal('dictionary-confirm-update-all');
         /** @type {HTMLButtonElement} */
         const dictionaryDeleteButton = querySelectorNotNull(document, '#dictionary-confirm-delete-button');
         /** @type {HTMLButtonElement} */
         const dictionaryUpdateButton = querySelectorNotNull(document, '#dictionary-confirm-update-button');
+        /** @type {HTMLButtonElement} */
+        const dictionaryUpdateAllButton = querySelectorNotNull(document, '#dictionary-confirm-update-all-button');
 
         /** @type {HTMLButtonElement} */
         const dictionaryMoveButton = querySelectorNotNull(document, '#dictionary-move-button');
@@ -669,7 +668,7 @@ export class DictionaryController {
         this._allCheckbox.addEventListener('change', this._onAllCheckboxChange.bind(this), false);
         dictionaryDeleteButton.addEventListener('click', this._onDictionaryConfirmDelete.bind(this), false);
         dictionaryUpdateButton.addEventListener('click', this._onDictionaryConfirmUpdate.bind(this), false);
-        /** @type {HTMLInputElement} */ (querySelectorNotNull(document, '.dictionary-auto-update-toggle')).addEventListener('change', this._onDictionaryAutoUpdateToggleChange.bind(this), false);
+        dictionaryUpdateAllButton.addEventListener('click', this._onDictionaryConfirmUpdateAll.bind(this), false);
 
         dictionaryMoveButton.addEventListener('click', this._onDictionaryMoveButtonClick.bind(this), false);
 
@@ -678,6 +677,9 @@ export class DictionaryController {
 
         if (this._checkUpdatesButton !== null) {
             this._checkUpdatesButton.addEventListener('click', this._onCheckUpdatesButtonClick.bind(this), false);
+        }
+        if (this._updateAllButton !== null) {
+            this._updateAllButton.addEventListener('click', this._onUpdateAllButtonClick.bind(this), false);
         }
         if (this._checkIntegrityButton !== null) {
             this._checkIntegrityButton.addEventListener('click', this._onCheckIntegrityButtonClick.bind(this), false);
@@ -813,16 +815,7 @@ export class DictionaryController {
      * @returns {import('settings').DictionaryOptions}
      */
     static createDefaultDictionarySettings(name, enabled, styles) {
-        return {
-            name,
-            alias: name,
-            enabled,
-            allowSecondarySearches: false,
-            definitionsCollapsible: 'not-collapsible',
-            partsOfSpeechFilter: true,
-            useDeinflections: true,
-            styles: styles ?? '',
-        };
+        return createDefaultDictionarySettings(name, enabled, styles);
     }
 
     /**
@@ -859,7 +852,7 @@ export class DictionaryController {
             }
 
             for (const {title, styles} of missingDictionaries) {
-                const value = DictionaryController.createDefaultDictionarySettings(title, newDictionariesEnabled, styles);
+                const value = createDefaultDictionarySettings(title, newDictionariesEnabled, styles);
                 dictionaryOptionsArray.push(value);
                 modified = true;
             }
@@ -1075,26 +1068,21 @@ export class DictionaryController {
     }
 
     /**
-     * @param {Event} e
+     * @param {MouseEvent} e
      */
-    async _onDictionaryAutoUpdateToggleChange(e) {
-        const toggle = /** @type {HTMLInputElement} */ (e.currentTarget);
-        const indexUrl = toggle.dataset.indexUrl;
-        if (typeof indexUrl !== 'string' || indexUrl.length === 0) {
-            return;
+    _onDictionaryConfirmUpdateAll(e) {
+        e.preventDefault();
+
+        const modal = /** @type {import('./modal.js').Modal} */ (this._updateAllDictionaryModal);
+        modal.setVisible(false);
+
+        const pendingUpdateTasks = this._pendingUpdateTasks;
+        this._pendingUpdateTasks = [];
+        for (const task of pendingUpdateTasks) {
+            if (task.type !== 'update') { continue; }
+            void this._enqueueTask(task);
+            this._hideUpdatesAvailableButton(task.dictionaryTitle);
         }
-        const optionsFull = await this._settingsController.getOptionsFull();
-        const nextIndexUrls = new Set(optionsFull.global.dictionaryAutoUpdates);
-        if (toggle.checked) {
-            nextIndexUrls.add(indexUrl);
-        } else {
-            nextIndexUrls.delete(indexUrl);
-        }
-        await this._settingsController.modifyGlobalSettings([{
-            action: 'set',
-            path: 'dictionaryAutoUpdates',
-            value: [...nextIndexUrls].sort((a, b) => a.localeCompare(b)),
-        }]);
     }
 
     /**
@@ -1123,6 +1111,14 @@ export class DictionaryController {
     _onCheckUpdatesButtonClick(e) {
         e.preventDefault();
         void this._checkForUpdates();
+    }
+
+    /**
+     * @param {MouseEvent} e
+     */
+    _onUpdateAllButtonClick(e) {
+        e.preventDefault();
+        void this._updateAllDictionaries();
     }
 
     /** */
@@ -1203,12 +1199,48 @@ export class DictionaryController {
             this._checkingUpdates = true;
             this._setButtonsEnabled(false);
 
-            const updateChecks = this._dictionaryEntries.map((entry) => entry.checkForUpdate());
-            const updateCount = (await Promise.all(updateChecks)).reduce((sum, value) => (sum + (value ? 1 : 0)), 0);
+            const updateTasks = await this._getDictionaryUpdateTasks();
+            const updateCount = updateTasks.length;
             if (this._checkUpdatesButton !== null) {
                 hasUpdates = !!updateCount;
                 this._checkUpdatesButton.textContent = hasUpdates ? `${updateCount} update${updateCount > 1 ? 's' : ''}` : 'No updates';
             }
+        } finally {
+            this._setButtonsEnabled(true);
+            if (this._checkUpdatesButton !== null && !hasUpdates) {
+                this._checkUpdatesButton.disabled = true;
+            }
+            this._checkingUpdates = false;
+        }
+    }
+
+    /** */
+    async _updateAllDictionaries() {
+        if (this._dictionaries === null || this._checkingIntegrity || this._checkingUpdates || this._isTaskQueueRunning) { return; }
+        const modal = this._updateAllDictionaryModal;
+        if (modal === null) { return; }
+
+        let hasUpdates;
+        try {
+            this._checkingUpdates = true;
+            this._setButtonsEnabled(false);
+
+            const updateTasks = await this._getDictionaryUpdateTasks();
+            const updateCount = updateTasks.length;
+            hasUpdates = (updateCount > 0);
+            if (this._checkUpdatesButton !== null) {
+                this._checkUpdatesButton.textContent = hasUpdates ? `${updateCount} update${updateCount > 1 ? 's' : ''}` : 'No updates';
+            }
+            if (!hasUpdates) {
+                this._pendingUpdateTasks = [];
+                return;
+            }
+
+            this._pendingUpdateTasks = updateTasks;
+            /** @type {HTMLElement} */
+            const countElement = querySelectorNotNull(modal.node, '#dictionary-confirm-update-all-count');
+            countElement.textContent = `${updateCount} ${updateCount === 1 ? 'dictionary' : 'dictionaries'}`;
+            modal.setVisible(true);
         } finally {
             this._setButtonsEnabled(true);
             if (this._checkUpdatesButton !== null && !hasUpdates) {
@@ -1292,6 +1324,24 @@ export class DictionaryController {
         container.insertBefore(fragment, relative);
 
         this._updateDictionaryEntryCount();
+    }
+
+    /**
+     * @returns {Promise<import('dictionary-controller.js').DictionaryTask[]>}
+     */
+    async _getDictionaryUpdateTasks() {
+        const updateChecks = this._dictionaryEntries.map(async (entry) => {
+            if (!await entry.checkForUpdate()) { return null; }
+            return /** @type {import('dictionary-controller.js').DictionaryTask} */ ({
+                type: 'update',
+                dictionaryTitle: entry.dictionaryTitle,
+                downloadUrl: entry.updateDownloadUrl ?? void 0,
+            });
+        });
+
+        return /** @type {import('dictionary-controller.js').DictionaryTask[]} */ (
+            (await Promise.all(updateChecks)).filter((task) => task !== null)
+        );
     }
 
 

--- a/ext/js/pages/settings/dictionary-import-controller.js
+++ b/ext/js/pages/settings/dictionary-import-controller.js
@@ -22,10 +22,12 @@ import {parseJson, readResponseJson} from '../../core/json.js';
 import {log} from '../../core/log.js';
 import {safePerformance} from '../../core/safe-performance.js';
 import {toError} from '../../core/to-error.js';
-import {getKebabCase} from '../../data/anki-template-util.js';
+import {
+    applyImportedDictionarySettings,
+    updateDictionaryAnkiFieldTemplates,
+} from '../../dictionary/dictionary-update-util.js';
 import {DictionaryWorker} from '../../dictionary/dictionary-worker.js';
 import {querySelectorNotNull} from '../../dom/query-selector.js';
-import {DictionaryController} from './dictionary-controller.js';
 
 const OPFS_REQUIRED_USER_MESSAGE = 'Manabitan requires OPFS storage support. Update to Chrome/Edge 120+ or Firefox 115+ and reload the extension.';
 const RECOMMENDED_DICTIONARY_CATEGORIES = ['terms', 'kanji', 'frequency', 'grammar', 'pronunciation'];
@@ -1808,7 +1810,7 @@ export class DictionaryImportController {
         }
 
         const addSettingsStartTime = safePerformance.now();
-        const errors2 = await this._addDictionarySettings(result, profilesDictionarySettings);
+        const errors2 = await this._updateSettingsAfterDictionaryImport(result, profilesDictionarySettings);
         const addSettingsEndTime = safePerformance.now();
         log.log(`[ImportTiming] [${dictionaryTitle}] add dictionary settings ${formatDurationMs(addSettingsEndTime - addSettingsStartTime)}`);
         recordLocalPhase('add-dictionary-settings', addSettingsStartTime, addSettingsEndTime, {
@@ -1844,28 +1846,6 @@ export class DictionaryImportController {
             });
         }
 
-        // Only runs if updating a dictionary
-        if (profilesDictionarySettings !== null) {
-            const profileUpdateStartTime = safePerformance.now();
-            const options = await this._settingsController.getOptionsFull();
-            const {profiles} = options;
-
-            for (const profile of profiles) {
-                for (const cardFormat of profile.options.anki.cardFormats) {
-                    const ankiTermFields = cardFormat.fields;
-                    const oldFieldSegmentRegex = new RegExp(getKebabCase(profilesDictionarySettings[profile.id].name), 'g');
-                    const newFieldSegment = getKebabCase(result.title);
-                    for (const key of Object.keys(ankiTermFields)) {
-                        ankiTermFields[key].value = ankiTermFields[key].value.replace(oldFieldSegmentRegex, newFieldSegment);
-                    }
-                }
-            }
-            await this._settingsController.setAllSettings(options);
-            const profileUpdateEndTime = safePerformance.now();
-            log.log(`[ImportTiming] [${dictionaryTitle}] update profile dictionary references ${formatDurationMs(profileUpdateEndTime - profileUpdateStartTime)}`);
-            recordLocalPhase('update-profile-dictionary-references', profileUpdateStartTime, profileUpdateEndTime);
-        }
-
         const importEndTime = safePerformance.now();
         log.log(`[ImportTiming] [${dictionaryTitle}] total import path ${formatDurationMs(importEndTime - importStartTime)} (errors=${errors.length + errors2.length})`);
         reportDiagnostics('dictionary-import-zip-complete', {
@@ -1892,55 +1872,35 @@ export class DictionaryImportController {
      * @param {import('settings-controller').ProfilesDictionarySettings} profilesDictionarySettings
      * @returns {Promise<Error[]>}
      */
-    async _addDictionarySettings(summary, profilesDictionarySettings) {
-        const {title, sequenced, styles} = summary;
-        let optionsFull;
+    async _updateSettingsAfterDictionaryImport(summary, profilesDictionarySettings) {
+        const optionsFull = await this._getOptionsFullWithRetry();
+        if (!optionsFull) {
+            return [new Error('Failed to automatically set dictionary settings. A page refresh and manual enabling of the dictionary may be required.')];
+        }
+
+        try {
+            applyImportedDictionarySettings(optionsFull, summary, profilesDictionarySettings, this._settingsController.profileIndex);
+            updateDictionaryAnkiFieldTemplates(optionsFull, profilesDictionarySettings, summary.title);
+            await this._settingsController.setAllSettings(optionsFull);
+            return [];
+        } catch (error) {
+            return [toError(error)];
+        }
+    }
+
+    /**
+     * @returns {Promise<import('settings').Options|undefined>}
+     */
+    async _getOptionsFullWithRetry() {
         // Workaround Firefox bug sometimes causing getOptionsFull to fail
-        for (let i = 0, success = false; (i < 10) && (success === false); i++) {
+        for (let i = 0; i < 10; ++i) {
             try {
-                optionsFull = await this._settingsController.getOptionsFull();
-                success = true;
+                return await this._settingsController.getOptionsFull();
             } catch (error) {
                 log.error(error);
             }
         }
-        if (!optionsFull) { return [new Error('Failed to automatically set dictionary settings. A page refresh and manual enabling of the dictionary may be required.')]; }
-
-        const profileIndex = this._settingsController.profileIndex;
-        /** @type {import('settings-modifications').Modification[]} */
-        const targets = [];
-        const profileCount = optionsFull.profiles.length;
-        for (let i = 0; i < profileCount; ++i) {
-            const {options, id: profileId} = optionsFull.profiles[i];
-            const enabled = profileIndex === i;
-            const defaultSettings = DictionaryController.createDefaultDictionarySettings(title, enabled, styles);
-            const path1 = `profiles[${i}].options.dictionaries`;
-
-            if (profilesDictionarySettings === null || typeof profilesDictionarySettings[profileId] === 'undefined') {
-                targets.push({action: 'push', path: path1, items: [defaultSettings]});
-            } else {
-                const {index, alias, name, ...currentSettings} = profilesDictionarySettings[profileId];
-                const newAlias = alias === name ? title : alias;
-                targets.push({
-                    action: 'splice',
-                    path: path1,
-                    start: index,
-                    items: [{
-                        ...currentSettings,
-                        styles,
-                        name: title,
-                        alias: newAlias,
-                    }],
-                    deleteCount: 0,
-                });
-            }
-
-            if (sequenced && options.general.mainDictionary === '') {
-                const path2 = `profiles[${i}].options.general.mainDictionary`;
-                targets.push({action: 'set', path: path2, value: title});
-            }
-        }
-        return await this._modifyGlobalSettings(targets);
+        return void 0;
     }
 
     /**

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -278,6 +278,16 @@
                 <button type="button" class="icon-button"><span class="icon-button-inner"><span class="icon" data-icon="material-right-arrow"></span></span></button>
             </div>
         </div></div>
+        <div class="settings-item"><div class="settings-item-inner">
+            <div class="settings-item-left">
+                <div class="settings-item-label">Auto-update dictionaries on startup</div>
+                <div class="settings-item-description">Check installed dictionaries for new revisions and update them automatically when Manabitan starts.</div>
+                <div class="settings-item-description warning-text">Warning: if an automatic update fails during import, the previous version may be unavailable until you import the dictionary again manually.</div>
+            </div>
+            <div class="settings-item-right">
+                <label class="toggle"><input type="checkbox" data-setting="global.database.autoUpdateDictionariesOnStartup" data-scope="global"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
+            </div>
+        </div></div>
         <div class="settings-item">
             <div class="settings-item settings-item-button" data-modal-action="show,recommended-dictionaries"><div class="settings-item-inner">
                 <div class="settings-item-left">

--- a/ext/templates-modals.html
+++ b/ext/templates-modals.html
@@ -69,6 +69,7 @@
             <button type="button" class="low-emphasis danger dictionary-database-mutating-input" id="dictionary-delete-all-button">Delete All</button>
             <button type="button" class="low-emphasis dictionary-database-mutating-input advanced-only" id="dictionary-check-integrity">Check Integrity</button>
             <button type="button" class="low-emphasis dictionary-database-mutating-input" id="dictionary-check-updates">Check for Updates</button>
+            <button type="button" class="low-emphasis dictionary-database-mutating-input" id="dictionary-update-all">Update All</button>
             <button type="button" class="low-emphasis dictionary-database-mutating-input" id="dictionary-import-button">Import</button>
             <button type="button" data-modal-action="hide">Close</button>
         </div>
@@ -122,6 +123,26 @@
         <div class="modal-footer">
             <button type="button" class="low-emphasis" data-modal-action="hide">Cancel</button>
             <button type="button" class="danger" data-modal-action="hide" id="dictionary-confirm-delete-all-button">Delete</button>
+        </div>
+    </div></div>
+
+    <div id="dictionary-confirm-update-all-modal" class="modal" tabindex="-1" role="dialog" hidden><div class="modal-content modal-content-small">
+        <div class="modal-header"><div class="modal-title">Confirm Dictionary Updates</div></div>
+        <div class="modal-body">
+            <p>Are you sure you want to update <strong id="dictionary-confirm-update-all-count"></strong>?</p>
+            <section>
+                Updating dictionaries involves:
+                <ul>
+                    <li>Deleting the installed version</li>
+                    <li>Downloading the latest version </li>
+                    <li>Importing the latest version</li>
+                </ul>
+                <p class="warning-text">Especially for large dictionaries, this process can take a while, and downloading will use your network.</p>
+            </section>
+        </div>
+        <div class="modal-footer">
+            <button type="button" class="low-emphasis" data-modal-action="hide">Cancel</button>
+            <button type="button" class="danger" data-modal-action="hide" id="dictionary-confirm-update-all-button">Update All</button>
         </div>
     </div></div>
 
@@ -228,21 +249,6 @@
                 <div class="settings-item-children more" hidden>
                     Deinflections from this dictionary will be used.
                     <p><a tabindex="0" class="more-toggle" data-parent-distance="3">Hide&hellip;</a></p>
-                </div>
-            </div>
-            <div class="settings-item dictionary-auto-update-setting" hidden>
-                <div class="settings-item-inner">
-                    <div class="settings-item-left">
-                        <div class="settings-item-label">
-                            Automatic hourly updates
-                        </div>
-                    </div>
-                    <div class="settings-item-right">
-                        <label class="toggle"><input type="checkbox" class="dictionary-auto-update-toggle"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
-                    </div>
-                </div>
-                <div class="settings-item-children">
-                    Check for updates every hour and install them automatically.
                 </div>
             </div>
             <hr>

--- a/test/backend-dictionary-auto-update.test.js
+++ b/test/backend-dictionary-auto-update.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2025  Yomitan Authors
+ * Copyright (C) 2023-2026  Yomitan Authors
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -25,9 +25,15 @@ vi.mock('../ext/lib/kanji-processor.js', () => ({
     convertVariants: (text) => text,
 }));
 
-const {Backend} = await import('../ext/js/background/backend.js');
+vi.mock('../ext/js/comm/yomitan-api.js', () => ({
+    YomitanApi: class {},
+}));
 
-const DICTIONARY_AUTO_UPDATE_INTERVAL_MS = 60 * 60 * 1000;
+vi.mock('../ext/js/dictionary/dictionary-database.js', () => ({
+    DictionaryDatabase: class {},
+}));
+
+const {Backend} = await import('../ext/js/background/backend.js');
 
 afterEach(() => {
     vi.restoreAllMocks();
@@ -91,7 +97,7 @@ function createCheckResult(overrides = {}) {
     };
 }
 
-describe('Backend dictionary auto-update helpers', () => {
+describe('Backend dictionary update helpers', () => {
     test('setDictionaryImportMode(true) clears the import-mode flag when suspension activation fails', async () => {
         const failure = new Error('suspend failed');
         const setSuspended = vi.fn(async (suspended) => {
@@ -142,57 +148,15 @@ describe('Backend dictionary auto-update helpers', () => {
         expect(context._ensureDictionaryDatabaseReady).not.toHaveBeenCalled();
     });
 
-    test('Prunes stale auto-update settings and runtime state', async () => {
-        const saveOptions = vi.fn(async () => {});
-        const setState = vi.fn(async () => {});
-        const context = {
-            _options: {
-                global: {
-                    dictionaryAutoUpdates: [
-                        'https://example.invalid/keep.json',
-                        'https://example.invalid/remove.json',
-                    ],
-                },
-            },
-            _ensureDictionaryDatabaseReady: async () => {},
-            _dictionaryDatabase: {
-                getDictionaryInfo: async () => [
-                    createDictionarySummary({indexUrl: 'https://example.invalid/keep.json'}),
-                    createDictionarySummary({title: 'Static Dictionary', isUpdatable: false, indexUrl: 'https://example.invalid/static.json'}),
-                ],
-            },
-            _saveOptions: saveOptions,
-            _getDictionaryAutoUpdateState: async () => ({
-                'https://example.invalid/keep.json': {lastAttemptAt: 1},
-                'https://example.invalid/remove.json': {lastAttemptAt: 2},
-            }),
-            _setDictionaryAutoUpdateState: setState,
-        };
-
-        await getBackendMethod('_pruneStaleDictionaryAutoUpdates').call(context);
-
-        expect(context._options.global.dictionaryAutoUpdates).toStrictEqual(['https://example.invalid/keep.json']);
-        expect(saveOptions).toHaveBeenCalledTimes(1);
-        expect(setState).toHaveBeenCalledTimes(1);
-        expect(setState).toHaveBeenCalledWith({
-            'https://example.invalid/keep.json': {lastAttemptAt: 1},
-        });
-    });
-
-    test('HEAD 304 check updates validators without fetching the index body', async () => {
+    test('GET check reports newer revisions', async () => {
         const dictionary = createDictionarySummary();
-        /** @type {Record<string, {etag?: string, lastModified?: string, lastAttemptAt?: number, lastSuccessfulCheckAt?: number, lastSeenRevision?: string, lastError?: string|null}>} */
-        const state = {
-            'https://example.invalid/index.json': {
-                etag: '"old-etag"',
-                lastModified: 'Mon, 01 Jan 2024 00:00:00 GMT',
-            },
-        };
-        const fetchAnonymous = vi.fn(async () => new Response(null, {
-            status: 304,
+        const fetchAnonymous = vi.fn(async () => new Response(JSON.stringify({
+            revision: '2',
+            downloadUrl: 'https://example.invalid/dictionary-v2.zip',
+        }), {
+            status: 200,
             headers: {
-                ETag: '"new-etag"',
-                'Last-Modified': 'Tue, 02 Jan 2024 00:00:00 GMT',
+                'Content-Type': 'application/json',
             },
         }));
         const context = {
@@ -200,67 +164,13 @@ describe('Backend dictionary auto-update helpers', () => {
             _getDictionaryIndexSchema: async () => ({isValid: () => true}),
         };
 
-        const result = await getBackendMethod('_checkDictionaryUpdate').call(context, dictionary, state);
+        const result = await getBackendMethod('_checkDictionaryUpdate').call(context, dictionary);
 
-        expect(result).toStrictEqual({
-            dictionaryTitle: 'Test Dictionary',
-            hasUpdate: false,
-            currentRevision: '1',
-            latestRevision: null,
-            downloadUrl: 'https://example.invalid/dictionary.zip',
-            error: null,
-        });
         expect(fetchAnonymous).toHaveBeenCalledTimes(1);
         expect(fetchAnonymous).toHaveBeenCalledWith('https://example.invalid/index.json', expect.objectContaining({
-            method: 'HEAD',
-            headers: {
-                'If-None-Match': '"old-etag"',
-                'If-Modified-Since': 'Mon, 01 Jan 2024 00:00:00 GMT',
-            },
+            method: 'GET',
+            cache: 'no-store',
         }));
-        expect(state['https://example.invalid/index.json']).toMatchObject({
-            etag: '"new-etag"',
-            lastModified: 'Tue, 02 Jan 2024 00:00:00 GMT',
-            lastSeenRevision: '1',
-            lastError: null,
-        });
-        expect(state['https://example.invalid/index.json'].lastAttemptAt).toEqual(expect.any(Number));
-        expect(state['https://example.invalid/index.json'].lastSuccessfulCheckAt).toEqual(expect.any(Number));
-    });
-
-    test('HEAD success falls through to GET and reports newer revisions', async () => {
-        const dictionary = createDictionarySummary();
-        /** @type {Record<string, {etag?: string, lastModified?: string|null, lastAttemptAt?: number, lastSuccessfulCheckAt?: number, lastSeenRevision?: string, lastError?: string|null}>} */
-        const state = {'https://example.invalid/index.json': {}};
-        const fetchAnonymous = vi
-            .fn()
-            .mockResolvedValueOnce(new Response(null, {
-                status: 200,
-                headers: {
-                    ETag: '"head-etag"',
-                    'Last-Modified': 'Tue, 02 Jan 2024 00:00:00 GMT',
-                },
-            }))
-            .mockResolvedValueOnce(new Response(JSON.stringify({
-                revision: '2',
-                downloadUrl: 'https://example.invalid/dictionary-v2.zip',
-            }), {
-                status: 200,
-                headers: {
-                    'Content-Type': 'application/json',
-                    ETag: '"get-etag"',
-                },
-            }));
-        const context = {
-            _requestBuilder: {fetchAnonymous},
-            _getDictionaryIndexSchema: async () => ({isValid: () => true}),
-        };
-
-        const result = await getBackendMethod('_checkDictionaryUpdate').call(context, dictionary, state);
-
-        expect(fetchAnonymous).toHaveBeenCalledTimes(2);
-        expect(fetchAnonymous.mock.calls[0][1]).toEqual(expect.objectContaining({method: 'HEAD'}));
-        expect(fetchAnonymous.mock.calls[1][1]).toEqual(expect.objectContaining({method: 'GET', headers: {}}));
         expect(result).toStrictEqual({
             dictionaryTitle: 'Test Dictionary',
             hasUpdate: true,
@@ -269,123 +179,38 @@ describe('Backend dictionary auto-update helpers', () => {
             downloadUrl: 'https://example.invalid/dictionary-v2.zip',
             error: null,
         });
-        expect(state['https://example.invalid/index.json']).toMatchObject({
-            etag: '"get-etag"',
-            lastModified: null,
-            lastSeenRevision: '2',
-            lastError: null,
-        });
     });
 
-    test('GET fallback reuses validators when HEAD fails', async () => {
+    test('checkDictionaryUpdate reports HTTP errors', async () => {
         const dictionary = createDictionarySummary();
-        /** @type {Record<string, {etag?: string, lastModified?: string, lastAttemptAt?: number, lastSuccessfulCheckAt?: number, lastSeenRevision?: string, lastError?: string|null}>} */
-        const state = {
-            'https://example.invalid/index.json': {
-                etag: '"old-etag"',
-                lastModified: 'Mon, 01 Jan 2024 00:00:00 GMT',
-            },
-        };
-        const fetchAnonymous = vi
-            .fn()
-            .mockRejectedValueOnce(new Error('HEAD unsupported'))
-            .mockResolvedValueOnce(new Response(JSON.stringify({revision: '1'}), {
-                status: 200,
-                headers: {
-                    'Content-Type': 'application/json',
-                    ETag: '"get-etag"',
-                },
-            }));
+        const fetchAnonymous = vi.fn(async () => new Response(null, {status: 500}));
         const context = {
             _requestBuilder: {fetchAnonymous},
             _getDictionaryIndexSchema: async () => ({isValid: () => true}),
         };
 
-        const result = await getBackendMethod('_checkDictionaryUpdate').call(context, dictionary, state);
+        const result = await getBackendMethod('_checkDictionaryUpdate').call(context, dictionary);
 
-        expect(fetchAnonymous).toHaveBeenCalledTimes(2);
-        expect(fetchAnonymous.mock.calls[0][1]).toEqual(expect.objectContaining({method: 'HEAD'}));
-        expect(fetchAnonymous.mock.calls[1][1]).toEqual(expect.objectContaining({
-            method: 'GET',
-            headers: {
-                'If-None-Match': '"old-etag"',
-                'If-Modified-Since': 'Mon, 01 Jan 2024 00:00:00 GMT',
-            },
-        }));
         expect(result).toStrictEqual({
             dictionaryTitle: 'Test Dictionary',
             hasUpdate: false,
             currentRevision: '1',
-            latestRevision: '1',
+            latestRevision: null,
             downloadUrl: 'https://example.invalid/dictionary.zip',
-            error: null,
-        });
-        expect(state['https://example.invalid/index.json']).toMatchObject({
-            etag: '"get-etag"',
-            lastSeenRevision: '1',
-            lastError: null,
+            error: 'HTTP 500',
         });
     });
 
-    test('Auto-update pass only checks enabled dictionaries that are due', async () => {
-        vi.spyOn(Date, 'now').mockReturnValue(2 * DICTIONARY_AUTO_UPDATE_INTERVAL_MS);
-        const checkDictionaryUpdates = vi.fn(async () => [createCheckResult()]);
-        const updateDictionaryByTitle = vi.fn(async () => ({status: 'updated'}));
-        const context = {
-            _dictionaryAutoUpdatePassPromise: null,
-            _dictionaryImportModeActive: false,
-            _options: {
-                global: {
-                    dictionaryAutoUpdates: [
-                        'https://example.invalid/due.json',
-                        'https://example.invalid/recent.json',
-                    ],
-                },
-            },
-            _ensureDictionaryDatabaseReady: async () => {},
-            _dictionaryDatabase: {
-                getDictionaryInfo: async () => [
-                    createDictionarySummary({title: 'Recent', indexUrl: 'https://example.invalid/recent.json'}),
-                    createDictionarySummary({title: 'Due', indexUrl: 'https://example.invalid/due.json'}),
-                    createDictionarySummary({title: 'Static', isUpdatable: false, indexUrl: 'https://example.invalid/static.json'}),
-                ],
-            },
-            _getDictionaryAutoUpdateState: async () => ({
-                'https://example.invalid/due.json': {lastAttemptAt: 0},
-                'https://example.invalid/recent.json': {lastAttemptAt: (2 * DICTIONARY_AUTO_UPDATE_INTERVAL_MS) - 1},
-            }),
-            _checkDictionaryUpdates: checkDictionaryUpdates,
-            _updateDictionaryByTitle: updateDictionaryByTitle,
-        };
-
-        await getBackendMethod('_runDictionaryAutoUpdatePass').call(context, 'alarm');
-
-        expect(checkDictionaryUpdates).toHaveBeenCalledTimes(1);
-        expect(checkDictionaryUpdates).toHaveBeenCalledWith(['Due']);
-        expect(updateDictionaryByTitle).toHaveBeenCalledTimes(1);
-        expect(updateDictionaryByTitle).toHaveBeenCalledWith('Due', false, expect.objectContaining({
-            dictionaryTitle: 'Test Dictionary',
-            hasUpdate: true,
-        }));
-        expect(context._dictionaryAutoUpdatePassPromise).toBeNull();
-    });
-
-    test('Auto-update update skips when the mutation lock is busy', async () => {
+    test('updateDictionaryByTitle skips when the mutation lock is busy', async () => {
         const dictionary = createDictionarySummary();
         const fetchAnonymous = vi.fn(async () => new Response(new Uint8Array([1, 2, 3]), {status: 200}));
         const performDictionaryUpdate = vi.fn(async () => ({status: 'updated'}));
         const context = {
-            _options: {
-                global: {
-                    dictionaryAutoUpdates: ['https://example.invalid/index.json'],
-                },
-            },
             _ensureDictionaryDatabaseReady: async () => {},
             _dictionaryDatabase: {
                 getDictionaryInfo: async () => [dictionary],
             },
             _requestBuilder: {fetchAnonymous},
-            _setDictionaryAutoUpdateError: vi.fn(async () => {}),
             _runWithDictionaryMutationLock: vi.fn(async () => void 0),
             _performDictionaryUpdate: performDictionaryUpdate,
         };
@@ -407,44 +232,22 @@ describe('Backend dictionary auto-update helpers', () => {
         expect(performDictionaryUpdate).not.toHaveBeenCalled();
     });
 
-    test('Auto-update update aborts when hourly updates were disabled before commit', async () => {
-        const dictionary = createDictionarySummary();
-        const performDictionaryUpdate = vi.fn(async () => ({status: 'updated'}));
+    test('updateDictionaryOnStartup returns true only when an update is applied', async () => {
+        const updateDictionaryByTitle = vi
+            .fn()
+            .mockResolvedValueOnce({status: 'updated', error: null})
+            .mockResolvedValueOnce({status: 'skipped', error: null});
         const context = {
-            _options: {
-                global: {
-                    dictionaryAutoUpdates: [],
-                },
-            },
-            _ensureDictionaryDatabaseReady: async () => {},
-            _dictionaryDatabase: {
-                getDictionaryInfo: vi.fn(async () => [dictionary]),
-            },
-            _requestBuilder: {
-                fetchAnonymous: vi.fn(async () => new Response(new Uint8Array([1, 2, 3]), {status: 200})),
-            },
-            _setDictionaryAutoUpdateError: vi.fn(async () => {}),
-            _runWithDictionaryMutationLock: vi.fn(async (callback) => await callback()),
-            _performDictionaryUpdate: performDictionaryUpdate,
+            _updateDictionaryByTitle: updateDictionaryByTitle,
         };
 
-        const result = await getBackendMethod('_updateDictionaryByTitle').call(
-            context,
-            'Test Dictionary',
-            false,
-            createCheckResult(),
-        );
-
-        expect(result).toStrictEqual({
-            dictionaryTitle: 'Test Dictionary',
-            status: 'skipped',
-            latestRevision: '2',
-            error: null,
-        });
-        expect(performDictionaryUpdate).not.toHaveBeenCalled();
+        await expect(getBackendMethod('_updateDictionaryOnStartup').call(context, 'Test Dictionary', createCheckResult())).resolves.toBe(true);
+        await expect(getBackendMethod('_updateDictionaryOnStartup').call(context, 'Test Dictionary', createCheckResult())).resolves.toBe(false);
+        expect(updateDictionaryByTitle).toHaveBeenNthCalledWith(1, 'Test Dictionary', false, expect.objectContaining({hasUpdate: true}));
+        expect(updateDictionaryByTitle).toHaveBeenNthCalledWith(2, 'Test Dictionary', false, expect.objectContaining({hasUpdate: true}));
     });
 
-    test('Imported dictionary settings migrate aliases, Anki fields, and auto-update preferences', async () => {
+    test('Imported dictionary settings migrate aliases, Anki fields, and related dictionary references', async () => {
         const saveOptions = vi.fn(async () => {});
         const context = {
             _options: {
@@ -494,19 +297,22 @@ describe('Backend dictionary auto-update helpers', () => {
                     },
                 ],
                 global: {
-                    dictionaryAutoUpdates: ['https://example.invalid/old-index.json'],
+                    database: {
+                        prefixWildcardsSupported: false,
+                        maxHeadwordLength: 0,
+                        autoUpdateDictionariesOnStartup: false,
+                    },
+                    dataTransmissionConsentShown: false,
                 },
             },
             _saveOptions: saveOptions,
         };
         const previousSummary = createDictionarySummary({
             title: 'Old Dictionary',
-            indexUrl: 'https://example.invalid/old-index.json',
             styles: 'old-style',
         });
         const importedSummary = createDictionarySummary({
             title: 'New Dictionary',
-            indexUrl: 'https://example.invalid/new-index.json',
             styles: 'new-style',
         });
         const updateContext = {
@@ -555,7 +361,6 @@ describe('Backend dictionary auto-update helpers', () => {
         expect(profile.options.general.mainDictionary).toBe('New Dictionary');
         expect(profile.options.general.sortFrequencyDictionary).toBe('New Dictionary');
         expect(profile.options.anki.cardFormats[0].fields.expression.value).toBe('new-dictionary-term new-dictionary-reading');
-        expect(context._options.global.dictionaryAutoUpdates).toStrictEqual(['https://example.invalid/new-index.json']);
         expect(saveOptions).toHaveBeenCalledTimes(1);
         expect(saveOptions).toHaveBeenCalledWith('background');
     });

--- a/test/dictionary-update-util.test.js
+++ b/test/dictionary-update-util.test.js
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2023-2026  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {describe, expect, test} from 'vitest';
+import {
+    applyImportedDictionarySettings,
+    createDefaultDictionarySettings,
+    getProfilesDictionarySettings,
+    updateDictionaryAnkiFieldTemplates,
+} from '../ext/js/dictionary/dictionary-update-util.js';
+
+describe('dictionary-update-util', () => {
+    test('createDefaultDictionarySettings creates the default dictionary option shape', () => {
+        expect(createDefaultDictionarySettings('Dictionary', true, 'styles')).toStrictEqual({
+            name: 'Dictionary',
+            alias: 'Dictionary',
+            enabled: true,
+            allowSecondarySearches: false,
+            definitionsCollapsible: 'not-collapsible',
+            partsOfSpeechFilter: true,
+            useDeinflections: true,
+            styles: 'styles',
+        });
+    });
+
+    test('applyImportedDictionarySettings preserves dictionary order and updates main dictionary references', () => {
+        const options = /** @type {import('settings').Options} */ (/** @type {unknown} */ ({
+            version: 0,
+            profileCurrent: 1,
+            global: {
+                database: {
+                    prefixWildcardsSupported: false,
+                    maxHeadwordLength: 0,
+                    autoUpdateDictionariesOnStartup: false,
+                },
+                dataTransmissionConsentShown: false,
+            },
+            profiles: [
+                {
+                    id: 'profile-0',
+                    options: {
+                        general: {mainDictionary: 'Test Dictionary'},
+                        dictionaries: [
+                            {name: 'Test Dictionary', alias: 'My Alias', enabled: true, allowSecondarySearches: false, definitionsCollapsible: 'not-collapsible', partsOfSpeechFilter: true, useDeinflections: true, styles: 'old'},
+                            {name: 'Other Dictionary', alias: 'Other Dictionary', enabled: false, allowSecondarySearches: false, definitionsCollapsible: 'not-collapsible', partsOfSpeechFilter: true, useDeinflections: true, styles: ''},
+                        ],
+                        anki: {cardFormats: []},
+                    },
+                },
+                {
+                    id: 'profile-1',
+                    options: {
+                        general: {mainDictionary: ''},
+                        dictionaries: [
+                            {name: 'Test Dictionary', alias: 'Test Dictionary', enabled: false, allowSecondarySearches: false, definitionsCollapsible: 'not-collapsible', partsOfSpeechFilter: true, useDeinflections: true, styles: 'old'},
+                        ],
+                        anki: {cardFormats: []},
+                    },
+                },
+            ],
+        }));
+
+        const profilesDictionarySettings = getProfilesDictionarySettings(options, 'Test Dictionary');
+        applyImportedDictionarySettings(options, /** @type {import('dictionary-importer').Summary} */ ({
+            title: 'Updated Dictionary',
+            revision: '2',
+            sequenced: true,
+            version: 3,
+            importDate: 0,
+            prefixWildcardsSupported: false,
+            styles: 'new',
+        }), profilesDictionarySettings);
+
+        expect(options.profiles[0].options.dictionaries[0]).toMatchObject({name: 'Updated Dictionary', alias: 'My Alias', styles: 'new'});
+        expect(options.profiles[1].options.dictionaries[0]).toMatchObject({name: 'Updated Dictionary', alias: 'Updated Dictionary', styles: 'new'});
+        expect(options.profiles[0].options.general.mainDictionary).toBe('Updated Dictionary');
+        expect(options.profiles[1].options.general.mainDictionary).toBe('Updated Dictionary');
+    });
+
+    test('applyImportedDictionarySettings enables new dictionaries for the selected settings profile', () => {
+        const options = /** @type {import('settings').Options} */ (/** @type {unknown} */ ({
+            version: 0,
+            profileCurrent: 0,
+            global: {
+                database: {
+                    prefixWildcardsSupported: false,
+                    maxHeadwordLength: 0,
+                    autoUpdateDictionariesOnStartup: false,
+                },
+                dataTransmissionConsentShown: false,
+            },
+            profiles: [
+                {
+                    id: 'profile-0',
+                    options: {
+                        general: {mainDictionary: ''},
+                        dictionaries: [],
+                        anki: {cardFormats: []},
+                    },
+                },
+                {
+                    id: 'profile-1',
+                    options: {
+                        general: {mainDictionary: ''},
+                        dictionaries: [],
+                        anki: {cardFormats: []},
+                    },
+                },
+            ],
+        }));
+
+        applyImportedDictionarySettings(options, /** @type {import('dictionary-importer').Summary} */ ({
+            title: 'Imported Dictionary',
+            revision: '1',
+            sequenced: false,
+            version: 3,
+            importDate: 0,
+            prefixWildcardsSupported: false,
+            styles: '',
+        }), /** @type {import('settings-controller').ProfilesDictionarySettings} */ ({}), 1);
+
+        expect(options.profiles[0].options.dictionaries[0]).toMatchObject({name: 'Imported Dictionary', enabled: false});
+        expect(options.profiles[1].options.dictionaries[0]).toMatchObject({name: 'Imported Dictionary', enabled: true});
+    });
+
+    test('updateDictionaryAnkiFieldTemplates rewrites matching dictionary field segments', () => {
+        const options = /** @type {import('settings').Options} */ (/** @type {unknown} */ ({
+            version: 0,
+            profileCurrent: 0,
+            global: {
+                database: {
+                    prefixWildcardsSupported: false,
+                    maxHeadwordLength: 0,
+                    autoUpdateDictionariesOnStartup: false,
+                },
+                dataTransmissionConsentShown: false,
+            },
+            profiles: [
+                {
+                    id: 'profile-0',
+                    options: {
+                        anki: {
+                            cardFormats: [
+                                {
+                                    fields: {
+                                        glossary: {value: '{{> single-glossary-test-dictionary}}'},
+                                        untouched: {value: '{{> single-glossary-other-dictionary}}'},
+                                    },
+                                },
+                            ],
+                        },
+                    },
+                },
+            ],
+        }));
+        const profilesDictionarySettings = /** @type {import('settings-controller').ProfilesDictionarySettings} */ ({
+            'profile-0': {
+                index: 0,
+                name: 'Test Dictionary',
+                alias: 'Test Dictionary',
+                enabled: true,
+                allowSecondarySearches: false,
+                definitionsCollapsible: 'not-collapsible',
+                partsOfSpeechFilter: true,
+                useDeinflections: true,
+                styles: '',
+            },
+        });
+
+        const modified = updateDictionaryAnkiFieldTemplates(options, profilesDictionarySettings, 'Updated Dictionary');
+
+        expect(modified).toBe(true);
+        expect(options.profiles[0].options.anki.cardFormats[0].fields.glossary.value).toBe('{{> single-glossary-updated-dictionary}}');
+        expect(options.profiles[0].options.anki.cardFormats[0].fields.untouched.value).toBe('{{> single-glossary-other-dictionary}}');
+    });
+});

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -706,14 +706,14 @@ function createOptionsUpdatedTestData1() {
             },
         ],
         profileCurrent: 0,
-        version: 76,
+        version: 77,
         global: {
             database: {
                 prefixWildcardsSupported: false,
                 maxHeadwordLength: 0,
+                autoUpdateDictionariesOnStartup: false,
             },
             dataTransmissionConsentShown: false,
-            dictionaryAutoUpdates: [],
         },
     };
 }
@@ -763,19 +763,21 @@ describe('OptionsUtil', () => {
         expect(partialsUpdated).toStrictEqual(partialsExpected);
     });
 
-    test('Version75And76MigrationsAddDictionaryOptions', async () => {
+    test('Version76And77MigrationsUpdateDictionaryOptions', async () => {
         const optionsUtil = new OptionsUtil();
         await optionsUtil.prepare();
 
         const options = /** @type {import('core').SafeAny} */ (createOptionsUpdatedTestData1());
-        options.version = 74;
-        delete options.global.dictionaryAutoUpdates;
+        options.version = 75;
         delete options.global.database.maxHeadwordLength;
+        delete options.global.database.autoUpdateDictionariesOnStartup;
+        options.global.dictionaryAutoUpdates = ['https://example.invalid/old-index.json'];
 
         const optionsUpdated = structuredClone(await optionsUtil.update(options));
-        expect(optionsUpdated.version).toBe(76);
-        expect(optionsUpdated.global.dictionaryAutoUpdates).toStrictEqual([]);
+        expect(optionsUpdated.version).toBe(77);
         expect(optionsUpdated.global.database.maxHeadwordLength).toBe(0);
+        expect(optionsUpdated.global.database.autoUpdateDictionariesOnStartup).toBe(false);
+        expect('dictionaryAutoUpdates' in optionsUpdated.global).toBe(false);
     });
 
     describe('Default', () => {

--- a/test/settings-dictionary-controller.test.js
+++ b/test/settings-dictionary-controller.test.js
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2023-2026  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* eslint-disable no-underscore-dangle, @typescript-eslint/unbound-method */
+
+import {describe, expect, vi} from 'vitest';
+import {DictionaryController} from '../ext/js/pages/settings/dictionary-controller.js';
+import {createDomTest} from './fixtures/dom-test.js';
+
+const test = createDomTest();
+
+/**
+ * @param {import('jsdom').DOMWindow} window
+ * @returns {{checkUpdatesButton: HTMLButtonElement, modalNode: HTMLDivElement}}
+ */
+function setupSettingsDom(window) {
+    window.document.body.innerHTML = `
+        <div id="dictionaries-modal-body"></div>
+        <div id="dictionary-list"><div class="dictionary-item-bottom"></div></div>
+        <input type="checkbox" id="all-dictionaries-enabled">
+        <button type="button" id="dictionary-check-updates" class="dictionary-database-mutating-input">Check for Updates</button>
+        <button type="button" id="dictionary-update-all" class="dictionary-database-mutating-input">Update All</button>
+    `;
+
+    const modalNode = window.document.createElement('div');
+    modalNode.innerHTML = '<strong id="dictionary-confirm-update-all-count"></strong>';
+    const checkUpdatesButton = /** @type {HTMLButtonElement} */ (window.document.querySelector('#dictionary-check-updates'));
+
+    return {checkUpdatesButton, modalNode};
+}
+
+/**
+ * @returns {import('dictionary-importer').Summary}
+ */
+function createDictionarySummary() {
+    return /** @type {import('dictionary-importer').Summary} */ ({
+        title: 'Dictionary',
+        revision: '1',
+        sequenced: true,
+        version: 3,
+        importDate: 0,
+        prefixWildcardsSupported: false,
+        styles: '',
+    });
+}
+
+/**
+ * @param {HTMLDivElement} modalNode
+ * @returns {DictionaryController}
+ */
+function createController(modalNode) {
+    const controller = new DictionaryController(
+        /** @type {import('../ext/js/pages/settings/settings-controller.js').SettingsController} */ (/** @type {unknown} */ ({
+            application: {
+                on: () => {},
+            },
+        })),
+        /** @type {import('../ext/js/pages/settings/modal-controller.js').ModalController} */ (/** @type {unknown} */ ({})),
+        /** @type {import('../ext/js/pages/settings/status-footer.js').StatusFooter} */ (/** @type {unknown} */ (null)),
+    );
+    controller._dictionaries = [createDictionarySummary()];
+    controller._updateAllDictionaryModal = /** @type {import('../ext/js/pages/settings/modal.js').Modal} */ (/** @type {unknown} */ ({
+        node: modalNode,
+        setVisible: vi.fn(),
+    }));
+    return controller;
+}
+
+describe('DictionaryController', () => {
+    test('getDictionaryUpdateTasks returns update tasks for dictionaries with available updates', async ({window}) => {
+        const {modalNode} = setupSettingsDom(window);
+        const controller = createController(modalNode);
+
+        controller._dictionaryEntries = /** @type {any} */ ([
+            {
+                dictionaryTitle: 'Dictionary A',
+                updateDownloadUrl: 'https://example.invalid/a.zip',
+                checkForUpdate: vi.fn(async () => true),
+            },
+            {
+                dictionaryTitle: 'Dictionary B',
+                updateDownloadUrl: null,
+                checkForUpdate: vi.fn(async () => false),
+            },
+            {
+                dictionaryTitle: 'Dictionary C',
+                updateDownloadUrl: 'https://example.invalid/c.zip',
+                checkForUpdate: vi.fn(async () => true),
+            },
+        ]);
+
+        const updateTasks = await controller._getDictionaryUpdateTasks();
+
+        expect(updateTasks).toStrictEqual([
+            {type: 'update', dictionaryTitle: 'Dictionary A', downloadUrl: 'https://example.invalid/a.zip'},
+            {type: 'update', dictionaryTitle: 'Dictionary C', downloadUrl: 'https://example.invalid/c.zip'},
+        ]);
+    });
+
+    test('update all opens a bulk confirmation modal with the discovered update count', async ({window}) => {
+        const {checkUpdatesButton, modalNode} = setupSettingsDom(window);
+        const controller = createController(modalNode);
+        controller._getDictionaryUpdateTasks = /** @type {any} */ (vi.fn(async () => [
+            {type: 'update', dictionaryTitle: 'Dictionary A', downloadUrl: 'https://example.invalid/a.zip'},
+            {type: 'update', dictionaryTitle: 'Dictionary C', downloadUrl: 'https://example.invalid/c.zip'},
+        ]));
+
+        await controller._updateAllDictionaries();
+
+        expect(checkUpdatesButton.textContent).toBe('2 updates');
+        expect(modalNode.querySelector('#dictionary-confirm-update-all-count')?.textContent).toBe('2 dictionaries');
+        expect(controller._pendingUpdateTasks).toStrictEqual([
+            {type: 'update', dictionaryTitle: 'Dictionary A', downloadUrl: 'https://example.invalid/a.zip'},
+            {type: 'update', dictionaryTitle: 'Dictionary C', downloadUrl: 'https://example.invalid/c.zip'},
+        ]);
+        expect(controller._updateAllDictionaryModal?.setVisible).toHaveBeenCalledWith(true);
+    });
+
+    test('bulk update confirmation enqueues the discovered update tasks', async ({window}) => {
+        const {modalNode} = setupSettingsDom(window);
+        const controller = createController(modalNode);
+        controller._pendingUpdateTasks = [
+            {type: 'update', dictionaryTitle: 'Dictionary A', downloadUrl: 'https://example.invalid/a.zip'},
+            {type: 'update', dictionaryTitle: 'Dictionary B', downloadUrl: 'https://example.invalid/b.zip'},
+        ];
+        controller._enqueueTask = vi.fn();
+        controller._hideUpdatesAvailableButton = vi.fn();
+
+        controller._onDictionaryConfirmUpdateAll(new window.MouseEvent('click'));
+
+        expect(controller._updateAllDictionaryModal?.setVisible).toHaveBeenCalledWith(false);
+        expect(controller._enqueueTask).toHaveBeenNthCalledWith(1, {type: 'update', dictionaryTitle: 'Dictionary A', downloadUrl: 'https://example.invalid/a.zip'});
+        expect(controller._enqueueTask).toHaveBeenNthCalledWith(2, {type: 'update', dictionaryTitle: 'Dictionary B', downloadUrl: 'https://example.invalid/b.zip'});
+        expect(controller._hideUpdatesAvailableButton).toHaveBeenNthCalledWith(1, 'Dictionary A');
+        expect(controller._hideUpdatesAvailableButton).toHaveBeenNthCalledWith(2, 'Dictionary B');
+        expect(controller._pendingUpdateTasks).toStrictEqual([]);
+    });
+});
+
+/* eslint-enable no-underscore-dangle, @typescript-eslint/unbound-method */

--- a/test/startup-dictionary-updater.test.js
+++ b/test/startup-dictionary-updater.test.js
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2023-2026  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {describe, expect, test, vi} from 'vitest';
+import {StartupDictionaryUpdater} from '../ext/js/background/startup-dictionary-updater.js';
+
+/**
+ * @param {string} title
+ * @returns {import('dictionary-importer').Summary}
+ */
+function createDictionarySummary(title) {
+    return /** @type {import('dictionary-importer').Summary} */ ({
+        title,
+        revision: '1',
+        sequenced: true,
+        version: 3,
+        importDate: 0,
+        prefixWildcardsSupported: false,
+        styles: '',
+    });
+}
+
+describe('StartupDictionaryUpdater', () => {
+    test('skips work when the feature is disabled', async () => {
+        const getDictionaryInfo = vi.fn(async () => /** @type {import('dictionary-importer').Summary[]} */ ([]));
+        const updater = new StartupDictionaryUpdater({
+            isEnabled: async () => false,
+            hasRunThisSession: async () => false,
+            markRunThisSession: async () => {},
+            getDictionaryInfo,
+            checkForUpdate: async () => null,
+            updateDictionary: async () => false,
+            onError: () => {},
+        });
+
+        expect(await updater.run()).toBe(0);
+        expect(getDictionaryInfo).not.toHaveBeenCalled();
+    });
+
+    test('updates dictionaries sequentially and continues after failures', async () => {
+        /** @type {string[]} */
+        const updatedTitles = [];
+        /** @type {{error: unknown, details: {dictionaryTitle: string, phase: 'check' | 'update'}}[]} */
+        const errors = [];
+        const markRunThisSession = vi.fn(async () => {});
+        const updater = new StartupDictionaryUpdater({
+            isEnabled: async () => true,
+            hasRunThisSession: async () => false,
+            markRunThisSession,
+            getDictionaryInfo: async () => [
+                createDictionarySummary('Dictionary A'),
+                createDictionarySummary('Dictionary B'),
+                createDictionarySummary('Dictionary C'),
+            ],
+            checkForUpdate: async ({title}) => {
+                if (title === 'Dictionary A') { return {downloadUrl: 'https://example.invalid/a.zip'}; }
+                if (title === 'Dictionary B') { return {downloadUrl: 'https://example.invalid/b.zip'}; }
+                return null;
+            },
+            updateDictionary: async (dictionaryTitle) => {
+                updatedTitles.push(dictionaryTitle);
+                if (dictionaryTitle === 'Dictionary B') {
+                    throw new Error('Update failed');
+                }
+                return true;
+            },
+            onError: (error, details) => {
+                errors.push({error, details});
+            },
+        });
+
+        expect(await updater.run()).toBe(1);
+        expect(markRunThisSession).toHaveBeenCalledTimes(1);
+        expect(updatedTitles).toStrictEqual(['Dictionary A', 'Dictionary B']);
+        expect(errors).toHaveLength(1);
+        expect(errors[0].details).toStrictEqual({dictionaryTitle: 'Dictionary B', phase: 'update'});
+    });
+});

--- a/types/ext/settings.d.ts
+++ b/types/ext/settings.d.ts
@@ -64,12 +64,12 @@ export type Options = {
 export type GlobalOptions = {
     database: GlobalDatabaseOptions;
     dataTransmissionConsentShown: boolean;
-    dictionaryAutoUpdates: string[];
 };
 
 export type GlobalDatabaseOptions = {
     prefixWildcardsSupported: boolean;
     maxHeadwordLength: number;
+    autoUpdateDictionariesOnStartup: boolean;
 };
 
 export type Profile = {


### PR DESCRIPTION
## Summary
- replace the unreleased per-dictionary hourly dictionary updater with a startup-only global auto-update toggle
- add an `Update All` flow to the dictionaries modal and route bulk updates through the existing per-dictionary queue
- share dictionary import/update settings preservation logic across the settings import flow and backend update flow
- add focused unit coverage for the new startup updater, shared dictionary update utilities, settings controller bulk update behavior, and updated backend helper behavior

## Testing
- `npx vitest run test/settings-dictionary-controller.test.js test/startup-dictionary-updater.test.js test/dictionary-update-util.test.js test/backend-dictionary-auto-update.test.js test/options-util.test.js`

## Notes
- A follow-up full lint/build pass in a clean worktree still depends on the generated ignored `ext/lib/*` bundle set being available locally.