### PR TITLE
Import MDX dictionaries directly

### DIFF
--- a/docs/development/mdx-import.md
+++ b/docs/development/mdx-import.md
@@ -1,12 +1,13 @@
 # Experimental MDX Import
 
-Manabitan’s experimental MDX flow now converts `.mdx` and companion `.mdd` files directly in the extension, then hands the generated Yomitan archive to the normal importer. Drag-and-drop and file-picker imports do not require an MDX-specific native helper or an MDX-specific `nativeMessaging` permission prompt.
+Manabitan’s experimental MDX flow now imports `.mdx` and companion `.mdd` files directly in the extension. Drag-and-drop and file-picker imports do not require an MDX-specific native helper or an MDX-specific `nativeMessaging` permission prompt.
 
 ## Runtime flow
 
-- [`mdx.js`](../../ext/js/comm/mdx.js) reads the selected `.mdx`/`.mdd` files, starts the browser worker, and keeps the existing `getVersion` / `getLocalVersion` / `convertDictionary` contract used by settings.
-- [`mdx-worker-main.js`](../../ext/js/dictionary/mdx-worker-main.js) runs conversion off the UI thread.
-- [`mdx-converter.js`](../../ext/js/dictionary/mdx/mdx-converter.js) parses MDX data, resolves `@@@LINK=` redirects, migrates HTML into structured content, rewrites asset/audio references, and packages a normal Yomitan archive.
+- [`dictionary-import-controller.js`](../../ext/js/pages/settings/dictionary-import-controller.js) groups `.mdx` / `.mdd` inputs, reports the existing settings-page upload progress, and sends raw MDX bytes to the dictionary worker without changing the UI flow.
+- [`dictionary-worker.js`](../../ext/js/dictionary/dictionary-worker.js) and [`dictionary-worker-handler.js`](../../ext/js/dictionary/dictionary-worker-handler.js) expose the direct `importMdxDictionary` worker action and keep MDX imports on the same import-session path as ZIP imports.
+- [`mdx-converter.js`](../../ext/js/dictionary/mdx/mdx-converter.js) parses MDX data, resolves `@@@LINK=` redirects, migrates HTML into structured content, rewrites asset/audio references, and materializes an in-memory dictionary file map for the importer.
+- [`dictionary-importer.js`](../../ext/js/dictionary/dictionary-importer.js) consumes either ZIP-backed archive entries or the in-memory MDX file map through the same import pipeline.
 - Vendored parser code under [`ext/js/dictionary/mdx/vendor/`](../../ext/js/dictionary/mdx/vendor/) is browser-adapted third-party code and intentionally kept out of the normal type/lint surface.
 
 ## What still lives in `dev/native/mdx-import/`
@@ -14,7 +15,7 @@ Manabitan’s experimental MDX flow now converts `.mdx` and companion `.mdd` fil
 - [`mdx_to_yomitan.py`](../../dev/native/mdx-import/mdx_to_yomitan.py) remains the reference Python implementation for parity checks and development experiments.
 - [`native_host.py`](../../dev/native/mdx-import/native_host.py) remains available as a non-runtime reference for the old native-host approach.
 
-Those files are no longer part of the extension’s normal MDX import path.
+Those files are no longer part of the extension’s normal MDX import path, and runtime MDX imports no longer go through a generated intermediate ZIP archive.
 
 ## Local testing
 
@@ -28,5 +29,5 @@ The Playwright coverage for this lives in [`integration.spec.js`](../../test/pla
 
 - `.mdd` files are optional unless the dictionary actually ships bundled media or images.
 - URL import still accepts a direct `.mdx` URL or a simple HTML directory listing that exposes one `.mdx` file plus matching `.mdd` links.
-- Unsupported, encrypted, or unhandled MDX variants should now fail with parser/converter errors instead of helper-install errors.
+- Unsupported, encrypted, or unhandled MDX variants should fail with parser/import errors instead of helper-install errors.
 - The browser path currently targets the same experimental compatibility band as the old helper flow; it is not meant as a blanket promise for every MDX variant in the wild.

--- a/ext/js/dictionary/dictionary-importer.js
+++ b/ext/js/dictionary/dictionary-importer.js
@@ -3192,21 +3192,38 @@ export class DictionaryImporter {
     }
 
     /**
-     * @template [T=unknown]
+     * @overload
      * @param {import('dictionary-importer').ImportFileEntry} entry
-     * @param {import('@zip.js/zip.js').Writer<T>|import('@zip.js/zip.js').WritableWriter} writer
-     * @returns {Promise<T>}
+     * @param {TextWriter} writer
+     * @returns {Promise<string>}
+     */
+    /**
+     * @overload
+     * @param {import('dictionary-importer').ImportFileEntry} entry
+     * @param {Uint8ArrayWriter} writer
+     * @returns {Promise<Uint8Array>}
+     */
+    /**
+     * @overload
+     * @param {import('dictionary-importer').ImportFileEntry} entry
+     * @param {BlobWriter} writer
+     * @returns {Promise<Blob>}
+     */
+    /**
+     * @param {import('dictionary-importer').ImportFileEntry} entry
+     * @param {import('@zip.js/zip.js').Writer<unknown>|import('@zip.js/zip.js').WritableWriter} writer
+     * @returns {Promise<unknown>}
      */
     async _getData(entry, writer) {
         if (entry instanceof MemoryImportFile) {
             if (writer instanceof TextWriter) {
-                return /** @type {T} */ (/** @type {unknown} */ (this._textDecoder.decode(entry.bytes)));
+                return this._textDecoder.decode(entry.bytes);
             }
             if (writer instanceof Uint8ArrayWriter) {
-                return /** @type {T} */ (/** @type {unknown} */ (new Uint8Array(entry.bytes)));
+                return new Uint8Array(entry.bytes);
             }
             if (writer instanceof BlobWriter) {
-                return /** @type {T} */ (/** @type {unknown} */ (new Blob([entry.bytes])));
+                return new Blob([entry.bytes]);
             }
             throw new Error(`Unsupported in-memory dictionary writer for ${entry.filename}`);
         }

--- a/ext/js/dictionary/dictionary-importer.js
+++ b/ext/js/dictionary/dictionary-importer.js
@@ -42,6 +42,7 @@ import {
 } from './zstd-term-content.js';
 import {decompress as zstdDecompress} from '../../lib/zstd-wasm.js';
 import {compareRevisions} from './dictionary-data-util.js';
+import {createMdxImportData} from './mdx/mdx-converter.js';
 import {consumeLastTermBankWasmParseProfile, parseTermBankWithWasmChunks} from './term-bank-wasm-parser.js';
 
 const BlobWriter = /** @type {typeof import('@zip.js/zip.js').BlobWriter} */ (/** @type {unknown} */ (BlobWriter0));
@@ -74,6 +75,19 @@ const STRUCTURED_CONTENT_MEDIA_LINK_PREFIX = 'media:';
 /** @type {import('dictionary-data').TermGlossary[]} */
 const EMPTY_TERM_GLOSSARY = [];
 Object.freeze(EMPTY_TERM_GLOSSARY);
+
+class MemoryImportFile {
+    /**
+     * @param {string} filename
+     * @param {Uint8Array} bytes
+     */
+    constructor(filename, bytes) {
+        /** @type {string} */
+        this.filename = filename;
+        /** @type {Uint8Array} */
+        this.bytes = bytes;
+    }
+}
 
 /**
  * @param {string} href
@@ -335,6 +349,78 @@ export class DictionaryImporter {
      * @returns {Promise<import('dictionary-importer').ImportResult>}
      */
     async importDictionary(dictionaryDatabase, archiveContent, details) {
+        return await this._importDictionaryFromSource(
+            dictionaryDatabase,
+            details,
+            async (recordPhaseTiming) => {
+                const tArchiveStart = Date.now();
+                try {
+                    const fileMap = await this._getFilesFromArchive(archiveContent);
+                    const index = await this._readAndValidateIndex(fileMap);
+                    recordPhaseTiming('archive-and-index', tArchiveStart, {
+                        ok: true,
+                        fileCount: fileMap.size,
+                        indexVersion: typeof index.version === 'number' ? index.version : null,
+                    });
+                    this._logImport(`archive+index ${Date.now() - tArchiveStart}ms files=${fileMap.size}`);
+                    return {fileMap, index};
+                } catch (error) {
+                    recordPhaseTiming('archive-and-index', tArchiveStart, {ok: false});
+                    throw error;
+                }
+            },
+        );
+    }
+
+    /**
+     * @param {import('./dictionary-database.js').DictionaryDatabase} dictionaryDatabase
+     * @param {{mdxFileName: string, mdxBytes: Uint8Array, mddFiles: Array<{name: string, bytes: Uint8Array}>, options?: {titleOverride?: string, descriptionOverride?: string, revision?: string, enableAudio?: boolean, includeAssets?: boolean, termBankSize?: number}}} mdxSource
+     * @param {import('dictionary-importer').ImportDetails} details
+     * @param {?((progress: {completed: number, total: number}) => void)} onPrepareProgress
+     * @returns {Promise<import('dictionary-importer').ImportResult>}
+     */
+    async importMdxDictionary(dictionaryDatabase, mdxSource, details, onPrepareProgress = null) {
+        return await this._importDictionaryFromSource(
+            dictionaryDatabase,
+            details,
+            async (recordPhaseTiming) => {
+                const tPrepareStart = Date.now();
+                try {
+                    const {files} = await createMdxImportData(
+                        mdxSource.mdxFileName,
+                        mdxSource.options ?? {},
+                        mdxSource.mdxBytes,
+                        mdxSource.mddFiles,
+                        ({completed, total}) => {
+                            if (typeof onPrepareProgress === 'function') {
+                                onPrepareProgress({completed, total});
+                            }
+                        },
+                    );
+                    const fileMap = this._createMemoryImportFileMap(files);
+                    const index = await this._readAndValidateIndex(fileMap);
+                    recordPhaseTiming('prepare-mdx', tPrepareStart, {
+                        ok: true,
+                        fileCount: fileMap.size,
+                        indexVersion: typeof index.version === 'number' ? index.version : null,
+                    });
+                    this._logImport(`prepare-mdx ${Date.now() - tPrepareStart}ms files=${fileMap.size}`);
+                    return {fileMap, index};
+                } catch (error) {
+                    recordPhaseTiming('prepare-mdx', tPrepareStart, {ok: false});
+                    throw error;
+                }
+            },
+        );
+    }
+
+    /**
+     * @param {import('./dictionary-database.js').DictionaryDatabase} dictionaryDatabase
+     * @param {import('dictionary-importer').ImportDetails} details
+     * @param {(recordPhaseTiming: (phase: string, startTime: number, phaseDetails?: Record<string, string|number|boolean|null>) => void) => Promise<{fileMap: import('dictionary-importer').ArchiveFileMap, index: import('dictionary-data').Index}>} loadSource
+     * @returns {Promise<import('dictionary-importer').ImportResult>}
+     */
+    async _importDictionaryFromSource(dictionaryDatabase, details, loadSource) {
         if (!dictionaryDatabase) {
             throw new Error('Invalid database');
         }
@@ -443,29 +529,19 @@ export class DictionaryImporter {
             },
         });
 
-        // Read archive
-        const tArchiveStart = Date.now();
         /** @type {import('dictionary-importer').ArchiveFileMap} */
         let fileMap;
         /** @type {import('dictionary-data').Index} */
         let index;
         try {
-            fileMap = await this._getFilesFromArchive(archiveContent);
-            index = await this._readAndValidateIndex(fileMap);
+            ({fileMap, index} = await loadSource(recordPhaseTiming));
         } catch (e) {
-            recordPhaseTiming('archive-and-index', tArchiveStart, {ok: false});
             return {
                 result: null,
                 errors: [toError(e)],
                 debug: {phaseTimings},
             };
         }
-        recordPhaseTiming('archive-and-index', tArchiveStart, {
-            ok: true,
-            fileCount: fileMap.size,
-            indexVersion: typeof index.version === 'number' ? index.version : null,
-        });
-        this._logImport(`archive+index ${Date.now() - tArchiveStart}ms files=${fileMap.size}`);
 
         const dictionaryTitle = index.title;
         const version = /** @type {import('dictionary-data').IndexVersion} */ (index.version);
@@ -538,7 +614,7 @@ export class DictionaryImporter {
         if (useTermArtifactFiles || typeof packedTermArtifactEntry !== 'undefined') {
             if (typeof packedTermArtifactEntry !== 'undefined') {
                 const tPackedArtifactReadStart = Date.now();
-                packedTermArtifactBytes = await this._getData(/** @type {import('@zip.js/zip.js').Entry} */ (packedTermArtifactEntry), new Uint8ArrayWriter());
+                packedTermArtifactBytes = await this._getData(/** @type {import('dictionary-importer').ImportFileEntry} */ (packedTermArtifactEntry), new Uint8ArrayWriter());
                 packedTermArtifactPreloadMs = Math.max(0, Date.now() - tPackedArtifactReadStart);
                 this._logImport(`packed term artifact preload ${packedTermArtifactPreloadMs}ms bytes=${packedTermArtifactBytes.byteLength}`);
             } else if (termArtifactFiles.length > 1) {
@@ -568,7 +644,7 @@ export class DictionaryImporter {
         }
         if (sharedGlossaryArtifactBytes === null && typeof sharedGlossaryArtifactEntry !== 'undefined') {
             const tSharedGlossaryReadStart = Date.now();
-            sharedGlossaryArtifactBytes = await this._getData(/** @type {import('@zip.js/zip.js').Entry} */ (sharedGlossaryArtifactEntry), new Uint8ArrayWriter());
+            sharedGlossaryArtifactBytes = await this._getData(/** @type {import('dictionary-importer').ImportFileEntry} */ (sharedGlossaryArtifactEntry), new Uint8ArrayWriter());
             sharedGlossaryArtifactPreloadMs = Math.max(0, Date.now() - tSharedGlossaryReadStart);
             this._logImport(`shared glossary artifact preload ${sharedGlossaryArtifactPreloadMs}ms bytes=${sharedGlossaryArtifactBytes.byteLength}`);
         }
@@ -597,7 +673,7 @@ export class DictionaryImporter {
             termArtifactManifest !== null &&
             termArtifactManifest.termBanksByArtifact.size > 0
         );
-        /** @type {Array<import('@zip.js/zip.js').Entry|{filename: string}>} */
+        /** @type {Array<import('dictionary-importer').ImportFileEntry|{filename: string}>} */
         const activeTermFiles = usePackedTermArtifact ?
             this._createPackedTermArtifactFiles(termArtifactManifest.termBanksByArtifact) :
             (useTermArtifactFiles ? termArtifactFiles : termFiles);
@@ -956,7 +1032,7 @@ export class DictionaryImporter {
                     streamedImportCompleted = true;
                 } else if (!this._disableTermBankWasmFastPath) {
                     try {
-                        const termFileEntry = /** @type {import('@zip.js/zip.js').Entry} */ (termFile);
+                        const termFileEntry = /** @type {import('dictionary-importer').ImportFileEntry} */ (termFile);
                         await this._readTermBankFileFast(
                             termFileEntry,
                             version,
@@ -1033,7 +1109,7 @@ export class DictionaryImporter {
                     updateStreamedTermFileProgress(streamedProgressStartIndex, 1, 1, true);
                 } else {
                     const tTermParseStart = Date.now();
-                    const termFileEntry = /** @type {import('@zip.js/zip.js').Entry} */ (termFile);
+                    const termFileEntry = /** @type {import('dictionary-importer').ImportFileEntry} */ (termFile);
                     const termReadResult = await this._readTermBankFile(
                         termFileEntry,
                         version,
@@ -1280,6 +1356,19 @@ export class DictionaryImporter {
     }
 
     /**
+     * @param {Map<string, Uint8Array>} files
+     * @returns {import('dictionary-importer').ArchiveFileMap}
+     */
+    _createMemoryImportFileMap(files) {
+        /** @type {import('dictionary-importer').ArchiveFileMap} */
+        const fileMap = new Map();
+        for (const [filename, bytes] of files) {
+            fileMap.set(filename, new MemoryImportFile(filename, bytes));
+        }
+        return fileMap;
+    }
+
+    /**
      * @param {import('dictionary-importer').ArchiveFileMap} fileMap
      * @returns {?string}
      */
@@ -1309,7 +1398,7 @@ export class DictionaryImporter {
             }
             throw new Error('No dictionary index found in archive');
         }
-        const indexFile2 = /** @type {import('@zip.js/zip.js').Entry} */ (indexFile);
+        const indexFile2 = /** @type {import('dictionary-importer').ImportFileEntry} */ (indexFile);
 
         const indexContent = await this._getData(indexFile2, new TextWriter());
         const index = /** @type {unknown} */ (parseJson(indexContent));
@@ -2238,7 +2327,7 @@ export class DictionaryImporter {
         let manifest;
         try {
             manifest = /** @type {{termBanks?: Array<{artifact?: unknown, packedOffset?: unknown, packedLength?: unknown, rows?: unknown}>, packedTermArtifact?: {file?: unknown}|null, sharedGlossaryArtifact?: {file?: unknown, packedOffset?: unknown, packedLength?: unknown, compression?: unknown, uncompressedBytes?: unknown}|null, termContentMode?: unknown}|null} */ (
-                parseJson(await this._getData(/** @type {import('@zip.js/zip.js').Entry} */ (manifestEntry), new TextWriter()))
+                parseJson(await this._getData(/** @type {import('dictionary-importer').ImportFileEntry} */ (manifestEntry), new TextWriter()))
             );
         } catch (_) {
             return null;
@@ -2315,7 +2404,7 @@ export class DictionaryImporter {
     }
 
     /**
-     * @param {import('@zip.js/zip.js').Entry[]} termArtifactFiles
+     * @param {import('dictionary-importer').ImportFileEntry[]} termArtifactFiles
      * @returns {Promise<Map<string, Uint8Array>>}
      */
     async _preloadTermArtifactFiles(termArtifactFiles) {
@@ -2353,7 +2442,7 @@ export class DictionaryImporter {
     /**
      * @template [TEntry=unknown]
      * @template [TResult=unknown]
-     * @param {import('@zip.js/zip.js').Entry[]} files
+     * @param {import('dictionary-importer').ImportFileEntry[]} files
      * @param {(entry: TEntry, dictionaryTitle: string) => TResult} convertEntry
      * @param {string} dictionaryTitle
      * @returns {Promise<TResult[]>}
@@ -2383,7 +2472,7 @@ export class DictionaryImporter {
     }
 
     /**
-     * @param {import('@zip.js/zip.js').Entry} termFile
+     * @param {import('dictionary-importer').ImportFileEntry} termFile
      * @param {import('dictionary-data').IndexVersion} version
      * @param {string} dictionaryTitle
      * @param {boolean} prefixWildcardsSupported
@@ -2462,7 +2551,7 @@ export class DictionaryImporter {
     }
 
     /**
-     * @param {import('@zip.js/zip.js').Entry} termFile
+     * @param {import('dictionary-importer').ImportFileEntry} termFile
      * @param {import('dictionary-data').IndexVersion} version
      * @param {string} dictionaryTitle
      * @param {boolean} prefixWildcardsSupported
@@ -2713,7 +2802,7 @@ export class DictionaryImporter {
     }
 
     /**
-     * @param {import('@zip.js/zip.js').Entry} termFile
+     * @param {import('dictionary-importer').ImportFileEntry} termFile
      * @param {string} dictionaryTitle
      * @param {boolean} prefixWildcardsSupported
      * @param {'baseline'|'raw-bytes'} termContentStorageMode
@@ -3104,14 +3193,27 @@ export class DictionaryImporter {
 
     /**
      * @template [T=unknown]
-     * @param {import('@zip.js/zip.js').Entry} entry
+     * @param {import('dictionary-importer').ImportFileEntry} entry
      * @param {import('@zip.js/zip.js').Writer<T>|import('@zip.js/zip.js').WritableWriter} writer
      * @returns {Promise<T>}
      */
     async _getData(entry, writer) {
-        if (typeof entry.getData === 'undefined') {
-            throw new Error(`Cannot read ${entry.filename}`);
+        if (entry instanceof MemoryImportFile) {
+            if (writer instanceof TextWriter) {
+                return /** @type {T} */ (/** @type {unknown} */ (this._textDecoder.decode(entry.bytes)));
+            }
+            if (writer instanceof Uint8ArrayWriter) {
+                return /** @type {T} */ (/** @type {unknown} */ (new Uint8Array(entry.bytes)));
+            }
+            if (writer instanceof BlobWriter) {
+                return /** @type {T} */ (/** @type {unknown} */ (new Blob([entry.bytes])));
+            }
+            throw new Error(`Unsupported in-memory dictionary writer for ${entry.filename}`);
         }
-        return await entry.getData(writer);
+        const archiveEntry = /** @type {import('@zip.js/zip.js').Entry} */ (entry);
+        if (typeof archiveEntry.getData === 'undefined') {
+            throw new Error(`Cannot read ${archiveEntry.filename}`);
+        }
+        return await archiveEntry.getData(writer);
     }
 }

--- a/ext/js/dictionary/dictionary-importer.js
+++ b/ext/js/dictionary/dictionary-importer.js
@@ -3194,19 +3194,19 @@ export class DictionaryImporter {
     /**
      * @overload
      * @param {import('dictionary-importer').ImportFileEntry} entry
-     * @param {TextWriter} writer
+     * @param {import('@zip.js/zip.js').TextWriter} writer
      * @returns {Promise<string>}
      */
     /**
      * @overload
      * @param {import('dictionary-importer').ImportFileEntry} entry
-     * @param {Uint8ArrayWriter} writer
+     * @param {import('@zip.js/zip.js').Uint8ArrayWriter} writer
      * @returns {Promise<Uint8Array>}
      */
     /**
      * @overload
      * @param {import('dictionary-importer').ImportFileEntry} entry
-     * @param {BlobWriter} writer
+     * @param {import('@zip.js/zip.js').BlobWriter} writer
      * @returns {Promise<Blob>}
      */
     /**

--- a/ext/js/dictionary/dictionary-worker-handler.js
+++ b/ext/js/dictionary/dictionary-worker-handler.js
@@ -22,6 +22,11 @@ import {DictionaryDatabase} from './dictionary-database.js';
 import {DictionaryImporter} from './dictionary-importer.js';
 import {DictionaryWorkerMediaLoader} from './dictionary-worker-media-loader.js';
 
+const MDX_IMPORT_VERSION = 1;
+const MDX_PREPARATION_PROGRESS_TOTAL = 1000;
+const MDX_PREPARATION_PROGRESS_START_INDEX = 450;
+const MDX_PREPARATION_PROGRESS_RANGE = MDX_PREPARATION_PROGRESS_TOTAL - MDX_PREPARATION_PROGRESS_START_INDEX;
+
 export class DictionaryWorkerHandler {
     constructor() {
         /** @type {DictionaryWorkerMediaLoader} */
@@ -46,11 +51,17 @@ export class DictionaryWorkerHandler {
             case 'importDictionary':
                 void this._onMessageWithProgress(params, this._importDictionary.bind(this));
                 break;
+            case 'importMdxDictionary':
+                void this._onMessageWithProgress(params, this._importMdxDictionary.bind(this));
+                break;
             case 'deleteDictionary':
                 void this._onMessageWithProgress(params, this._deleteDictionary.bind(this));
                 break;
             case 'getDictionaryCounts':
                 void this._onMessageWithProgress(params, this._getDictionaryCounts.bind(this));
+                break;
+            case 'getMdxVersion':
+                void this._onMessageWithProgress(params, this._getMdxVersion.bind(this));
                 break;
             case 'getImageDetails.response':
                 this._mediaLoader.handleMessage(params);
@@ -128,6 +139,57 @@ export class DictionaryWorkerHandler {
      * @returns {Promise<import('dictionary-worker').MessageCompleteResultSerialized>}
      */
     async _importDictionary({details, archiveContent}, onProgress) {
+        return await this._runImport(details, onProgress, async (dictionaryImporter, dictionaryDatabase) => (
+            await dictionaryImporter.importDictionary(dictionaryDatabase, archiveContent, details)
+        ));
+    }
+
+    /**
+     * @param {import('dictionary-worker-handler').ImportMdxDictionaryMessageParams} params
+     * @param {import('dictionary-worker-handler').OnProgressCallback} onProgress
+     * @returns {Promise<import('dictionary-worker').MessageCompleteResultSerialized>}
+     */
+    async _importMdxDictionary({details, mdxFileName, mdxBytes, mddFiles = [], options = {}}, onProgress) {
+        if (!(mdxBytes instanceof ArrayBuffer)) {
+            throw new Error('MDX import worker did not receive MDX bytes');
+        }
+        const mdxSource = {
+            mdxFileName: typeof mdxFileName === 'string' && mdxFileName.length > 0 ? mdxFileName : 'dictionary.mdx',
+            mdxBytes: new Uint8Array(mdxBytes),
+            mddFiles: Array.isArray(mddFiles) ? mddFiles
+                .filter((value) => typeof value === 'object' && value !== null && !Array.isArray(value))
+                .map((value) => {
+                    const name = typeof value.name === 'string' && value.name.length > 0 ? value.name : 'dictionary.mdd';
+                    const bytes = value.bytes instanceof ArrayBuffer ? new Uint8Array(value.bytes) : new Uint8Array(0);
+                    return {name, bytes};
+                }) : [],
+            options: (typeof options === 'object' && options !== null && !Array.isArray(options)) ? options : {},
+        };
+
+        return await this._runImport(details, onProgress, async (dictionaryImporter, dictionaryDatabase) => (
+            await dictionaryImporter.importMdxDictionary(
+                dictionaryDatabase,
+                mdxSource,
+                details,
+                ({completed, total}) => {
+                    const normalizedProgress = total > 0 ? Math.max(0, Math.min(1, completed / total)) : 1;
+                    onProgress({
+                        nextStep: false,
+                        index: MDX_PREPARATION_PROGRESS_START_INDEX + Math.round(MDX_PREPARATION_PROGRESS_RANGE * normalizedProgress),
+                        count: MDX_PREPARATION_PROGRESS_TOTAL,
+                    });
+                },
+            )
+        ));
+    }
+
+    /**
+     * @param {import('dictionary-importer').ImportDetails} details
+     * @param {import('dictionary-worker-handler').OnProgressCallback} onProgress
+     * @param {(dictionaryImporter: DictionaryImporter, dictionaryDatabase: DictionaryDatabase) => Promise<import('dictionary-importer').ImportResult>} importCallback
+     * @returns {Promise<import('dictionary-worker').MessageCompleteResultSerialized>}
+     */
+    async _runImport(details, onProgress, importCallback) {
         const useImportSession = (
             typeof details === 'object' &&
             details !== null &&
@@ -164,7 +226,7 @@ export class DictionaryWorkerHandler {
             /** @type {import('dictionary-importer').ImportDebug|null} */
             let importerDebug = null;
             try {
-                const importPayload = await dictionaryImporter.importDictionary(dictionaryDatabase, archiveContent, details);
+                const importPayload = await importCallback(dictionaryImporter, dictionaryDatabase);
                 ({result, errors} = importPayload);
                 importerDebug = (typeof importPayload === 'object' && importPayload !== null && !Array.isArray(importPayload)) ?
                     (/** @type {import('dictionary-importer').ImportDebug|null} */ (Reflect.get(importPayload, 'debug') ?? null)) :
@@ -197,6 +259,15 @@ export class DictionaryWorkerHandler {
                 await dictionaryDatabase.close();
             }
         }
+    }
+
+    /**
+     * @param {Record<string, never>} _params
+     * @param {import('dictionary-worker-handler').OnProgressCallback} _onProgress
+     * @returns {Promise<number>}
+     */
+    async _getMdxVersion(_params, _onProgress) {
+        return MDX_IMPORT_VERSION;
     }
 
     /**

--- a/ext/js/dictionary/dictionary-worker-handler.js
+++ b/ext/js/dictionary/dictionary-worker-handler.js
@@ -159,9 +159,12 @@ export class DictionaryWorkerHandler {
             mddFiles: Array.isArray(mddFiles) ?
                 mddFiles
                     .filter((value) => typeof value === 'object' && value !== null && !Array.isArray(value))
-                    .map((value) => {
+                    .map((value, index) => {
                         const name = typeof value.name === 'string' && value.name.length > 0 ? value.name : 'dictionary.mdd';
-                        const bytes = value.bytes instanceof ArrayBuffer ? new Uint8Array(value.bytes) : new Uint8Array(0);
+                        if (!(value.bytes instanceof ArrayBuffer)) {
+                            throw new Error(`MDX import worker did not receive valid bytes for MDD file at index ${index} (${name})`);
+                        }
+                        const bytes = new Uint8Array(value.bytes);
                         return {name, bytes};
                     }) :
                 [],

--- a/ext/js/dictionary/dictionary-worker-handler.js
+++ b/ext/js/dictionary/dictionary-worker-handler.js
@@ -156,13 +156,15 @@ export class DictionaryWorkerHandler {
         const mdxSource = {
             mdxFileName: typeof mdxFileName === 'string' && mdxFileName.length > 0 ? mdxFileName : 'dictionary.mdx',
             mdxBytes: new Uint8Array(mdxBytes),
-            mddFiles: Array.isArray(mddFiles) ? mddFiles
-                .filter((value) => typeof value === 'object' && value !== null && !Array.isArray(value))
-                .map((value) => {
-                    const name = typeof value.name === 'string' && value.name.length > 0 ? value.name : 'dictionary.mdd';
-                    const bytes = value.bytes instanceof ArrayBuffer ? new Uint8Array(value.bytes) : new Uint8Array(0);
-                    return {name, bytes};
-                }) : [],
+            mddFiles: Array.isArray(mddFiles) ?
+                mddFiles
+                    .filter((value) => typeof value === 'object' && value !== null && !Array.isArray(value))
+                    .map((value) => {
+                        const name = typeof value.name === 'string' && value.name.length > 0 ? value.name : 'dictionary.mdd';
+                        const bytes = value.bytes instanceof ArrayBuffer ? new Uint8Array(value.bytes) : new Uint8Array(0);
+                        return {name, bytes};
+                    }) :
+                [],
             options: (typeof options === 'object' && options !== null && !Array.isArray(options)) ? options : {},
         };
 

--- a/ext/js/dictionary/dictionary-worker.js
+++ b/ext/js/dictionary/dictionary-worker.js
@@ -50,6 +50,32 @@ export class DictionaryWorker {
     }
 
     /**
+     * @param {string} mdxFileName
+     * @param {ArrayBuffer} mdxBytes
+     * @param {Array<{name: string, bytes: ArrayBuffer}>} mddFiles
+     * @param {import('dictionary-importer').ImportDetails} details
+     * @param {?import('dictionary-worker').ImportProgressCallback} onProgress
+     * @param {{titleOverride?: string, descriptionOverride?: string, revision?: string, enableAudio?: boolean, includeAssets?: boolean, termBankSize?: number}} [options]
+     * @returns {Promise<import('dictionary-importer').ImportResult>}
+     */
+    importMdxDictionary(mdxFileName, mdxBytes, mddFiles, details, onProgress, options = {}) {
+        return this._invoke(
+            'importMdxDictionary',
+            {details, mdxFileName, mdxBytes, mddFiles, options},
+            [mdxBytes, ...mddFiles.map(({bytes}) => bytes)],
+            onProgress,
+            this._formatImportDictionaryResult.bind(this),
+        );
+    }
+
+    /**
+     * @returns {Promise<number>}
+     */
+    getMdxVersion() {
+        return this._invoke('getMdxVersion', {}, [], null, null);
+    }
+
+    /**
      * @param {string} dictionaryTitle
      * @param {?import('dictionary-worker').DeleteProgressCallback} onProgress
      * @returns {Promise<void>}

--- a/ext/js/dictionary/mdx/mdx-converter.js
+++ b/ext/js/dictionary/mdx/mdx-converter.js
@@ -777,10 +777,10 @@ function extractDescription(mdx, override) {
  * @param {{titleOverride?: string, descriptionOverride?: string, revision?: string, enableAudio?: boolean, includeAssets?: boolean, termBankSize?: number}} options
  * @param {Uint8Array} mdxBytes
  * @param {Array<{name: string, bytes: Uint8Array}>} mddSources
- * @param {?(details: {stage: 'convert'|'download', completed: number, total: number}) => void} onProgress
- * @returns {Promise<{archiveContent: ArrayBuffer, archiveFileName: string}>}
+ * @param {?(details: {stage: 'convert', completed: number, total: number}) => void} onProgress
+ * @returns {Promise<{files: Map<string, Uint8Array>, archiveFileName: string}>}
  */
-export async function convertMdxToArchive(fileName, options, mdxBytes, mddSources, onProgress = null) {
+export async function createMdxImportData(fileName, options, mdxBytes, mddSources, onProgress = null) {
     const {
         titleOverride = '',
         descriptionOverride = '',
@@ -806,9 +806,9 @@ export async function convertMdxToArchive(fileName, options, mdxBytes, mddSource
             onProgress({stage: 'convert', completed: 0, total: Math.max(1, mdx.keywordList.length)});
         }
 
-        const writer = new BlobWriter();
-        const zipWriter = new ZipWriter(writer, {level: 0});
         const encoder = new TextEncoder();
+        /** @type {Map<string, Uint8Array>} */
+        const files = new Map();
         /** @type {Array<[string, string]>} */
         const inlineStylesheets = [];
         let bankIndex = 1;
@@ -821,13 +821,13 @@ export async function convertMdxToArchive(fileName, options, mdxBytes, mddSource
         /**
          * @param {string} path
          * @param {unknown} value
-         * @returns {Promise<void>}
+         * @returns {void}
          */
-        const writeJson = async (path, value) => {
-            await zipWriter.add(path, new Uint8ArrayReader(encoder.encode(JSON.stringify(value))));
+        const writeJson = (path, value) => {
+            files.set(path, encoder.encode(JSON.stringify(value)));
         };
 
-        await writeJson('index.json', {
+        writeJson('index.json', {
             title,
             revision: revision.trim().length > 0 ? revision.trim() : 'mdx import',
             sequenced: true,
@@ -871,7 +871,7 @@ export async function convertMdxToArchive(fileName, options, mdxBytes, mddSource
             }
             sequence += 1;
             if (bank.length >= termBankSize) {
-                await writeJson(`term_bank_${bankIndex}.json`, bank);
+                writeJson(`term_bank_${bankIndex}.json`, bank);
                 bank = [];
                 bankIndex += 1;
             }
@@ -881,7 +881,7 @@ export async function convertMdxToArchive(fileName, options, mdxBytes, mddSource
         }
 
         if (bank.length > 0) {
-            await writeJson(`term_bank_${bankIndex}.json`, bank);
+            writeJson(`term_bank_${bankIndex}.json`, bank);
         }
 
         /** @type {Map<string, Uint8Array>} */
@@ -891,22 +891,56 @@ export async function convertMdxToArchive(fileName, options, mdxBytes, mddSource
         }
         const rootStylesheet = buildRootStylesheet(archiveAssets, assetPrefix, inlineStylesheets);
         if (rootStylesheet !== null) {
-            await zipWriter.add('styles.css', new Uint8ArrayReader(encoder.encode(rootStylesheet)));
+            files.set('styles.css', encoder.encode(rootStylesheet));
         }
         for (const [archivePath, bytes] of archiveAssets) {
-            await zipWriter.add(archivePath, new Uint8ArrayReader(bytes));
+            files.set(archivePath, bytes);
         }
-
-        await zipWriter.close();
-        const archiveContent = await (await writer.getData()).arrayBuffer();
         if (typeof onProgress === 'function') {
-            onProgress({stage: 'download', completed: archiveContent.byteLength, total: archiveContent.byteLength});
+            onProgress({stage: 'convert', completed: totalEntries, total: totalEntries});
         }
         return {
-            archiveContent,
+            files,
             archiveFileName: `${title}.zip`,
         };
     } finally {
         mdx.close();
     }
+}
+
+/**
+ * @param {string} fileName
+ * @param {{titleOverride?: string, descriptionOverride?: string, revision?: string, enableAudio?: boolean, includeAssets?: boolean, termBankSize?: number}} options
+ * @param {Uint8Array} mdxBytes
+ * @param {Array<{name: string, bytes: Uint8Array}>} mddSources
+ * @param {?(details: {stage: 'convert'|'download', completed: number, total: number}) => void} onProgress
+ * @returns {Promise<{archiveContent: ArrayBuffer, archiveFileName: string}>}
+ */
+export async function convertMdxToArchive(fileName, options, mdxBytes, mddSources, onProgress = null) {
+    const {files, archiveFileName} = await createMdxImportData(
+        fileName,
+        options,
+        mdxBytes,
+        mddSources,
+        (details) => {
+            if (typeof onProgress === 'function') {
+                onProgress(details);
+            }
+        },
+    );
+
+    const writer = new BlobWriter();
+    const zipWriter = new ZipWriter(writer, {level: 0});
+    for (const [archivePath, bytes] of files) {
+        await zipWriter.add(archivePath, new Uint8ArrayReader(bytes));
+    }
+    await zipWriter.close();
+    const archiveContent = await (await writer.getData()).arrayBuffer();
+    if (typeof onProgress === 'function') {
+        onProgress({stage: 'download', completed: archiveContent.byteLength, total: archiveContent.byteLength});
+    }
+    return {
+        archiveContent,
+        archiveFileName,
+    };
 }

--- a/ext/js/pages/settings/dictionary-import-controller.js
+++ b/ext/js/pages/settings/dictionary-import-controller.js
@@ -2358,17 +2358,28 @@ export class DictionaryImportController {
             importStartTime,
             localPhaseTimings,
             recordLocalPhase,
-            async () => await dictionaryWorker.importMdxDictionary(
-                source.mdxFile.name,
-                new Uint8Array(mdxBytes).buffer,
-                mddFiles.map(({name, bytes}) => ({name, bytes: new Uint8Array(bytes).buffer})),
-                {
-                    ...importDetails,
-                    ...(useImportSession ? {useImportSession: true, finalizeImportSession} : {}),
-                },
-                onProgress,
-                {enableAudio: false},
-            ),
+            async () => {
+                const mdxBytesView = (mdxBytes instanceof Uint8Array ? mdxBytes : new Uint8Array(mdxBytes));
+                const mdxBytesCopyBuffer = mdxBytesView.slice().buffer;
+
+                const mddFilesCopy = mddFiles.map(({name, bytes}) => {
+                    const bytesView = (bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes));
+                    const bytesCopyBuffer = bytesView.slice().buffer;
+                    return {name, bytes: bytesCopyBuffer};
+                });
+
+                return await dictionaryWorker.importMdxDictionary(
+                    source.mdxFile.name,
+                    mdxBytesCopyBuffer,
+                    mddFilesCopy,
+                    {
+                        ...importDetails,
+                        ...(useImportSession ? {useImportSession: true, finalizeImportSession} : {}),
+                    },
+                    onProgress,
+                    {enableAudio: false},
+                );
+            },
         );
     }
 

--- a/ext/js/pages/settings/dictionary-import-controller.js
+++ b/ext/js/pages/settings/dictionary-import-controller.js
@@ -23,7 +23,6 @@ import {log} from '../../core/log.js';
 import {safePerformance} from '../../core/safe-performance.js';
 import {toError} from '../../core/to-error.js';
 import {getKebabCase} from '../../data/anki-template-util.js';
-import {Mdx} from '../../comm/mdx.js';
 import {DictionaryWorker} from '../../dictionary/dictionary-worker.js';
 import {querySelectorNotNull} from '../../dom/query-selector.js';
 import {DictionaryController} from './dictionary-controller.js';
@@ -31,6 +30,7 @@ import {DictionaryController} from './dictionary-controller.js';
 const OPFS_REQUIRED_USER_MESSAGE = 'Manabitan requires OPFS storage support. Update to Chrome/Edge 120+ or Firefox 115+ and reload the extension.';
 const RECOMMENDED_DICTIONARY_CATEGORIES = ['terms', 'kanji', 'frequency', 'grammar', 'pronunciation'];
 const MDX_CONVERSION_PROGRESS_TOTAL = 1000;
+const MDX_UPLOAD_PROGRESS_RATIO = 0.45;
 const DUPLICATE_IMPORT_SKIP_ERROR_PATTERN = /^Dictionary .+ is already imported, skipped it\.$/;
 
 /**
@@ -405,8 +405,6 @@ export class DictionaryImportController {
         this._recommendedDictionariesPrimed = false;
         /** @type {DictionaryImportSource[]} */
         this._pendingImportSources = [];
-        /** @type {Mdx} */
-        this._mdx = new Mdx();
         /** @type {(event: MouseEvent) => void} */
         this._onDocumentClickCaptureBind = this._onDocumentClickCapture.bind(this);
         /** @type {(event: Event) => void} */
@@ -505,7 +503,6 @@ export class DictionaryImportController {
             this._sessionDictionaryWorker.destroy();
             this._sessionDictionaryWorker = null;
         }
-        this._mdx.disconnect();
     }
 
     /**
@@ -1512,7 +1509,19 @@ export class DictionaryImportController {
      * @returns {Promise<void>}
      */
     async _ensureMdxImportReady() {
-        await this._mdx.getVersion();
+        await this._getMdxVersion();
+    }
+
+    /**
+     * @returns {Promise<number>}
+     */
+    async _getMdxVersion() {
+        const dictionaryWorker = new DictionaryWorker({reuseWorker: false});
+        try {
+            return await dictionaryWorker.getMdxVersion();
+        } finally {
+            dictionaryWorker.destroy();
+        }
     }
 
     /**
@@ -1524,13 +1533,13 @@ export class DictionaryImportController {
         let progress = 0;
         switch (stage) {
             case 'upload':
-                progress = (total > 0 ? completed / total : 0) * 0.45;
+                progress = (total > 0 ? completed / total : 0) * MDX_UPLOAD_PROGRESS_RATIO;
                 break;
             case 'convert':
-                progress = 0.55;
+                progress = MDX_UPLOAD_PROGRESS_RATIO + ((total > 0 ? completed / total : 1) * (1 - MDX_UPLOAD_PROGRESS_RATIO));
                 break;
             case 'download':
-                progress = 0.55 + ((total > 0 ? completed / total : 0) * 0.45);
+                progress = 1;
                 break;
         }
         onProgress({
@@ -2262,6 +2271,42 @@ export class DictionaryImportController {
 
     /**
      * @param {MdxImportSource} source
+     * @param {import('dictionary-worker').ImportProgressCallback} onProgress
+     * @returns {Promise<{mdxBytes: ArrayBuffer, mddFiles: Array<{name: string, bytes: ArrayBuffer}>, totalBytes: number}>}
+     */
+    async _readMdxImportSourceBytes(source, onProgress) {
+        const uploadFiles = [source.mdxFile, ...source.mddFiles];
+        const totalUploadBytes = uploadFiles.reduce((sum, file) => sum + file.size, 0);
+        let uploadedBytes = 0;
+        /**
+         * @param {File} file
+         * @returns {Promise<ArrayBuffer>}
+         */
+        const readFileWithProgress = async (file) => {
+            const buffer = await file.arrayBuffer();
+            uploadedBytes += file.size;
+            this._reportMdxConversionProgress(onProgress, {
+                stage: 'upload',
+                completed: uploadedBytes,
+                total: totalUploadBytes,
+            });
+            return buffer;
+        };
+
+        const mdxBytes = await readFileWithProgress(source.mdxFile);
+        /** @type {Array<{name: string, bytes: ArrayBuffer}>} */
+        const mddFiles = [];
+        for (const file of source.mddFiles) {
+            mddFiles.push({
+                name: file.name,
+                bytes: await readFileWithProgress(file),
+            });
+        }
+        return {mdxBytes, mddFiles, totalBytes: totalUploadBytes};
+    }
+
+    /**
+     * @param {MdxImportSource} source
      * @param {import('settings-controller').ProfilesDictionarySettings} profilesDictionarySettings
      * @param {import('dictionary-importer').ImportDetails} importDetails
      * @param {DictionaryWorker} dictionaryWorker
@@ -2287,7 +2332,7 @@ export class DictionaryImportController {
             log.log(`[ImportTiming] [${sourceTitle}] phase ${phase} ${formatDurationMs(elapsedMs)} details=${JSON.stringify(details)}`);
         };
 
-        log.log(`[ImportTiming] [${sourceTitle}] starting MDX conversion`);
+        log.log(`[ImportTiming] [${sourceTitle}] starting MDX import`);
         reportDiagnostics('dictionary-import-mdx-begin', {
             dictionaryTitle: sourceTitle,
             mddCount: source.mddFiles.length,
@@ -2297,34 +2342,33 @@ export class DictionaryImportController {
         });
 
         onProgress({nextStep: true, index: 0, count: 0});
-        const convertStartTime = safePerformance.now();
-        const {archiveContent, archiveFileName} = await this._mdx.convertDictionary(
-            {
-                mdxFile: source.mdxFile,
-                mddFiles: source.mddFiles,
-                enableAudio: false,
-            },
-            this._reportMdxConversionProgress.bind(this, onProgress),
-        );
-        const convertEndTime = safePerformance.now();
-        recordLocalPhase('convert-mdx', convertStartTime, convertEndTime, {
-            archiveFileName,
+        const readStartTime = safePerformance.now();
+        const {mdxBytes, mddFiles, totalBytes} = await this._readMdxImportSourceBytes(source, onProgress);
+        const readEndTime = safePerformance.now();
+        recordLocalPhase('read-mdx-source', readStartTime, readEndTime, {
             mddCount: source.mddFiles.length,
-            archiveSizeBytes: archiveContent.byteLength,
+            sizeBytes: totalBytes,
         });
 
-        return await this._importDictionaryArchiveContent(
-            archiveFileName,
-            archiveContent,
+        return await this._importDictionaryWithWorkerInvocation(
+            sourceTitle,
             profilesDictionarySettings,
-            importDetails,
-            dictionaryWorker,
             useImportSession,
             finalizeImportSession,
-            onProgress,
             importStartTime,
             localPhaseTimings,
             recordLocalPhase,
+            async () => await dictionaryWorker.importMdxDictionary(
+                source.mdxFile.name,
+                new Uint8Array(mdxBytes).buffer,
+                mddFiles.map(({name, bytes}) => ({name, bytes: new Uint8Array(bytes).buffer})),
+                {
+                    ...importDetails,
+                    ...(useImportSession ? {useImportSession: true, finalizeImportSession} : {}),
+                },
+                onProgress,
+                {enableAudio: false},
+            ),
         );
     }
 
@@ -2402,23 +2446,44 @@ export class DictionaryImportController {
      */
     async _importDictionaryArchiveContent(dictionaryTitle, archiveContent, profilesDictionarySettings, importDetails, dictionaryWorker, useImportSession, finalizeImportSession, onProgress, importStartTime, localPhaseTimings, recordLocalPhase) {
         const archiveContentBytes = new Uint8Array(archiveContent);
+        return await this._importDictionaryWithWorkerInvocation(
+            dictionaryTitle,
+            profilesDictionarySettings,
+            useImportSession,
+            finalizeImportSession,
+            importStartTime,
+            localPhaseTimings,
+            recordLocalPhase,
+            async () => await dictionaryWorker.importDictionary(
+                new Uint8Array(archiveContentBytes).buffer,
+                {
+                    ...importDetails,
+                    ...(useImportSession ? {useImportSession: true, finalizeImportSession} : {}),
+                },
+                onProgress,
+            ),
+        );
+    }
+
+    /**
+     * @param {string} dictionaryTitle
+     * @param {import('settings-controller').ProfilesDictionarySettings} profilesDictionarySettings
+     * @param {boolean} useImportSession
+     * @param {boolean} finalizeImportSession
+     * @param {number} importStartTime
+     * @param {Array<{phase: string, elapsedMs: number, details?: Record<string, string|number|boolean|null>}>} localPhaseTimings
+     * @param {(phase: string, startTime: number, endTime: number, details?: Record<string, string|number|boolean|null>) => void} recordLocalPhase
+     * @param {() => Promise<import('dictionary-importer').ImportResult & {debug?: {usesFallbackStorage?: boolean, openStorageDiagnostics?: unknown, useImportSession?: boolean, finalizeImportSession?: boolean, importerDebug?: {phaseTimings?: Array<{phase: string, elapsedMs: number, details?: Record<string, string|number|boolean|null>}>|null}|null}}>} invokeWorkerImport
+     * @returns {Promise<Error[] | undefined>}
+     */
+    async _importDictionaryWithWorkerInvocation(dictionaryTitle, profilesDictionarySettings, useImportSession, finalizeImportSession, importStartTime, localPhaseTimings, recordLocalPhase, invokeWorkerImport) {
         const workerImportStartTime = safePerformance.now();
         /** @type {import('dictionary-importer').ImportResult & {debug?: {usesFallbackStorage?: boolean, openStorageDiagnostics?: unknown, useImportSession?: boolean, finalizeImportSession?: boolean, importerDebug?: {phaseTimings?: Array<{phase: string, elapsedMs: number, details?: Record<string, string|number|boolean|null>}>|null}|null}}} */
         let importResult;
         const maxImportAttempts = 6;
         for (let attempt = 1; ; ++attempt) {
             try {
-                const archiveContentAttempt = new Uint8Array(archiveContentBytes).buffer;
-                importResult = /** @type {import('dictionary-importer').ImportResult & {debug?: {usesFallbackStorage?: boolean, openStorageDiagnostics?: unknown, useImportSession?: boolean, finalizeImportSession?: boolean, importerDebug?: {phaseTimings?: Array<{phase: string, elapsedMs: number, details?: Record<string, string|number|boolean|null>}>|null}|null}}} */ (
-                    await dictionaryWorker.importDictionary(
-                        archiveContentAttempt,
-                        {
-                            ...importDetails,
-                            ...(useImportSession ? {useImportSession: true, finalizeImportSession} : {}),
-                        },
-                        onProgress,
-                    )
-                );
+                importResult = await invokeWorkerImport();
             } catch (error) {
                 const message = (error instanceof Error) ? error.message : String(error);
                 const failureClass = classifyImportOpenFailure(message);

--- a/test/dictionary-import-controller.test.js
+++ b/test/dictionary-import-controller.test.js
@@ -115,7 +115,11 @@ function createLanguageSelect(document, value) {
  * @returns {File}
  */
 function createFile(name) {
-    return new File(['test'], name);
+    const file = new File(['test'], name);
+    if (typeof file.arrayBuffer !== 'function') {
+        Reflect.set(file, 'arrayBuffer', async () => new TextEncoder().encode('test').buffer);
+    }
+    return file;
 }
 
 /**
@@ -351,26 +355,22 @@ describe('MDX import readiness', () => {
 
     test('checks MDX converter availability through the browser client', async () => {
         const controller = createControllerForInternalTests();
-        const getVersion = vi.fn().mockResolvedValue(2);
+        const getMdxVersion = vi.fn().mockResolvedValue(2);
 
-        Reflect.set(controller, '_mdx', {
-            getVersion,
-        });
+        Reflect.set(controller, '_getMdxVersion', getMdxVersion);
 
         await expect(ensureMdxImportReady.call(controller)).resolves.toBeUndefined();
-        expect(getVersion).toHaveBeenCalledTimes(1);
+        expect(getMdxVersion).toHaveBeenCalledTimes(1);
     });
 
     test('surfaces browser-side converter readiness errors unchanged', async () => {
         const controller = createControllerForInternalTests();
-        const getVersion = vi.fn().mockRejectedValue(new Error('MDX worker bootstrap failed'));
+        const getMdxVersion = vi.fn().mockRejectedValue(new Error('MDX worker bootstrap failed'));
 
-        Reflect.set(controller, '_mdx', {
-            getVersion,
-        });
+        Reflect.set(controller, '_getMdxVersion', getMdxVersion);
 
         await expect(ensureMdxImportReady.call(controller)).rejects.toThrow('MDX worker bootstrap failed');
-        expect(getVersion).toHaveBeenCalledTimes(1);
+        expect(getMdxVersion).toHaveBeenCalledTimes(1);
     });
 });
 
@@ -817,19 +817,14 @@ describe('MDX import flow integration', () => {
         expect(triggerStorageChanged).toHaveBeenCalledTimes(1);
     });
 
-    test('converts MDX sources with default options, reports progress, and hands the archive to the importer', async () => {
+    test('imports MDX sources through the direct worker path with upload progress and session flags', async () => {
         const controller = createControllerForInternalTests();
-        const archiveContent = new Uint8Array([1, 2, 3, 4]).buffer;
-        const importArchiveContent = vi.fn().mockResolvedValue(void 0);
-        const convertDictionary = vi.fn(async (_details, onProgress) => {
-            onProgress({stage: 'upload', completed: 5, total: 10});
-            onProgress({stage: 'convert', completed: 0, total: 0});
-            onProgress({stage: 'download', completed: 10, total: 10});
-            return {archiveContent, archiveFileName: 'alpha-converted.zip'};
+        const importDictionaryWithWorkerInvocation = vi.fn(async (...args) => {
+            const invokeWorkerImport = /** @type {() => Promise<unknown>} */ (args[7]);
+            await invokeWorkerImport();
+            return [];
         });
-
-        Reflect.set(controller, '_mdx', {convertDictionary});
-        Reflect.set(controller, '_importDictionaryArchiveContent', importArchiveContent);
+        Reflect.set(controller, '_importDictionaryWithWorkerInvocation', importDictionaryWithWorkerInvocation);
 
         /** @type {{type: 'mdx', mdxFile: File, mddFiles: File[]}} */
         const source = {type: 'mdx', mdxFile: createFile('Alpha.mdx'), mddFiles: [createFile('Alpha.mdd'), createFile('Alpha.1.mdd')]};
@@ -838,31 +833,44 @@ describe('MDX import flow integration', () => {
             yomitanVersion: '1.2.3.4',
         }));
         const onProgress = vi.fn();
+        const dictionaryWorker = {
+            importMdxDictionary: vi.fn().mockResolvedValue({
+                result: null,
+                errors: [],
+                debug: {importerDebug: {phaseTimings: []}},
+            }),
+        };
 
-        await importDictionaryFromMdx.call(controller, source, null, importDetails, {importDictionary: vi.fn()}, true, false, onProgress);
+        await importDictionaryFromMdx.call(controller, source, null, importDetails, dictionaryWorker, true, false, onProgress);
 
-        expect(convertDictionary).toHaveBeenCalledWith({
-            mdxFile: source.mdxFile,
-            mddFiles: source.mddFiles,
-            enableAudio: false,
-        }, expect.any(Function));
         expect(onProgress.mock.calls.map(([value]) => value)).toContainEqual({nextStep: true, index: 0, count: 0});
-        expect(onProgress.mock.calls.map(([value]) => value)).toContainEqual({nextStep: false, index: 225, count: 1000});
-        expect(onProgress.mock.calls.map(([value]) => value)).toContainEqual({nextStep: false, index: 550, count: 1000});
-        expect(onProgress.mock.calls.map(([value]) => value)).toContainEqual({nextStep: false, index: 1000, count: 1000});
-        expect(importArchiveContent).toHaveBeenCalledWith(
-            'alpha-converted.zip',
-            archiveContent,
+        expect(onProgress.mock.calls.map(([value]) => value)).toContainEqual({nextStep: false, index: 150, count: 1000});
+        expect(onProgress.mock.calls.map(([value]) => value)).toContainEqual({nextStep: false, index: 300, count: 1000});
+        expect(onProgress.mock.calls.map(([value]) => value)).toContainEqual({nextStep: false, index: 450, count: 1000});
+        expect(importDictionaryWithWorkerInvocation).toHaveBeenCalledWith(
+            'Alpha.mdx',
             null,
-            importDetails,
-            {importDictionary: expect.any(Function)},
             true,
             false,
-            onProgress,
             expect.any(Number),
             expect.any(Array),
             expect.any(Function),
+            expect.any(Function),
         );
+        expect(dictionaryWorker.importMdxDictionary).toHaveBeenCalledTimes(1);
+        const [mdxFileName, mdxBytes, mddFiles, workerImportDetails, workerOnProgress, options] = dictionaryWorker.importMdxDictionary.mock.calls[0];
+        expect(mdxFileName).toBe('Alpha.mdx');
+        expect(new Uint8Array(/** @type {ArrayBuffer} */ (mdxBytes))).toStrictEqual(new TextEncoder().encode('test'));
+        expect(mddFiles).toHaveLength(2);
+        expect(mddFiles.map((/** @type {{name: string}} */ value) => value.name)).toStrictEqual(['Alpha.mdd', 'Alpha.1.mdd']);
+        expect(workerImportDetails).toStrictEqual({
+            prefixWildcardsSupported: true,
+            yomitanVersion: '1.2.3.4',
+            useImportSession: true,
+            finalizeImportSession: false,
+        });
+        expect(workerOnProgress).toBe(onProgress);
+        expect(options).toStrictEqual({enableAudio: false});
     });
 
     test('defers database-updated notifications until the import session is finalized', async () => {
@@ -921,27 +929,25 @@ describe('MDX import flow integration', () => {
         expect(shownErrors?.[1]?.message).toBe('Dictionary may not have been imported properly: 1 error reported.');
     });
 
-    test('surfaces MDX conversion failures without attempting a worker import', async () => {
+    test('surfaces direct MDX worker failures unchanged', async () => {
         const controller = createControllerForInternalTests();
         const conversionError = new Error('Unsupported MDX variant');
-        const importArchiveContent = vi.fn();
-
-        Reflect.set(controller, '_mdx', {
-            convertDictionary: vi.fn().mockRejectedValue(conversionError),
-        });
-        Reflect.set(controller, '_importDictionaryArchiveContent', importArchiveContent);
+        Reflect.set(controller, '_importDictionaryWithWorkerInvocation', vi.fn(async (...args) => {
+            const invokeWorkerImport = /** @type {() => Promise<unknown>} */ (args[7]);
+            await invokeWorkerImport();
+            return [];
+        }));
 
         await expect(importDictionaryFromMdx.call(
             controller,
             {type: 'mdx', mdxFile: createFile('Broken.mdx'), mddFiles: []},
             null,
             /** @type {import('dictionary-importer').ImportDetails} */ (/** @type {unknown} */ ({yomitanVersion: '1.2.3.4'})),
-            {importDictionary: vi.fn()},
+            {importMdxDictionary: vi.fn().mockRejectedValue(conversionError)},
             true,
             true,
             vi.fn(),
         )).rejects.toThrow('Unsupported MDX variant');
-        expect(importArchiveContent).not.toHaveBeenCalled();
     });
 
     test('closes the import modal and starts importing selected sources with initial errors', () => {

--- a/test/mdx-client.test.js
+++ b/test/mdx-client.test.js
@@ -15,24 +15,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import {File as NodeFile} from 'node:buffer';
 import {afterEach, describe, expect, test, vi} from 'vitest';
-import {Mdx} from '../ext/js/comm/mdx.js';
-
-/**
- * @typedef {{stage: 'upload'|'convert'|'download', completed: number, total: number}} MdxProgressEvent
- */
-
-/**
- * @param {string} name
- * @param {Uint8Array} bytes
- * @returns {File}
- */
-function createFile(name, bytes) {
-    const file = new NodeFile([bytes], name, {type: 'application/octet-stream'});
-    Reflect.set(file, 'webkitRelativePath', '');
-    return /** @type {File} */ (/** @type {unknown} */ (file));
-}
+import {DictionaryWorker} from '../ext/js/dictionary/dictionary-worker.js';
 
 /**
  * @param {number} length
@@ -57,22 +41,37 @@ class FakeWorker {
         this.options = options;
         this.postMessage = vi.fn();
         this.terminate = vi.fn();
-        /** @type {{message: Array<(event: MessageEvent) => void>, error: Array<(event: ErrorEvent) => void>}} */
+        /** @type {{message: Array<(event: MessageEvent) => void>, error: Array<(event: ErrorEvent) => void>, messageerror: Array<(event: MessageEvent) => void>}} */
         this._listeners = {
             message: [],
             error: [],
+            messageerror: [],
         };
     }
 
     /**
-     * @param {'message'|'error'} type
+     * @param {'message'|'error'|'messageerror'} type
      * @param {(event: MessageEvent|ErrorEvent) => void} listener
      */
     addEventListener(type, listener) {
         if (type === 'message') {
             this._listeners.message.push(/** @type {(event: MessageEvent) => void} */ (listener));
-        } else {
+        } else if (type === 'error') {
             this._listeners.error.push(/** @type {(event: ErrorEvent) => void} */ (listener));
+        } else {
+            this._listeners.messageerror.push(/** @type {(event: MessageEvent) => void} */ (listener));
+        }
+    }
+
+    /**
+     * @param {'message'|'error'|'messageerror'} type
+     * @param {(event: MessageEvent|ErrorEvent) => void} listener
+     */
+    removeEventListener(type, listener) {
+        const listeners = this._listeners[type];
+        const index = /** @type {unknown[]} */ (listeners).indexOf(listener);
+        if (index >= 0) {
+            listeners.splice(index, 1);
         }
     }
 
@@ -100,16 +99,8 @@ afterEach(() => {
     vi.unstubAllGlobals();
 });
 
-describe('Mdx browser worker integration', () => {
-    test('normalizes unsupported variant errors with actionable guidance', () => {
-        const mdx = new Mdx();
-        const error = mdx._normalizeError('MDX variant uses unsupported xxHash-backed LZO blocks');
-
-        expect(error.message).toContain('unsupported compression, encryption, or format variant');
-        expect(error.message).toContain('Worker detail: MDX variant uses unsupported xxHash-backed LZO blocks');
-    });
-
-    test('converts MDX files through the worker and reports upload and worker progress', async () => {
+describe('DictionaryWorker MDX import integration', () => {
+    test('imports MDX bytes through the dictionary worker and forwards parser progress', async () => {
         /** @type {FakeWorker[]} */
         const workerInstances = [];
         vi.stubGlobal('Worker', vi.fn((url, options) => {
@@ -118,23 +109,25 @@ describe('Mdx browser worker integration', () => {
             return worker;
         }));
 
-        const mdx = new Mdx();
-        const mdxFile = createFile('fixture.mdx', createBytes(12, 11));
-        const mddFiles = [createFile('fixture.mdd', createBytes(8, 47))];
-        /** @type {MdxProgressEvent[]} */
+        const dictionaryWorker = new DictionaryWorker();
+        /** @type {import('dictionary-importer').ProgressData[]} */
         const progressEvents = [];
+        const mdxBytes = createBytes(12, 11).buffer;
+        const mddBytes = createBytes(8, 47).buffer;
 
-        const invocationPromise = mdx.convertDictionary(
+        const invocationPromise = dictionaryWorker.importMdxDictionary(
+            'fixture.mdx',
+            mdxBytes,
+            [{name: 'fixture.mdd', bytes: mddBytes}],
+            {prefixWildcardsSupported: true, yomitanVersion: '1.2.3.4'},
+            (details) => {
+                progressEvents.push(details);
+            },
             {
-                mdxFile,
-                mddFiles,
                 titleOverride: 'Fixture',
                 descriptionOverride: 'Fixture description',
                 revision: '2026.03.18',
                 enableAudio: true,
-            },
-            (details) => {
-                progressEvents.push(details);
             },
         );
 
@@ -143,61 +136,55 @@ describe('Mdx browser worker integration', () => {
         });
 
         const [worker] = workerInstances;
-        expect(worker?.url).toBe('/js/dictionary/mdx-worker-main.js');
+        expect(worker?.url).toBe('/js/dictionary/dictionary-worker-main.js');
         expect(worker?.options).toStrictEqual({type: 'module'});
-        expect(mdx.isConnected()).toBe(true);
-        expect(mdx.isActive()).toBe(true);
 
         const postMessageCalls = worker?.postMessage.mock.calls ?? [];
         expect(postMessageCalls).toHaveLength(1);
-        const [message, transferables] = /** @type {[{action: string, params: {mdxFileName: string, mdxBytes: ArrayBuffer, mddFiles: Array<{name: string, bytes: ArrayBuffer}>, options: Record<string, unknown>}}, Transferable[]]} */ (/** @type {unknown} */ (postMessageCalls[0]));
-        expect(message.action).toBe('convertDictionary');
+        const [message, transferables] = /** @type {[{action: string, params: {details: Record<string, unknown>, mdxFileName: string, mdxBytes: ArrayBuffer, mddFiles: Array<{name: string, bytes: ArrayBuffer}>, options: Record<string, unknown>}}, Transferable[]]} */ (/** @type {unknown} */ (postMessageCalls[0]));
+        expect(message.action).toBe('importMdxDictionary');
         expect(message.params.mdxFileName).toBe('fixture.mdx');
-        expect(message.params.mddFiles.map(({name}) => name)).toStrictEqual(['fixture.mdd']);
+        expect(message.params.details).toMatchObject({
+            prefixWildcardsSupported: true,
+            yomitanVersion: '1.2.3.4',
+        });
         expect(message.params.options).toMatchObject({
             titleOverride: 'Fixture',
             descriptionOverride: 'Fixture description',
             revision: '2026.03.18',
             enableAudio: true,
-            includeAssets: true,
-            termBankSize: 10000,
         });
         expect(new Uint8Array(message.params.mdxBytes)).toStrictEqual(createBytes(12, 11));
         expect(new Uint8Array(message.params.mddFiles[0].bytes)).toStrictEqual(createBytes(8, 47));
         expect(transferables).toHaveLength(2);
 
-        const archiveContent = createBytes(10, 99).buffer;
         worker?.emitMessage({
             action: 'progress',
             params: {
-                details: {stage: 'convert', completed: 3, total: 5},
+                args: [{nextStep: false, index: 725, count: 1000}],
             },
         });
         worker?.emitMessage({
             action: 'complete',
             params: {
                 result: {
-                    archiveContent,
-                    archiveFileName: 'fixture.zip',
+                    result: null,
+                    errors: [],
+                    debug: null,
                 },
             },
         });
 
         await expect(invocationPromise).resolves.toStrictEqual({
-            archiveContent,
-            archiveFileName: 'fixture.zip',
+            result: null,
+            errors: [],
+            debug: null,
         });
-        expect(progressEvents).toStrictEqual([
-            {stage: 'upload', completed: 12, total: 20},
-            {stage: 'upload', completed: 20, total: 20},
-            {stage: 'convert', completed: 3, total: 5},
-        ]);
+        expect(progressEvents).toStrictEqual([{nextStep: false, index: 725, count: 1000}]);
         expect(worker?.terminate).toHaveBeenCalledTimes(1);
-        expect(mdx.isConnected()).toBe(false);
-        expect(mdx.isActive()).toBe(false);
     });
 
-    test('surfaces worker failures and disconnects cleanly', async () => {
+    test('queries the direct MDX import version through the dictionary worker', async () => {
         /** @type {FakeWorker[]} */
         const workerInstances = [];
         vi.stubGlobal('Worker', vi.fn((url, options) => {
@@ -206,18 +193,55 @@ describe('Mdx browser worker integration', () => {
             return worker;
         }));
 
-        const mdx = new Mdx();
-        const invocationPromise = mdx.convertDictionary({mdxFile: createFile('fixture.mdx', createBytes(4, 7))});
+        const dictionaryWorker = new DictionaryWorker();
+        const invocationPromise = dictionaryWorker.getMdxVersion();
 
         await vi.waitFor(() => {
             expect(workerInstances).toHaveLength(1);
         });
 
-        workerInstances[0]?.emitError('MDX worker exploded');
+        const [worker] = workerInstances;
+        const postMessageCalls = worker?.postMessage.mock.calls ?? [];
+        expect(postMessageCalls).toHaveLength(1);
+        const [message, transferables] = /** @type {[{action: string, params: Record<string, never>}, Transferable[]]} */ (/** @type {unknown} */ (postMessageCalls[0]));
+        expect(message.action).toBe('getMdxVersion');
+        expect(transferables).toHaveLength(0);
 
-        await expect(invocationPromise).rejects.toThrow('MDX worker exploded');
+        worker?.emitMessage({
+            action: 'complete',
+            params: {
+                result: 1,
+            },
+        });
+
+        await expect(invocationPromise).resolves.toBe(1);
+    });
+
+    test('surfaces worker failures and disconnects cleanly during direct MDX import', async () => {
+        /** @type {FakeWorker[]} */
+        const workerInstances = [];
+        vi.stubGlobal('Worker', vi.fn((url, options) => {
+            const worker = new FakeWorker(url, options);
+            workerInstances.push(worker);
+            return worker;
+        }));
+
+        const dictionaryWorker = new DictionaryWorker();
+        const invocationPromise = dictionaryWorker.importMdxDictionary(
+            'fixture.mdx',
+            createBytes(4, 7).buffer,
+            [],
+            {prefixWildcardsSupported: true, yomitanVersion: '1.2.3.4'},
+            null,
+        );
+
+        await vi.waitFor(() => {
+            expect(workerInstances).toHaveLength(1);
+        });
+
+        workerInstances[0]?.emitError('Dictionary worker exploded');
+
+        await expect(invocationPromise).rejects.toThrow('Dictionary worker failed: Dictionary worker exploded');
         expect(workerInstances[0]?.terminate).toHaveBeenCalledTimes(1);
-        expect(mdx.isConnected()).toBe(false);
-        expect(mdx.isActive()).toBe(false);
     });
 });

--- a/test/mdx-import-flow.test.js
+++ b/test/mdx-import-flow.test.js
@@ -139,15 +139,19 @@ describe('MDX import controller handoff', () => {
 
         expect(importMdxDictionary).toHaveBeenCalledTimes(1);
         const workerCall = importMdxDictionary.mock.calls[0];
-        expect(workerCall?.[0]).toBe('fixture.mdx');
-        expect(new Uint8Array(/** @type {ArrayBuffer} */ (workerCall?.[1]))).toStrictEqual(createBytes(32_000, 17));
-        expect((/** @type {Array<{name: string, bytes: ArrayBuffer}>} */ (workerCall?.[2])).map(({name}) => name)).toStrictEqual(['fixture.mdd']);
-        expect(workerCall?.[3]).toStrictEqual({
+        expect(workerCall).toBeDefined();
+        if (typeof workerCall === 'undefined') {
+            throw new Error('Missing direct MDX worker call');
+        }
+        expect(workerCall[0]).toBe('fixture.mdx');
+        expect(new Uint8Array(/** @type {ArrayBuffer} */ (workerCall[1]))).toStrictEqual(createBytes(32_000, 17));
+        expect((/** @type {Array<{name: string, bytes: ArrayBuffer}>} */ (workerCall[2])).map(({name}) => name)).toStrictEqual(['fixture.mdd']);
+        expect(workerCall[3]).toStrictEqual({
             ...importDetails,
             useImportSession: true,
             finalizeImportSession: false,
         });
-        expect(workerCall?.[5]).toStrictEqual({enableAudio: false});
+        expect(workerCall[5]).toStrictEqual({enableAudio: false});
 
         expect(progressEvents[0]).toStrictEqual({nextStep: true, index: 0, count: 0});
         expect(progressEvents.every(({nextStep}, index) => index === 0 || nextStep === false)).toBe(true);

--- a/test/mdx-import-flow.test.js
+++ b/test/mdx-import-flow.test.js
@@ -55,7 +55,7 @@ function createControllerForInternalTests() {
  */
 
 describe('MDX import controller handoff', () => {
-    test('DictionaryImportController imports converted MDX archives through the zip importer path', async () => {
+    test('DictionaryImportController imports MDX sources through the direct dictionary-worker path', async () => {
         const controller = createControllerForInternalTests();
         /** @type {TestMdxSource} */
         const source = {
@@ -65,24 +65,24 @@ describe('MDX import controller handoff', () => {
                 createFile('fixture.mdd', createBytes(8_000, 23)),
             ],
         };
-        const archiveBytes = createBytes(24_000, 211);
         /** @type {import('dictionary-importer').ProgressData[]} */
         const progressEvents = [];
-        const convertDictionary = vi.fn(async (details, onProgress) => {
-            onProgress({stage: 'upload', completed: 20_000, total: 40_000});
-            onProgress({stage: 'convert', completed: 1, total: 1});
-            onProgress({stage: 'download', completed: archiveBytes.byteLength, total: archiveBytes.byteLength});
-            return {
-                archiveContent: Uint8Array.from(archiveBytes).buffer,
-                archiveFileName: 'fixture.zip',
-            };
+        const importDictionaryWithWorkerInvocation = vi.fn(async (...args) => {
+            const invokeWorkerImport = /** @type {() => Promise<unknown>} */ (args[7]);
+            await invokeWorkerImport();
+            return [];
         });
-        const importDictionaryArchiveContent = vi.fn(async () => []);
-        controller._mdx = /** @type {import('../ext/js/comm/mdx.js').Mdx} */ (/** @type {unknown} */ ({convertDictionary}));
-        controller._importDictionaryArchiveContent = importDictionaryArchiveContent;
+        controller._importDictionaryWithWorkerInvocation = importDictionaryWithWorkerInvocation;
         controller._reportMdxConversionProgress = DictionaryImportController.prototype._reportMdxConversionProgress;
 
-        const dictionaryWorker = /** @type {import('../ext/js/dictionary/dictionary-worker.js').DictionaryWorker} */ (/** @type {unknown} */ ({}));
+        const importMdxDictionary = vi.fn().mockResolvedValue({
+            result: null,
+            errors: [],
+            debug: {importerDebug: {phaseTimings: []}},
+        });
+        const dictionaryWorker = /** @type {import('../ext/js/dictionary/dictionary-worker.js').DictionaryWorker} */ (/** @type {unknown} */ ({
+            importMdxDictionary,
+        }));
         const importDetails = /** @type {import('dictionary-importer').ImportDetails} */ ({
             prefixWildcardsSupported: true,
             yomitanVersion: '0.0.0',
@@ -107,59 +107,54 @@ describe('MDX import controller handoff', () => {
         );
 
         expect(errors).toStrictEqual([]);
-        expect(convertDictionary).toHaveBeenCalledTimes(1);
-        expect(convertDictionary).toHaveBeenCalledWith(
-            {
-                mdxFile: source.mdxFile,
-                mddFiles: source.mddFiles,
-                enableAudio: false,
-            },
-            expect.any(Function),
-        );
-
-        expect(importDictionaryArchiveContent).toHaveBeenCalledTimes(1);
-        const importCall = importDictionaryArchiveContent.mock.calls[0];
+        expect(importDictionaryWithWorkerInvocation).toHaveBeenCalledTimes(1);
+        const importCall = importDictionaryWithWorkerInvocation.mock.calls[0];
         if (typeof importCall === 'undefined') {
-            throw new Error('Expected MDX archive import handoff');
+            throw new Error('Expected direct MDX worker import handoff');
         }
         const importCallValues = /** @type {unknown[]} */ (/** @type {unknown} */ (importCall));
         const dictionaryTitle = /** @type {string} */ (importCallValues[0]);
-        const archiveContent = /** @type {ArrayBuffer} */ (importCallValues[1]);
-        const profilesDictionarySettings = /** @type {null} */ (importCallValues[2]);
-        const importDetailsCall = /** @type {import('dictionary-importer').ImportDetails} */ (importCallValues[3]);
-        const dictionaryWorkerCall = importCallValues[4];
-        const useImportSession = /** @type {boolean} */ (importCallValues[5]);
-        const finalizeImportSession = /** @type {boolean} */ (importCallValues[6]);
-        const onProgress = /** @type {Function} */ (importCallValues[7]);
-        const importStartTime = /** @type {number} */ (importCallValues[8]);
-        const localPhaseTimings = /** @type {Array<{phase: string, elapsedMs: number, details?: Record<string, string|number|boolean|null>}>} */ (importCallValues[9]);
-        const recordLocalPhase = /** @type {Function} */ (importCallValues[10]);
-        expect(dictionaryTitle).toBe('fixture.zip');
-        expect(new Uint8Array(archiveContent)).toStrictEqual(archiveBytes);
+        const profilesDictionarySettings = /** @type {null} */ (importCallValues[1]);
+        const useImportSession = /** @type {boolean} */ (importCallValues[2]);
+        const finalizeImportSession = /** @type {boolean} */ (importCallValues[3]);
+        const importStartTime = /** @type {number} */ (importCallValues[4]);
+        const localPhaseTimings = /** @type {Array<{phase: string, elapsedMs: number, details?: Record<string, string|number|boolean|null>}>} */ (importCallValues[5]);
+        const recordLocalPhase = /** @type {Function} */ (importCallValues[6]);
+        const invokeWorkerImport = /** @type {Function} */ (importCallValues[7]);
+        expect(dictionaryTitle).toBe('fixture.mdx');
         expect(profilesDictionarySettings).toBeNull();
-        expect(importDetailsCall).toBe(importDetails);
-        expect(dictionaryWorkerCall).toBe(dictionaryWorker);
         expect(useImportSession).toBe(true);
         expect(finalizeImportSession).toBe(false);
-        expect(onProgress).toBeInstanceOf(Function);
         expect(typeof importStartTime).toBe('number');
         expect(localPhaseTimings).toHaveLength(1);
         expect(localPhaseTimings[0]).toMatchObject({
-            phase: 'convert-mdx',
+            phase: 'read-mdx-source',
             details: {
-                archiveFileName: 'fixture.zip',
                 mddCount: 1,
-                archiveSizeBytes: archiveBytes.byteLength,
+                sizeBytes: 40_000,
             },
         });
         expect(recordLocalPhase).toBeInstanceOf(Function);
+        expect(invokeWorkerImport).toBeInstanceOf(Function);
+
+        expect(importMdxDictionary).toHaveBeenCalledTimes(1);
+        const workerCall = importMdxDictionary.mock.calls[0];
+        expect(workerCall?.[0]).toBe('fixture.mdx');
+        expect(new Uint8Array(/** @type {ArrayBuffer} */ (workerCall?.[1]))).toStrictEqual(createBytes(32_000, 17));
+        expect((/** @type {Array<{name: string, bytes: ArrayBuffer}>} */ (workerCall?.[2])).map(({name}) => name)).toStrictEqual(['fixture.mdd']);
+        expect(workerCall?.[3]).toStrictEqual({
+            ...importDetails,
+            useImportSession: true,
+            finalizeImportSession: false,
+        });
+        expect(workerCall?.[5]).toStrictEqual({enableAudio: false});
 
         expect(progressEvents[0]).toStrictEqual({nextStep: true, index: 0, count: 0});
         expect(progressEvents.every(({nextStep}, index) => index === 0 || nextStep === false)).toBe(true);
         expect(progressEvents.at(-1)).toMatchObject({
             nextStep: false,
         });
-        expect(progressEvents.at(-1)?.index).toBe(progressEvents.at(-1)?.count);
-        expect(progressEvents.at(-1)?.count).toBeGreaterThan(0);
+        expect(progressEvents.at(-1)?.index).toBe(450);
+        expect(progressEvents.at(-1)?.count).toBe(1000);
     });
 });

--- a/types/ext/dictionary-importer.d.ts
+++ b/types/ext/dictionary-importer.d.ts
@@ -146,7 +146,35 @@ export type ImportRequirementContext = {
     media: Map<string, DictionaryDatabase.MediaDataArrayBufferContent>;
 };
 
-export type ArchiveFileMap = Map<string, ZipJS.Entry>;
+export type MemoryImportFile = {
+    filename: string;
+    bytes: Uint8Array;
+};
+
+export type ImportFileEntry = ZipJS.Entry | MemoryImportFile;
+
+export type MdxInputFile = {
+    name: string;
+    bytes: Uint8Array;
+};
+
+export type MdxImportOptions = {
+    titleOverride?: string;
+    descriptionOverride?: string;
+    revision?: string;
+    enableAudio?: boolean;
+    includeAssets?: boolean;
+    termBankSize?: number;
+};
+
+export type MdxImportSource = {
+    mdxFileName: string;
+    mdxBytes: Uint8Array;
+    mddFiles: MdxInputFile[];
+    options?: MdxImportOptions;
+};
+
+export type ArchiveFileMap = Map<string, ImportFileEntry>;
 
 /**
  * An array of tuples of a file type inside a dictionary and its corresponding regular expression.
@@ -156,7 +184,7 @@ export type QueryDetails = [fileType: string, fileNameFormat: RegExp][];
 /**
  * A map of file types inside a dictionary and its matching entries.
  */
-export type QueryResult = Map<string, ZipJS.Entry[]>;
+export type QueryResult = Map<string, ImportFileEntry[]>;
 
 export type CompiledSchemaNameArray = [
     termBank: CompiledSchemaName,

--- a/types/ext/dictionary-worker-handler.d.ts
+++ b/types/ext/dictionary-worker-handler.d.ts
@@ -22,8 +22,10 @@ export type OnProgressCallback = (...args: unknown[]) => void;
 
 export type Message = (
     ImportDictionaryMessage |
+    ImportMdxDictionaryMessage |
     DeleteDictionaryMessage |
     GetDictionaryCountsMessage |
+    GetMdxVersionMessage |
     GetImageDetailsResponseMessage
 );
 
@@ -35,6 +37,19 @@ export type ImportDictionaryMessage = {
 export type ImportDictionaryMessageParams = {
     details: DictionaryImporter.ImportDetails;
     archiveContent: ArrayBuffer;
+};
+
+export type ImportMdxDictionaryMessage = {
+    action: 'importMdxDictionary';
+    params: ImportMdxDictionaryMessageParams;
+};
+
+export type ImportMdxDictionaryMessageParams = {
+    details: DictionaryImporter.ImportDetails;
+    mdxFileName: string;
+    mdxBytes: ArrayBuffer;
+    mddFiles: Array<{name: string, bytes: ArrayBuffer}>;
+    options?: DictionaryImporter.MdxImportOptions;
 };
 
 export type DeleteDictionaryMessage = {
@@ -54,6 +69,11 @@ export type GetDictionaryCountsMessage = {
 export type GetDictionaryCountsMessageParams = {
     dictionaryNames: string[];
     getTotal: boolean;
+};
+
+export type GetMdxVersionMessage = {
+    action: 'getMdxVersion';
+    params: Record<string, never>;
 };
 
 export type GetImageDetailsResponseMessage = {


### PR DESCRIPTION
## Summary
- replace the runtime MDX archive-conversion path with direct MDX/MDD import through the dictionary worker
- keep the settings UI and non-MDX zip import flow unchanged while sharing the importer orchestration between archive and MDX sources
- update controller, worker, importer, docs, and tests for the direct MDX path

## Testing
- npm run test:unit
- npm run test:ts
- npm run test:build
- node ./dev/bin/run-playwright.js test integration.spec.js --project=chromium --workers=1 --reporter=line --grep "MDX"