### PR TITLE
Optimize direct MDX import preparation

### DIFF
--- a/benches/mdx-import.bench.js
+++ b/benches/mdx-import.bench.js
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2026  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {IDBKeyRange, indexedDB} from 'fake-indexeddb';
+import {readFileSync} from 'fs';
+import {fileURLToPath} from 'node:url';
+import path from 'path';
+import {bench, describe, vi} from 'vitest';
+import {chrome, fetch} from '../test/mocks/common.js';
+import {DictionaryImporterMediaLoader} from '../test/mocks/dictionary-importer-media-loader.js';
+import {setupStubs} from '../test/utilities/database.js';
+
+setupStubs();
+installBenchmarkConsoleFilter();
+vi.stubGlobal('indexedDB', indexedDB);
+vi.stubGlobal('IDBKeyRange', IDBKeyRange);
+vi.stubGlobal('fetch', fetch);
+vi.stubGlobal('chrome', chrome);
+
+const pakoModule = await import('../ext/js/dictionary/mdx/vendor/pako-inflate.js');
+vi.stubGlobal('pako', Reflect.get(pakoModule, 'default') ?? pakoModule);
+
+const {DictionaryDatabase: DictionaryDatabaseClass} = await import('../ext/js/dictionary/dictionary-database.js');
+const {DictionaryImporter: DictionaryImporterClass} = await import('../ext/js/dictionary/dictionary-importer.js');
+const {createMdxImportData} = await import('../ext/js/dictionary/mdx/mdx-converter.js');
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixtureDirectory = path.join(dirname, '..', 'test', 'data', 'dictionaries');
+const importDataBenchmarkOptions = Object.freeze({
+    throws: true,
+    time: 0,
+    iterations: 16,
+    warmupTime: 0,
+    warmupIterations: 4,
+});
+const importerBenchmarkOptions = Object.freeze({
+    throws: true,
+    time: 0,
+    iterations: 3,
+    warmupTime: 0,
+    warmupIterations: 1,
+    setup: resetImportBenchmarkContext,
+});
+const mdxImportOptions = Object.freeze({
+    enableAudio: false,
+});
+const importDetails = Object.freeze({
+    prefixWildcardsSupported: true,
+    yomitanVersion: '0.0.0.0',
+});
+const fixtures = Object.freeze([
+    createFixture('playwright-read.mdx'),
+    createFixture('playwright-yome.mdx'),
+]);
+
+/** @type {{dictionaryDatabase: import('../ext/js/dictionary/dictionary-database.js').DictionaryDatabase, dictionaryImporter: import('../ext/js/dictionary/dictionary-importer.js').DictionaryImporter}|null} */
+let importContext = null;
+let importIteration = 0;
+
+process.once('beforeExit', () => {
+    void destroyImportBenchmarkContext();
+});
+
+describe('MDX import', () => {
+    bench(`createMdxImportData - fixture batch (n=${fixtures.length})`, async () => {
+        for (const fixture of fixtures) {
+            await createMdxImportData(
+                fixture.fileName,
+                mdxImportOptions,
+                fixture.bytes,
+                [],
+            );
+        }
+    }, importDataBenchmarkOptions);
+
+    bench(`DictionaryImporter.importMdxDictionary - shared prepared database fixture batch (n=${fixtures.length})`, async () => {
+        if (importContext === null) {
+            throw new Error('Benchmark import context is not initialized');
+        }
+
+        const iterationId = ++importIteration;
+        for (const fixture of fixtures) {
+            const titleOverride = createIterationDictionaryTitle(fixture.fileName, iterationId);
+            const {result, errors} = await importContext.dictionaryImporter.importMdxDictionary(
+                importContext.dictionaryDatabase,
+                {
+                    mdxFileName: fixture.fileName,
+                    mdxBytes: fixture.bytes,
+                    mddFiles: [],
+                    options: {
+                        ...mdxImportOptions,
+                        titleOverride,
+                    },
+                },
+                importDetails,
+            );
+            if (result === null || result.title !== titleOverride || errors.length > 0) {
+                throw new Error(`Expected fixture ${fixture.fileName} to import without errors`);
+            }
+        }
+    }, importerBenchmarkOptions);
+});
+
+/**
+ * @param {string} fileName
+ * @returns {{fileName: string, bytes: Uint8Array}}
+ */
+function createFixture(fileName) {
+    return {
+        fileName,
+        bytes: Uint8Array.from(readFileSync(path.join(fixtureDirectory, fileName))),
+    };
+}
+
+/**
+ * @param {string} fileName
+ * @param {number} iterationId
+ * @returns {string}
+ */
+function createIterationDictionaryTitle(fileName, iterationId) {
+    return `${fileName.replace(/\.mdx$/u, '')} benchmark ${iterationId}`;
+}
+
+async function createImportBenchmarkContext() {
+    importContext = {
+        dictionaryDatabase: new DictionaryDatabaseClass(),
+        dictionaryImporter: new DictionaryImporterClass(new DictionaryImporterMediaLoader()),
+    };
+    await importContext.dictionaryDatabase.prepare();
+}
+
+async function resetImportBenchmarkContext() {
+    await destroyImportBenchmarkContext();
+    importIteration = 0;
+    await createImportBenchmarkContext();
+}
+
+async function destroyImportBenchmarkContext() {
+    if (importContext === null) {
+        return;
+    }
+
+    try {
+        await importContext.dictionaryDatabase.purge();
+    } finally {
+        if (importContext.dictionaryDatabase.isPrepared()) {
+            await importContext.dictionaryDatabase.close();
+        }
+        importContext = null;
+    }
+}
+
+function installBenchmarkConsoleFilter() {
+    for (const methodName of /** @type {const} */ (['log', 'warn', 'error'])) {
+        const original = console[methodName].bind(console);
+        console[methodName] = (...args) => {
+            if (shouldSuppressBenchmarkConsoleMessage(args)) {
+                return;
+            }
+            original(...args);
+        };
+    }
+}
+
+/**
+ * @param {unknown[]} args
+ * @returns {boolean}
+ */
+function shouldSuppressBenchmarkConsoleMessage(args) {
+    const first = args[0];
+    return (
+        typeof first === 'string' &&
+        (
+            first.startsWith('SQL TRACE #') ||
+            first.startsWith('Ignoring inability to install OPFS sqlite3_vfs:')
+        )
+    );
+}

--- a/ext/js/dictionary/dictionary-importer.js
+++ b/ext/js/dictionary/dictionary-importer.js
@@ -363,7 +363,7 @@ export class DictionaryImporter {
                         indexVersion: typeof index.version === 'number' ? index.version : null,
                     });
                     this._logImport(`archive+index ${Date.now() - tArchiveStart}ms files=${fileMap.size}`);
-                    return {fileMap, index};
+                    return {fileMap, index, extraPhaseTimings: []};
                 } catch (error) {
                     recordPhaseTiming('archive-and-index', tArchiveStart, {ok: false});
                     throw error;
@@ -386,7 +386,7 @@ export class DictionaryImporter {
             async (recordPhaseTiming) => {
                 const tPrepareStart = Date.now();
                 try {
-                    const {files} = await createMdxImportData(
+                    const {files, phaseTimings: mdxPhaseTimings} = await createMdxImportData(
                         mdxSource.mdxFileName,
                         mdxSource.options ?? {},
                         mdxSource.mdxBytes,
@@ -405,7 +405,7 @@ export class DictionaryImporter {
                         indexVersion: typeof index.version === 'number' ? index.version : null,
                     });
                     this._logImport(`prepare-mdx ${Date.now() - tPrepareStart}ms files=${fileMap.size}`);
-                    return {fileMap, index};
+                    return {fileMap, index, extraPhaseTimings: mdxPhaseTimings};
                 } catch (error) {
                     recordPhaseTiming('prepare-mdx', tPrepareStart, {ok: false});
                     throw error;
@@ -417,7 +417,7 @@ export class DictionaryImporter {
     /**
      * @param {import('./dictionary-database.js').DictionaryDatabase} dictionaryDatabase
      * @param {import('dictionary-importer').ImportDetails} details
-     * @param {(recordPhaseTiming: (phase: string, startTime: number, phaseDetails?: Record<string, string|number|boolean|null>) => void) => Promise<{fileMap: import('dictionary-importer').ArchiveFileMap, index: import('dictionary-data').Index}>} loadSource
+     * @param {(recordPhaseTiming: (phase: string, startTime: number, phaseDetails?: Record<string, string|number|boolean|null>) => void) => Promise<{fileMap: import('dictionary-importer').ArchiveFileMap, index: import('dictionary-data').Index, extraPhaseTimings?: Array<{phase: string, elapsedMs: number, details?: Record<string, string|number|boolean|null>}>}>} loadSource
      * @returns {Promise<import('dictionary-importer').ImportResult>}
      */
     async _importDictionaryFromSource(dictionaryDatabase, details, loadSource) {
@@ -533,14 +533,20 @@ export class DictionaryImporter {
         let fileMap;
         /** @type {import('dictionary-data').Index} */
         let index;
+        /** @type {Array<{phase: string, elapsedMs: number, details?: Record<string, string|number|boolean|null>}>} */
+        let extraPhaseTimings = [];
         try {
-            ({fileMap, index} = await loadSource(recordPhaseTiming));
+            ({fileMap, index, extraPhaseTimings = []} = await loadSource(recordPhaseTiming));
         } catch (e) {
             return {
                 result: null,
                 errors: [toError(e)],
                 debug: {phaseTimings},
             };
+        }
+        for (const phaseTiming of extraPhaseTimings) {
+            phaseTimings.push(phaseTiming);
+            this._logImport(`phase ${phaseTiming.phase} ${phaseTiming.elapsedMs}ms details=${JSON.stringify(phaseTiming.details ?? {})}`);
         }
 
         const dictionaryTitle = index.title;

--- a/ext/js/dictionary/dictionary-worker-handler.js
+++ b/ext/js/dictionary/dictionary-worker-handler.js
@@ -207,7 +207,7 @@ export class DictionaryWorkerHandler {
             const preparePhaseTiming = importerDebug?.phaseTimings.find(({phase}) => phase === 'prepare-mdx') ?? null;
             if (preparePhaseTiming !== null) {
                 preparePhaseTiming.details = {
-                    ...(preparePhaseTiming.details ?? {}),
+                    ...preparePhaseTiming.details,
                     progressMessageCount: progressState.messageCount,
                 };
             }

--- a/ext/js/dictionary/dictionary-worker-handler.js
+++ b/ext/js/dictionary/dictionary-worker-handler.js
@@ -167,22 +167,52 @@ export class DictionaryWorkerHandler {
                 [],
             options: (typeof options === 'object' && options !== null && !Array.isArray(options)) ? options : {},
         };
+        const progressState = {
+            messageCount: 0,
+            lastCompleted: 0,
+            lastReportedAt: 0,
+        };
 
-        return await this._runImport(details, onProgress, async (dictionaryImporter, dictionaryDatabase) => (
-            await dictionaryImporter.importMdxDictionary(
+        return await this._runImport(details, onProgress, async (dictionaryImporter, dictionaryDatabase) => {
+            const importPayload = await dictionaryImporter.importMdxDictionary(
                 dictionaryDatabase,
                 mdxSource,
                 details,
                 ({completed, total}) => {
-                    const normalizedProgress = total > 0 ? Math.max(0, Math.min(1, completed / total)) : 1;
+                    const normalizedTotal = Math.max(1, total);
+                    const clampedCompleted = Math.max(0, Math.min(normalizedTotal, completed));
+                    const now = Date.now();
+                    const minimumEntryDelta = Math.max(1, Math.min(100, Math.ceil(normalizedTotal * 0.01)));
+                    const shouldEmit = (
+                        progressState.messageCount === 0 ||
+                        clampedCompleted >= normalizedTotal ||
+                        (clampedCompleted - progressState.lastCompleted) >= minimumEntryDelta ||
+                        (now - progressState.lastReportedAt) >= 50
+                    );
+                    if (!shouldEmit) { return; }
+                    progressState.messageCount += 1;
+                    progressState.lastCompleted = clampedCompleted;
+                    progressState.lastReportedAt = now;
+                    const normalizedProgress = normalizedTotal > 0 ? Math.max(0, Math.min(1, clampedCompleted / normalizedTotal)) : 1;
                     onProgress({
                         nextStep: false,
                         index: MDX_PREPARATION_PROGRESS_START_INDEX + Math.round(MDX_PREPARATION_PROGRESS_RANGE * normalizedProgress),
                         count: MDX_PREPARATION_PROGRESS_TOTAL,
                     });
                 },
-            )
-        ));
+            );
+            const importerDebug = (typeof importPayload === 'object' && importPayload !== null && !Array.isArray(importPayload)) ?
+                (/** @type {import('dictionary-importer').ImportDebug|null} */ (Reflect.get(importPayload, 'debug') ?? null)) :
+                null;
+            const preparePhaseTiming = importerDebug?.phaseTimings.find(({phase}) => phase === 'prepare-mdx') ?? null;
+            if (preparePhaseTiming !== null) {
+                preparePhaseTiming.details = {
+                    ...(preparePhaseTiming.details ?? {}),
+                    progressMessageCount: progressState.messageCount,
+                };
+            }
+            return importPayload;
+        });
     }
 
     /**

--- a/ext/js/dictionary/mdx/mdx-converter.js
+++ b/ext/js/dictionary/mdx/mdx-converter.js
@@ -252,6 +252,68 @@ class EmbeddedAssetCollector {
     }
 }
 
+class MddAssetResolver {
+    /**
+     * @param {Array<{name: string, bytes: Uint8Array}>} mddSources
+     */
+    constructor(mddSources) {
+        /** @type {Array<MddDictionaryLike>} */
+        this._dictionaries = [];
+        /** @type {Map<string, {dictionaryIndex: number, item: MdictKeyword}>} */
+        this._records = new Map();
+        /** @type {string[]} */
+        this._cssKeys = [];
+
+        for (const {name, bytes} of mddSources) {
+            const dictionary = /** @type {MddDictionaryLike} */ (new MDD(name, bytes));
+            const dictionaryIndex = this._dictionaries.length;
+            this._dictionaries.push(dictionary);
+            for (const item of dictionary.keywordList) {
+                const key = normalizeAssetKey(item.keyText);
+                if (key.length === 0 || this._records.has(key)) { continue; }
+                this._records.set(key, {dictionaryIndex, item});
+                if (key.toLowerCase().endsWith('.css')) {
+                    this._cssKeys.push(key);
+                }
+            }
+        }
+    }
+
+    /**
+     * @returns {number}
+     */
+    get recordCount() {
+        return this._records.size;
+    }
+
+    /**
+     * @returns {string[]}
+     */
+    get cssKeys() {
+        return this._cssKeys;
+    }
+
+    /**
+     * @param {string} key
+     * @returns {Uint8Array|null}
+     */
+    getBytes(key) {
+        const entry = this._records.get(key);
+        if (typeof entry === 'undefined') { return null; }
+        return this._dictionaries[entry.dictionaryIndex]?.lookupRecordByKeyBlock(entry.item) ?? null;
+    }
+
+    /** */
+    close() {
+        for (const dictionary of this._dictionaries) {
+            dictionary.close();
+        }
+        this._dictionaries = [];
+        this._records.clear();
+        this._cssKeys = [];
+    }
+}
+
 /**
  * @param {string} value
  * @returns {string}
@@ -356,6 +418,18 @@ function prefixRelativeAssetPath(path, assetPrefix, sourceAssetPath = null) {
 }
 
 /**
+ * @param {string} path
+ * @param {string} assetPrefix
+ * @param {string|null} sourceAssetPath
+ * @returns {string|null}
+ */
+function normalizeReferencedAssetKey(path, assetPrefix, sourceAssetPath = null) {
+    const normalizedPath = normalizeRelativeAssetPath(path, sourceAssetPath);
+    if (normalizedPath === null) { return null; }
+    return normalizedPath.startsWith(assetPrefix) ? normalizedPath.slice(assetPrefix.length) : normalizedPath;
+}
+
+/**
  * @param {string} value
  * @returns {{mediaType: string, data: Uint8Array}|null}
  */
@@ -400,56 +474,43 @@ function decodeStylesheetAsset(bytes) {
  * @param {string} stylesheet
  * @param {string} assetPrefix
  * @param {string|null} sourceAssetPath
+ * @param {Set<string>|null} assetReferences
  * @returns {string}
  */
-function rewriteCssAssetUrls(stylesheet, assetPrefix, sourceAssetPath) {
+function rewriteCssAssetUrls(stylesheet, assetPrefix, sourceAssetPath, assetReferences = null) {
     return stylesheet.replace(/url\(\s*(["']?)(.*?)\1\s*\)/giu, (match, _quote, rawPath) => {
         const path = typeof rawPath === 'string' ? rawPath : '';
-        const prefixedPath = prefixRelativeAssetPath(path, assetPrefix, sourceAssetPath);
+        const normalizedPath = normalizeReferencedAssetKey(path, assetPrefix, sourceAssetPath);
+        if (normalizedPath !== null && assetReferences !== null) {
+            assetReferences.add(normalizedPath);
+        }
+        const prefixedPath = normalizedPath === null ? null : (
+            normalizedPath.startsWith(assetPrefix) ? normalizedPath : `${assetPrefix}${normalizedPath}`
+        );
         return prefixedPath === null ? match : `url("${prefixedPath}")`;
     });
 }
 
 /**
- * @param {Map<string, Uint8Array>} assets
+ * @param {Map<string, Uint8Array>} cssAssets
  * @param {string} assetPrefix
  * @param {Array<[string, string]>} inlineStylesheets
+ * @param {Set<string>|null} assetReferences
  * @returns {string|null}
  */
-function buildRootStylesheet(assets, assetPrefix, inlineStylesheets) {
+function buildRootStylesheet(cssAssets, assetPrefix, inlineStylesheets, assetReferences = null) {
     /** @type {string[]} */
     const sections = [];
-    for (const [archivePath, bytes] of [...assets.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
-        if (!archivePath.toLowerCase().endsWith('.css')) { continue; }
+    for (const [archivePath, bytes] of [...cssAssets.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
         const stylesheet = decodeStylesheetAsset(bytes);
         if (stylesheet === null) { continue; }
         const sourceName = archivePath.startsWith(assetPrefix) ? archivePath.slice(assetPrefix.length) : archivePath;
-        sections.push(`/* Source: ${sourceName} */\n${rewriteCssAssetUrls(stylesheet, assetPrefix, sourceName)}`);
+        sections.push(`/* Source: ${sourceName} */\n${rewriteCssAssetUrls(stylesheet, assetPrefix, sourceName, assetReferences)}`);
     }
     for (const [sourceName, stylesheet] of inlineStylesheets) {
-        sections.push(`/* Source: ${sourceName} */\n${rewriteCssAssetUrls(stylesheet, assetPrefix, null)}`);
+        sections.push(`/* Source: ${sourceName} */\n${rewriteCssAssetUrls(stylesheet, assetPrefix, null, assetReferences)}`);
     }
     return sections.length > 0 ? `${sections.join('\n\n')}\n` : null;
-}
-
-/**
- * @param {Map<string, Uint8Array>} assets
- * @param {Array<{name: string, bytes: Uint8Array}>} mddSources
- */
-function collectAssets(assets, mddSources) {
-    for (const {name, bytes} of mddSources) {
-        const mdd = /** @type {MddDictionaryLike} */ (new MDD(name, bytes));
-        for (const item of mdd.keywordList) {
-            const key = normalizeAssetKey(item.keyText);
-            if (key.length === 0) { continue; }
-            const value = mdd.lookupRecordByKeyBlock(item);
-            if (!(value instanceof Uint8Array)) { continue; }
-            if (!assets.has(key)) {
-                assets.set(key, value);
-            }
-        }
-        mdd.close();
-    }
 }
 
 /**
@@ -477,9 +538,10 @@ function buildStructuredData(attrs) {
 /**
  * @param {string|null|undefined} styleText
  * @param {string} assetPrefix
+ * @param {Set<string>} assetReferences
  * @returns {Record<string, string|string[]>|null}
  */
-function convertInlineStyle(styleText, assetPrefix) {
+function convertInlineStyle(styleText, assetPrefix, assetReferences) {
     if (typeof styleText !== 'string' || styleText.trim().length === 0) { return null; }
     /** @type {Record<string, string|string[]>} */
     const style = {};
@@ -490,7 +552,7 @@ function convertInlineStyle(styleText, assetPrefix) {
         let value = declaration.slice(separator + 1).trim();
         if (propertyName.length === 0 || value.length === 0) { continue; }
         if (value.includes('url(')) {
-            value = rewriteCssAssetUrls(value, assetPrefix, null);
+            value = rewriteCssAssetUrls(value, assetPrefix, null, assetReferences);
         }
         if (propertyName === 'text-decoration' || propertyName === 'text-decoration-line') {
             const parts = value.split(/\s+/u).filter((part) => ['underline', 'overline', 'line-through', 'none'].includes(part));
@@ -507,17 +569,23 @@ function convertInlineStyle(styleText, assetPrefix) {
 
 /**
  * @param {string} href
- * @param {{assetPrefix: string, enableAudio: boolean, embeddedAssets: EmbeddedAssetCollector}} details
+ * @param {{assetPrefix: string, enableAudio: boolean, embeddedAssets: EmbeddedAssetCollector, assetReferences: Set<string>}} details
  * @returns {string}
  */
-function convertLinkHref(href, {assetPrefix, enableAudio, embeddedAssets}) {
+function convertLinkHref(href, {assetPrefix, enableAudio, embeddedAssets, assetReferences}) {
     const value = href.trim();
     const lowered = value.toLowerCase();
     if (lowered.startsWith('entry://')) { return `?query=${value.slice(8)}`; }
     if (lowered.startsWith('bword://')) { return `?query=${value.slice(8)}`; }
     if (lowered.startsWith('d:') || lowered.startsWith('x:')) { return `?query=${value.slice(2)}`; }
     if (lowered.startsWith('sound://')) {
-        const assetPath = prefixRelativeAssetPath(value.slice(8), assetPrefix, null);
+        const normalizedPath = normalizeReferencedAssetKey(value.slice(8), assetPrefix, null);
+        if (normalizedPath !== null) {
+            assetReferences.add(normalizedPath);
+        }
+        const assetPath = normalizedPath === null ? null : (
+            normalizedPath.startsWith(assetPrefix) ? normalizedPath : `${assetPrefix}${normalizedPath}`
+        );
         return enableAudio && assetPath !== null ? `media:${encodeMediaPath(assetPath)}` : '#';
     }
     if (lowered.startsWith('http://') || lowered.startsWith('https://') || lowered.startsWith('mailto:') || lowered.startsWith('tel:')) {
@@ -530,19 +598,36 @@ function convertLinkHref(href, {assetPrefix, enableAudio, embeddedAssets}) {
     if (lowered.startsWith('javascript:') || lowered.startsWith('vbscript:') || lowered.startsWith('about:') || value.startsWith('#')) {
         return '#';
     }
-    const assetPath = prefixRelativeAssetPath(value, assetPrefix, null);
+    const normalizedPath = normalizeReferencedAssetKey(value, assetPrefix, null);
+    if (normalizedPath !== null) {
+        assetReferences.add(normalizedPath);
+    }
+    const assetPath = normalizedPath === null ? null : (
+        normalizedPath.startsWith(assetPrefix) ? normalizedPath : `${assetPrefix}${normalizedPath}`
+    );
     return assetPath !== null ? `media:${encodeMediaPath(assetPath)}` : '#';
 }
 
 /**
  * @param {Record<string, string>} attrs
- * @param {{assetPrefix: string, embeddedAssets: EmbeddedAssetCollector}} details
+ * @param {{assetPrefix: string, embeddedAssets: EmbeddedAssetCollector, assetReferences: Set<string>}} details
  * @returns {Record<string, unknown>|null}
  */
-function createStructuredImage(attrs, {assetPrefix, embeddedAssets}) {
+function createStructuredImage(attrs, {assetPrefix, embeddedAssets, assetReferences}) {
     const src = attrs.src ?? '';
     const lowerSrc = src.trim().toLowerCase();
-    const path = lowerSrc.startsWith('data:') ? embeddedAssets.registerDataUrl(src) : prefixRelativeAssetPath(src, assetPrefix, null);
+    let path;
+    if (lowerSrc.startsWith('data:')) {
+        path = embeddedAssets.registerDataUrl(src);
+    } else {
+        const normalizedPath = normalizeReferencedAssetKey(src, assetPrefix, null);
+        if (normalizedPath !== null) {
+            assetReferences.add(normalizedPath);
+        }
+        path = normalizedPath === null ? null : (
+            normalizedPath.startsWith(assetPrefix) ? normalizedPath : `${assetPrefix}${normalizedPath}`
+        );
+    }
     if (path === null) { return null; }
     /** @type {Record<string, unknown>} */
     const image = {tag: 'img', path};
@@ -587,7 +672,7 @@ function getDirectTextContent(parent) {
 /**
  * @param {Parse5ParentNode} parent
  * @param {Array<unknown>} content
- * @param {{assetPrefix: string, enableAudio: boolean, embeddedAssets: EmbeddedAssetCollector, inlineStylesheets: Array<[string, string]>}} details
+ * @param {{assetPrefix: string, enableAudio: boolean, embeddedAssets: EmbeddedAssetCollector, inlineStylesheets: Array<[string, string]>, assetReferences: Set<string>}} details
  */
 function appendStructuredContent(parent, content, details) {
     for (const child of parent.childNodes ?? []) {
@@ -642,7 +727,7 @@ function appendStructuredContent(parent, content, details) {
         if (typeof defaultStyle !== 'undefined') {
             Object.assign(style, defaultStyle);
         }
-        const inlineStyle = convertInlineStyle(attrs.style, details.assetPrefix);
+        const inlineStyle = convertInlineStyle(attrs.style, details.assetPrefix, details.assetReferences);
         if (inlineStyle !== null) {
             Object.assign(style, inlineStyle);
         }
@@ -695,10 +780,12 @@ function appendStructuredContent(parent, content, details) {
 /**
  * @param {string} definition
  * @param {{enableAudio: boolean, assetPrefix: string}} options
- * @returns {{glossary: Record<string, unknown>, inlineStylesheets: Array<[string, string]>, embeddedAssets: Map<string, Uint8Array>}}
+ * @returns {{glossary: Record<string, unknown>, inlineStylesheets: Array<[string, string]>, embeddedAssets: Map<string, Uint8Array>, assetReferences: Set<string>}}
  */
 function convertDefinitionToStructuredContent(definition, options) {
     const embeddedAssets = new EmbeddedAssetCollector(options.assetPrefix);
+    /** @type {Set<string>} */
+    const assetReferences = new Set();
     /** @type {Array<[string, string]>} */
     const inlineStylesheets = [];
     const fragmentResult = /** @type {unknown} */ (parse5.parseFragment(definition));
@@ -710,6 +797,7 @@ function convertDefinitionToStructuredContent(definition, options) {
         enableAudio: options.enableAudio,
         embeddedAssets,
         inlineStylesheets,
+        assetReferences,
     });
     return {
         glossary: {
@@ -725,27 +813,8 @@ function convertDefinitionToStructuredContent(definition, options) {
         },
         inlineStylesheets,
         embeddedAssets: embeddedAssets.assets,
+        assetReferences,
     };
-}
-
-/**
- * @param {MdxDictionaryLike} mdx
- * @returns {Map<string, string[]>}
- */
-function buildRedirectMap(mdx) {
-    /** @type {Map<string, string[]>} */
-    const redirects = new Map();
-    for (const item of mdx.keywordList) {
-        const result = mdx.fetch_definition(item);
-        const term = trimNullSuffix(item.keyText);
-        const definition = trimNullSuffix(result.definition ?? '');
-        if (term.length === 0 || !definition.startsWith('@@@LINK=')) { continue; }
-        const target = trimNullSuffix(definition.slice(8));
-        const values = redirects.get(target) ?? [];
-        values.push(term);
-        redirects.set(target, values);
-    }
-    return redirects;
 }
 
 /**
@@ -778,7 +847,7 @@ function extractDescription(mdx, override) {
  * @param {Uint8Array} mdxBytes
  * @param {Array<{name: string, bytes: Uint8Array}>} mddSources
  * @param {?(details: {stage: 'convert', completed: number, total: number}) => void} onProgress
- * @returns {Promise<{files: Map<string, Uint8Array>, archiveFileName: string}>}
+ * @returns {Promise<{files: Map<string, Uint8Array>, archiveFileName: string, phaseTimings: Array<{phase: string, elapsedMs: number, details?: Record<string, string|number|boolean|null>}>}>}
  */
 export async function createMdxImportData(fileName, options, mdxBytes, mddSources, onProgress = null) {
     const {
@@ -791,32 +860,63 @@ export async function createMdxImportData(fileName, options, mdxBytes, mddSource
     } = options;
 
     const mdx = /** @type {MdxDictionaryLike} */ (new MDX(fileName, mdxBytes));
+    /** @type {MddAssetResolver|null} */
+    let assetResolver = null;
     try {
-        const redirects = buildRedirectMap(mdx);
         const title = extractTitle(mdx, fileName, titleOverride);
         const description = extractDescription(mdx, descriptionOverride);
         const assetPrefix = 'mdict-media/';
-        /** @type {Map<string, Uint8Array>} */
-        const assets = new Map();
-        if (includeAssets && mddSources.length > 0) {
-            collectAssets(assets, mddSources);
-        }
+        /** @type {Array<{phase: string, elapsedMs: number, details?: Record<string, string|number|boolean|null>}>} */
+        const phaseTimings = [];
+        /**
+         * @param {string} phase
+         * @param {number} startTime
+         * @param {Record<string, string|number|boolean|null>} [details]
+         * @returns {void}
+         */
+        const recordPhaseTiming = (phase, startTime, details = {}) => {
+            phaseTimings.push({
+                phase,
+                elapsedMs: Math.max(0, Date.now() - startTime),
+                details,
+            });
+        };
 
+        const tIndexMddStart = Date.now();
+        if (includeAssets && mddSources.length > 0) {
+            assetResolver = new MddAssetResolver(mddSources);
+        }
+        recordPhaseTiming('prepare-mdx:index-mdd', tIndexMddStart, {
+            includeAssets,
+            mddCount: mddSources.length,
+            indexedAssetCount: assetResolver?.recordCount ?? 0,
+            cssAssetCount: assetResolver?.cssKeys.length ?? 0,
+        });
+
+        const totalEntries = Math.max(1, mdx.keywordList.length);
         if (typeof onProgress === 'function') {
-            onProgress({stage: 'convert', completed: 0, total: Math.max(1, mdx.keywordList.length)});
+            onProgress({stage: 'convert', completed: 0, total: totalEntries});
         }
 
         const encoder = new TextEncoder();
         /** @type {Map<string, Uint8Array>} */
         const files = new Map();
+        /** @type {Map<string, Uint8Array>} */
+        const embeddedAssets = new Map();
         /** @type {Array<[string, string]>} */
         const inlineStylesheets = [];
-        let bankIndex = 1;
+        /** @type {Set<string>} */
+        const referencedAssetKeys = new Set();
+        /** @type {Map<string, string[]>} */
+        const redirects = new Map();
+        /** @type {Array<{term: string, glossary: Record<string, unknown>, sequence: number}>} */
+        const convertedEntries = [];
         let sequence = 0;
-        /** @type {unknown[][]} */
-        let bank = [];
-        const totalEntries = Math.max(1, mdx.keywordList.length);
         let processedEntries = 0;
+        let redirectCount = 0;
+        let encodedTermBankCount = 0;
+        let encodedTermRowCount = 0;
+        let jsonEncodeMs = 0;
 
         /**
          * @param {string} path
@@ -824,7 +924,9 @@ export async function createMdxImportData(fileName, options, mdxBytes, mddSource
          * @returns {void}
          */
         const writeJson = (path, value) => {
+            const tEncodeStart = Date.now();
             files.set(path, encoder.encode(JSON.stringify(value)));
+            jsonEncodeMs += Math.max(0, Date.now() - tEncodeStart);
         };
 
         writeJson('index.json', {
@@ -835,12 +937,26 @@ export async function createMdxImportData(fileName, options, mdxBytes, mddSource
             description,
         });
 
+        const tConvertEntriesStart = Date.now();
         for (const item of mdx.keywordList) {
             const term = trimNullSuffix(item.keyText);
             const result = mdx.fetch_definition(item);
             const definition = trimNullSuffix(result.definition ?? '');
             processedEntries += 1;
-            if (term.length === 0 || definition.startsWith('@@@LINK=')) {
+            if (term.length === 0) {
+                if (typeof onProgress === 'function') {
+                    onProgress({stage: 'convert', completed: processedEntries, total: totalEntries});
+                }
+                continue;
+            }
+            if (definition.startsWith('@@@LINK=')) {
+                const target = trimNullSuffix(definition.slice(8));
+                if (target.length > 0) {
+                    const aliases = redirects.get(target) ?? [];
+                    aliases.push(term);
+                    redirects.set(target, aliases);
+                    redirectCount += 1;
+                }
                 if (typeof onProgress === 'function') {
                     onProgress({stage: 'convert', completed: processedEntries, total: totalEntries});
                 }
@@ -849,13 +965,36 @@ export async function createMdxImportData(fileName, options, mdxBytes, mddSource
 
             const converted = convertDefinitionToStructuredContent(definition, {enableAudio, assetPrefix});
             for (const [path, bytes] of converted.embeddedAssets) {
-                if (!assets.has(path)) {
-                    assets.set(path, bytes);
+                if (!embeddedAssets.has(path)) {
+                    embeddedAssets.set(path, bytes);
                 }
             }
             for (const [sourceName, stylesheet] of converted.inlineStylesheets) {
                 inlineStylesheets.push([`${term}/${sourceName}`, stylesheet]);
             }
+            for (const assetKey of converted.assetReferences) {
+                referencedAssetKeys.add(assetKey);
+            }
+            convertedEntries.push({term, glossary: converted.glossary, sequence});
+            sequence += 1;
+            if (typeof onProgress === 'function') {
+                onProgress({stage: 'convert', completed: processedEntries, total: totalEntries});
+            }
+        }
+        recordPhaseTiming('prepare-mdx:convert-entries', tConvertEntriesStart, {
+            entries: processedEntries,
+            convertedEntryCount: convertedEntries.length,
+            redirectCount,
+            referencedAssetCount: referencedAssetKeys.size,
+            inlineStylesheetCount: inlineStylesheets.length,
+            embeddedAssetCount: embeddedAssets.size,
+        });
+
+        const tEncodeBanksStart = Date.now();
+        let bankIndex = 1;
+        /** @type {unknown[][]} */
+        let bank = [];
+        for (const {term, glossary, sequence: entrySequence} of convertedEntries) {
             const expressions = [term, ...(redirects.get(term) ?? [])];
             for (const expression of expressions) {
                 bank.push([
@@ -864,46 +1003,83 @@ export async function createMdxImportData(fileName, options, mdxBytes, mddSource
                     '',
                     '',
                     0,
-                    [converted.glossary],
-                    sequence,
+                    [glossary],
+                    entrySequence,
                     '',
                 ]);
             }
-            sequence += 1;
             if (bank.length >= termBankSize) {
+                encodedTermRowCount += bank.length;
                 writeJson(`term_bank_${bankIndex}.json`, bank);
                 bank = [];
                 bankIndex += 1;
-            }
-            if (typeof onProgress === 'function') {
-                onProgress({stage: 'convert', completed: processedEntries, total: totalEntries});
+                encodedTermBankCount += 1;
             }
         }
-
         if (bank.length > 0) {
+            encodedTermRowCount += bank.length;
             writeJson(`term_bank_${bankIndex}.json`, bank);
+            encodedTermBankCount += 1;
         }
+        recordPhaseTiming('prepare-mdx:encode-banks', tEncodeBanksStart, {
+            encodedTermBankCount,
+            encodedTermRowCount,
+            jsonEncodeMs: Math.max(0, jsonEncodeMs),
+        });
 
+        const tMaterializeAssetsStart = Date.now();
         /** @type {Map<string, Uint8Array>} */
-        const archiveAssets = new Map();
-        for (const [path, bytes] of assets) {
-            archiveAssets.set(path.startsWith(assetPrefix) ? path : `${assetPrefix}${path}`, bytes);
+        const cssAssets = new Map();
+        if (assetResolver !== null) {
+            for (const cssKey of assetResolver.cssKeys) {
+                const bytes = assetResolver.getBytes(cssKey);
+                if (!(bytes instanceof Uint8Array)) { continue; }
+                cssAssets.set(cssKey, bytes);
+            }
         }
-        const rootStylesheet = buildRootStylesheet(archiveAssets, assetPrefix, inlineStylesheets);
+        /** @type {Set<string>} */
+        const cssReferencedAssetKeys = new Set();
+        const rootStylesheet = buildRootStylesheet(cssAssets, assetPrefix, inlineStylesheets, cssReferencedAssetKeys);
         if (rootStylesheet !== null) {
             files.set('styles.css', encoder.encode(rootStylesheet));
         }
-        for (const [archivePath, bytes] of archiveAssets) {
-            files.set(archivePath, bytes);
+        for (const [assetPath, bytes] of embeddedAssets) {
+            files.set(assetPath, bytes);
         }
+        for (const [cssKey, bytes] of cssAssets) {
+            files.set(`${assetPrefix}${cssKey}`, bytes);
+        }
+        let materializedReferencedAssetCount = 0;
+        if (assetResolver !== null) {
+            const allReferencedAssetKeys = new Set([...referencedAssetKeys, ...cssReferencedAssetKeys]);
+            for (const assetKey of allReferencedAssetKeys) {
+                if (assetKey.toLowerCase().endsWith('.css')) { continue; }
+                const bytes = assetResolver.getBytes(assetKey);
+                if (!(bytes instanceof Uint8Array)) { continue; }
+                const archivePath = `${assetPrefix}${assetKey}`;
+                if (files.has(archivePath)) { continue; }
+                files.set(archivePath, bytes);
+                materializedReferencedAssetCount += 1;
+            }
+        }
+        recordPhaseTiming('prepare-mdx:materialize-assets', tMaterializeAssetsStart, {
+            cssAssetCount: cssAssets.size,
+            referencedAssetCount: referencedAssetKeys.size,
+            cssReferencedAssetCount: cssReferencedAssetKeys.size,
+            embeddedAssetCount: embeddedAssets.size,
+            materializedReferencedAssetCount,
+            hasRootStylesheet: rootStylesheet !== null,
+        });
         if (typeof onProgress === 'function') {
             onProgress({stage: 'convert', completed: totalEntries, total: totalEntries});
         }
         return {
             files,
             archiveFileName: `${title}.zip`,
+            phaseTimings,
         };
     } finally {
+        assetResolver?.close();
         mdx.close();
     }
 }

--- a/ext/js/dictionary/mdx/mdx-converter.js
+++ b/ext/js/dictionary/mdx/mdx-converter.js
@@ -484,9 +484,7 @@ function rewriteCssAssetUrls(stylesheet, assetPrefix, sourceAssetPath, assetRefe
         if (normalizedPath !== null && assetReferences !== null) {
             assetReferences.add(normalizedPath);
         }
-        const prefixedPath = normalizedPath === null ? null : (
-            normalizedPath.startsWith(assetPrefix) ? normalizedPath : `${assetPrefix}${normalizedPath}`
-        );
+        const prefixedPath = prefixRelativeAssetPath(path, assetPrefix, sourceAssetPath);
         return prefixedPath === null ? match : `url("${prefixedPath}")`;
     });
 }
@@ -583,9 +581,7 @@ function convertLinkHref(href, {assetPrefix, enableAudio, embeddedAssets, assetR
         if (normalizedPath !== null) {
             assetReferences.add(normalizedPath);
         }
-        const assetPath = normalizedPath === null ? null : (
-            normalizedPath.startsWith(assetPrefix) ? normalizedPath : `${assetPrefix}${normalizedPath}`
-        );
+        const assetPath = prefixRelativeAssetPath(value.slice(8), assetPrefix);
         return enableAudio && assetPath !== null ? `media:${encodeMediaPath(assetPath)}` : '#';
     }
     if (lowered.startsWith('http://') || lowered.startsWith('https://') || lowered.startsWith('mailto:') || lowered.startsWith('tel:')) {
@@ -602,9 +598,7 @@ function convertLinkHref(href, {assetPrefix, enableAudio, embeddedAssets, assetR
     if (normalizedPath !== null) {
         assetReferences.add(normalizedPath);
     }
-    const assetPath = normalizedPath === null ? null : (
-        normalizedPath.startsWith(assetPrefix) ? normalizedPath : `${assetPrefix}${normalizedPath}`
-    );
+    const assetPath = prefixRelativeAssetPath(value, assetPrefix);
     return assetPath !== null ? `media:${encodeMediaPath(assetPath)}` : '#';
 }
 
@@ -624,9 +618,7 @@ function createStructuredImage(attrs, {assetPrefix, embeddedAssets, assetReferen
         if (normalizedPath !== null) {
             assetReferences.add(normalizedPath);
         }
-        path = normalizedPath === null ? null : (
-            normalizedPath.startsWith(assetPrefix) ? normalizedPath : `${assetPrefix}${normalizedPath}`
-        );
+        path = prefixRelativeAssetPath(src, assetPrefix);
     }
     if (path === null) { return null; }
     /** @type {Record<string, unknown>} */

--- a/ext/js/pages/settings/dictionary-import-controller.js
+++ b/ext/js/pages/settings/dictionary-import-controller.js
@@ -2294,14 +2294,10 @@ export class DictionaryImportController {
         };
 
         const mdxBytes = await readFileWithProgress(source.mdxFile);
-        /** @type {Array<{name: string, bytes: ArrayBuffer}>} */
-        const mddFiles = [];
-        for (const file of source.mddFiles) {
-            mddFiles.push({
-                name: file.name,
-                bytes: await readFileWithProgress(file),
-            });
-        }
+        const mddFiles = await Promise.all(source.mddFiles.map(async (file) => ({
+            name: file.name,
+            bytes: await readFileWithProgress(file),
+        })));
         return {mdxBytes, mddFiles, totalBytes: totalUploadBytes};
     }
 

--- a/test/backend-mecab-parse.test.js
+++ b/test/backend-mecab-parse.test.js
@@ -32,13 +32,11 @@ describe('Backend._onApiParseText', () => {
                     {name: 'unidic-csj-202302', lines: [parsedLine]},
                 ]),
             },
-            // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/unbound-method
             _textParseMecab: Backend.prototype._textParseMecab,
             _textParseScanning: async () => {
                 throw new Error('Unexpected call to _textParseScanning');
             },
         };
-        // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/unbound-method
         const onApiParseText = Backend.prototype._onApiParseText;
 
         const results = await onApiParseText.call(context, {

--- a/test/dictionary-worker-handler.test.js
+++ b/test/dictionary-worker-handler.test.js
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2026  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {afterEach, describe, expect, test, vi} from 'vitest';
+import {DictionaryWorkerHandler} from '../ext/js/dictionary/dictionary-worker-handler.js';
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+/**
+ * @param {Array<number>} values
+ * @returns {() => number}
+ */
+function createNowMock(values) {
+    let index = 0;
+    return () => {
+        const value = values[index];
+        if (typeof value === 'number') {
+            index += 1;
+            return value;
+        }
+        return values.at(-1) ?? 0;
+    };
+}
+
+describe('DictionaryWorkerHandler direct MDX import progress', () => {
+    test('throttles intermediate progress updates and records the emitted message count', async () => {
+        const handler = new DictionaryWorkerHandler();
+        const onProgress = vi.fn();
+        vi.spyOn(Date, 'now').mockReturnValue(1000);
+
+        const importMdxDictionary = vi.fn(async (
+            /** @type {import('../ext/js/dictionary/dictionary-database.js').DictionaryDatabase} */ _dictionaryDatabase,
+            /** @type {{mdxFileName: string, mdxBytes: Uint8Array, mddFiles: Array<{name: string, bytes: Uint8Array}>, options?: Record<string, unknown>}} */ mdxSource,
+            /** @type {import('dictionary-importer').ImportDetails} */ details,
+            /** @type {(progress: {completed: number, total: number}) => void} */ onPrepareProgress,
+        ) => {
+            expect(mdxSource).toMatchObject({
+                mdxFileName: 'fixture.mdx',
+                mddFiles: [{name: 'fixture.mdd'}],
+            });
+            expect(mdxSource.mdxBytes).toBeInstanceOf(Uint8Array);
+            expect(mdxSource.mddFiles[0]?.bytes).toBeInstanceOf(Uint8Array);
+            expect(details).toMatchObject({yomitanVersion: '1.2.3.4'});
+
+            onPrepareProgress({completed: 0, total: 1000});
+            onPrepareProgress({completed: 1, total: 1000});
+            onPrepareProgress({completed: 9, total: 1000});
+            onPrepareProgress({completed: 10, total: 1000});
+            onPrepareProgress({completed: 11, total: 1000});
+            onPrepareProgress({completed: 1000, total: 1000});
+
+            return {
+                result: null,
+                errors: [],
+                debug: {
+                    phaseTimings: [{phase: 'prepare-mdx', elapsedMs: 12, details: {source: 'fixture'}}],
+                },
+            };
+        });
+
+        Reflect.set(handler, '_runImport', vi.fn(async (
+            /** @type {import('dictionary-importer').ImportDetails} */ details,
+            /** @type {(value: {nextStep: boolean, index: number, count: number}) => void} */ progressCallback,
+            /** @type {(dictionaryImporter: {importMdxDictionary: typeof importMdxDictionary}, dictionaryDatabase: import('../ext/js/dictionary/dictionary-database.js').DictionaryDatabase) => Promise<unknown>} */ importCallback,
+        ) => {
+            expect(details).toMatchObject({yomitanVersion: '1.2.3.4'});
+            expect(progressCallback).toBe(onProgress);
+            return await importCallback(
+                {importMdxDictionary},
+                /** @type {import('../ext/js/dictionary/dictionary-database.js').DictionaryDatabase} */ (/** @type {unknown} */ ({})),
+            );
+        }));
+
+        const result = await handler._importMdxDictionary({
+            details: {prefixWildcardsSupported: true, yomitanVersion: '1.2.3.4'},
+            mdxFileName: 'fixture.mdx',
+            mdxBytes: new Uint8Array([1, 2, 3]).buffer,
+            mddFiles: [{name: 'fixture.mdd', bytes: new Uint8Array([4, 5]).buffer}],
+            options: {enableAudio: false},
+        }, onProgress);
+
+        expect(importMdxDictionary).toHaveBeenCalledTimes(1);
+        expect(onProgress.mock.calls.map(([value]) => value)).toStrictEqual([
+            {nextStep: false, index: 450, count: 1000},
+            {nextStep: false, index: 456, count: 1000},
+            {nextStep: false, index: 1000, count: 1000},
+        ]);
+        expect(result).toMatchObject({
+            debug: {
+                phaseTimings: [{
+                    phase: 'prepare-mdx',
+                    details: {
+                        source: 'fixture',
+                        progressMessageCount: 3,
+                    },
+                }],
+            },
+        });
+    });
+
+    test('emits a time-based progress update when entry deltas stay below the percentage threshold', async () => {
+        const handler = new DictionaryWorkerHandler();
+        const onProgress = vi.fn();
+        vi.spyOn(Date, 'now').mockImplementation(createNowMock([1000, 1000, 1051, 1051]));
+
+        Reflect.set(handler, '_runImport', vi.fn(async (
+            /** @type {import('dictionary-importer').ImportDetails} */ _details,
+            /** @type {(value: {nextStep: boolean, index: number, count: number}) => void} */ _progressCallback,
+            /** @type {(dictionaryImporter: {importMdxDictionary: (dictionaryDatabase: import('../ext/js/dictionary/dictionary-database.js').DictionaryDatabase, mdxSource: {mdxFileName: string, mdxBytes: Uint8Array, mddFiles: Array<{name: string, bytes: Uint8Array}>, options?: Record<string, unknown>}, importDetails: import('dictionary-importer').ImportDetails, onPrepareProgress: (progress: {completed: number, total: number}) => void) => Promise<unknown>}, dictionaryDatabase: import('../ext/js/dictionary/dictionary-database.js').DictionaryDatabase) => Promise<unknown>} */ importCallback,
+        ) => (
+            await importCallback(
+                {
+                    importMdxDictionary: async (
+                        /** @type {import('../ext/js/dictionary/dictionary-database.js').DictionaryDatabase} */ _dictionaryDatabase,
+                        /** @type {{mdxFileName: string, mdxBytes: Uint8Array, mddFiles: Array<{name: string, bytes: Uint8Array}>, options?: Record<string, unknown>}} */ _mdxSource,
+                        /** @type {import('dictionary-importer').ImportDetails} */ _importDetails,
+                        /** @type {(progress: {completed: number, total: number}) => void} */ onPrepareProgress,
+                    ) => {
+                        onPrepareProgress({completed: 0, total: 10000});
+                        onPrepareProgress({completed: 10, total: 10000});
+                        onPrepareProgress({completed: 20, total: 10000});
+                        onPrepareProgress({completed: 10000, total: 10000});
+                        return {
+                            result: null,
+                            errors: [],
+                            debug: {
+                                phaseTimings: [{phase: 'prepare-mdx', elapsedMs: 1, details: {}}],
+                            },
+                        };
+                    },
+                },
+                /** @type {import('../ext/js/dictionary/dictionary-database.js').DictionaryDatabase} */ (/** @type {unknown} */ ({})),
+            )
+        )));
+
+        await handler._importMdxDictionary({
+            details: {prefixWildcardsSupported: true, yomitanVersion: '1.2.3.4'},
+            mdxFileName: 'fixture.mdx',
+            mdxBytes: new Uint8Array([1]).buffer,
+            mddFiles: [],
+            options: {enableAudio: false},
+        }, onProgress);
+
+        expect(onProgress.mock.calls.map(([value]) => value)).toStrictEqual([
+            {nextStep: false, index: 450, count: 1000},
+            {nextStep: false, index: 451, count: 1000},
+            {nextStep: false, index: 1000, count: 1000},
+        ]);
+    });
+});

--- a/test/mdx-converter.test.js
+++ b/test/mdx-converter.test.js
@@ -26,7 +26,7 @@ import {afterEach, describe, expect, test, vi} from 'vitest';
  * @typedef {Array<{keyText: string, value: Uint8Array}>} MockMddDictionary
  */
 
-/** @type {{mdxFactory: (fileName: string) => MockMdxDictionary, mddFactory: (fileName: string) => MockMddDictionary}} */
+/** @type {{mdxFactory: (fileName: string) => MockMdxDictionary, mddFactory: (fileName: string) => MockMddDictionary, onFetchDefinition: (fileName: string, keyText: string) => void, onLookupRecord: (fileName: string, keyText: string) => void}} */
 const mockState = {
     /**
      * @param {string} fileName
@@ -51,6 +51,8 @@ const mockState = {
     mddFactory(_fileName) {
         return [];
     },
+    onFetchDefinition(_fileName, _keyText) {},
+    onLookupRecord(_fileName, _keyText) {},
 };
 
 vi.mock('../ext/js/dictionary/mdx/vendor/js-mdict/mdx.js', () => ({
@@ -59,6 +61,7 @@ vi.mock('../ext/js/dictionary/mdx/vendor/js-mdict/mdx.js', () => ({
          * @param {string} fileName
          */
         constructor(fileName) {
+            this._fileName = fileName;
             const {header, entries} = mockState.mdxFactory(fileName);
             this.header = header;
             this.keywordList = entries.map(({keyText}) => ({keyText}));
@@ -70,6 +73,7 @@ vi.mock('../ext/js/dictionary/mdx/vendor/js-mdict/mdx.js', () => ({
          * @returns {{definition: string}}
          */
         fetch_definition(item) {
+            mockState.onFetchDefinition(this._fileName, item.keyText);
             return {definition: this._definitions.get(item.keyText) ?? ''};
         }
 
@@ -83,6 +87,7 @@ vi.mock('../ext/js/dictionary/mdx/vendor/js-mdict/mdd.js', () => ({
          * @param {string} fileName
          */
         constructor(fileName) {
+            this._fileName = fileName;
             const entries = mockState.mddFactory(fileName);
             this.keywordList = entries.map(({keyText}) => ({keyText}));
             this._records = new Map(entries.map(({keyText, value}) => [keyText, value]));
@@ -93,6 +98,7 @@ vi.mock('../ext/js/dictionary/mdx/vendor/js-mdict/mdd.js', () => ({
          * @returns {Uint8Array|null}
          */
         lookupRecordByKeyBlock(item) {
+            mockState.onLookupRecord(this._fileName, item.keyText);
             return this._records.get(item.keyText) ?? null;
         }
 
@@ -100,7 +106,7 @@ vi.mock('../ext/js/dictionary/mdx/vendor/js-mdict/mdd.js', () => ({
     },
 }));
 
-const {convertMdxToArchive} = await import('../ext/js/dictionary/mdx/mdx-converter.js');
+const {convertMdxToArchive, createMdxImportData} = await import('../ext/js/dictionary/mdx/mdx-converter.js');
 
 afterEach(() => {
     mockState.mdxFactory = /** @type {(fileName: string) => MockMdxDictionary} */ ((fileName) => ({
@@ -111,6 +117,8 @@ afterEach(() => {
         entries: [],
     }));
     mockState.mddFactory = /** @type {(fileName: string) => MockMddDictionary} */ ((_fileName) => []);
+    mockState.onFetchDefinition = () => {};
+    mockState.onLookupRecord = () => {};
 });
 
 /**
@@ -137,6 +145,11 @@ async function readJson(zip, path) {
 
 describe('convertMdxToArchive', () => {
     test('converts redirects, metadata, structured content, and MDD assets into a Yomitan archive', async () => {
+        /** @type {string[]} */
+        const fetchedDefinitions = [];
+        mockState.onFetchDefinition = (_fileName, keyText) => {
+            fetchedDefinitions.push(keyText);
+        };
         mockState.mdxFactory = () => ({
             header: {
                 Title: 'Mock MDX',
@@ -171,6 +184,7 @@ describe('convertMdxToArchive', () => {
         const stylesCss = await zip.file('styles.css')?.async('text');
 
         expect(result.archiveFileName).toBe('Mock MDX.zip');
+        expect(fetchedDefinitions).toStrictEqual(['Read', 'read']);
         expect(index).toMatchObject({
             title: 'Mock MDX',
             description: 'Mock description',
@@ -196,6 +210,147 @@ describe('convertMdxToArchive', () => {
         expect(stylesCss).toContain('url("mdict-media/images/read.png")');
         expect(await zip.file('mdict-media/audio/read.mp3')?.async('uint8array')).toStrictEqual(Uint8Array.of(1, 2, 3));
         expect(await zip.file('mdict-media/images/read.png')?.async('uint8array')).toStrictEqual(Uint8Array.of(4, 5, 6));
+    });
+
+    test('records direct MDX preparation subphase timings', async () => {
+        mockState.mdxFactory = () => ({
+            header: {
+                Title: 'Timing Fixture',
+                Description: 'Timing description',
+            },
+            entries: [
+                {
+                    keyText: 'Timed',
+                    definition: '<div><img src="images/timed.png"></div>',
+                },
+            ],
+        });
+        mockState.mddFactory = () => [
+            {keyText: 'images/timed.png', value: Uint8Array.of(1, 2, 3)},
+            {keyText: 'styles/extra.css', value: new TextEncoder().encode('.timed{background:url("../images/timed.png")}')},
+        ];
+
+        const {phaseTimings, files} = await createMdxImportData(
+            'timing-fixture.mdx',
+            {enableAudio: false},
+            new Uint8Array([1, 2, 3]),
+            [{name: 'timing-fixture.mdd', bytes: new Uint8Array([9, 9, 9])}],
+        );
+
+        expect(phaseTimings.map(({phase}) => phase)).toStrictEqual([
+            'prepare-mdx:index-mdd',
+            'prepare-mdx:convert-entries',
+            'prepare-mdx:encode-banks',
+            'prepare-mdx:materialize-assets',
+        ]);
+        expect(files.has('styles.css')).toBe(true);
+        expect(files.has('mdict-media/images/timed.png')).toBe(true);
+    });
+
+    test('resolves aliases when the redirect appears before the target and drops unresolved redirects', async () => {
+        mockState.mdxFactory = () => ({
+            header: {
+                Title: 'Redirect Fixture',
+                Description: '',
+            },
+            entries: [
+                {keyText: 'Alias', definition: '@@@LINK=Target'},
+                {keyText: 'MissingAlias', definition: '@@@LINK=MissingTarget'},
+                {keyText: 'Target', definition: '<div>Resolved target</div>'},
+            ],
+        });
+
+        const result = await convertMdxToArchive(
+            'redirect-fixture.mdx',
+            {enableAudio: false},
+            new Uint8Array([1]),
+            [],
+        );
+        const zip = await loadArchive(result.archiveContent);
+        const termBank = /** @type {Array<[string, string, string, string, number, Array<unknown>, number, string]>} */ (await readJson(zip, 'term_bank_1.json'));
+
+        expect(termBank.map(([expression]) => expression)).toStrictEqual(['Target', 'Alias']);
+        expect(termBank[0]?.[5]).toStrictEqual(termBank[1]?.[5]);
+        expect(termBank[0]?.[6]).toBe(termBank[1]?.[6]);
+        expect(termBank.some(([expression]) => expression === 'MissingAlias')).toBe(false);
+    });
+
+    test('uses the first matching MDD asset and skips unreferenced non-CSS assets', async () => {
+        /** @type {string[]} */
+        const lookupKeys = [];
+        mockState.onLookupRecord = (_fileName, keyText) => {
+            lookupKeys.push(keyText);
+        };
+        mockState.mdxFactory = () => ({
+            header: {
+                Title: 'MDD precedence',
+                Description: '',
+            },
+            entries: [
+                {keyText: 'Asset', definition: '<div><img src="images/shared.png"></div>'},
+            ],
+        });
+        mockState.mddFactory = (fileName) => {
+            if (fileName === 'first.mdd') {
+                return [
+                    {keyText: 'images/shared.png', value: Uint8Array.of(1, 2, 3)},
+                    {keyText: 'unused/ignored.bin', value: Uint8Array.of(9, 9, 9)},
+                ];
+            }
+            return [
+                {keyText: 'images/shared.png', value: Uint8Array.of(4, 5, 6)},
+            ];
+        };
+
+        const result = await convertMdxToArchive(
+            'mdd-precedence.mdx',
+            {enableAudio: false},
+            new Uint8Array([1]),
+            [
+                {name: 'first.mdd', bytes: new Uint8Array([1])},
+                {name: 'second.mdd', bytes: new Uint8Array([2])},
+            ],
+        );
+        const zip = await loadArchive(result.archiveContent);
+
+        expect(await zip.file('mdict-media/images/shared.png')?.async('uint8array')).toStrictEqual(Uint8Array.of(1, 2, 3));
+        expect(zip.file('mdict-media/unused/ignored.bin')).toBeNull();
+        expect(lookupKeys).toStrictEqual(['images/shared.png']);
+    });
+
+    test('loads CSS url dependencies from MDD assets lazily', async () => {
+        /** @type {string[]} */
+        const lookupKeys = [];
+        mockState.onLookupRecord = (_fileName, keyText) => {
+            lookupKeys.push(keyText);
+        };
+        mockState.mdxFactory = () => ({
+            header: {
+                Title: 'CSS dependency fixture',
+                Description: '',
+            },
+            entries: [
+                {keyText: 'Styled', definition: '<div class="styled">Styled</div>'},
+            ],
+        });
+        mockState.mddFactory = () => [
+            {keyText: 'styles/extra.css', value: new TextEncoder().encode('.styled{background:url("../images/css-bg.png")}')},
+            {keyText: 'images/css-bg.png', value: Uint8Array.of(7, 8, 9)},
+        ];
+
+        const result = await convertMdxToArchive(
+            'css-dependency.mdx',
+            {enableAudio: false},
+            new Uint8Array([1]),
+            [{name: 'css-dependency.mdd', bytes: new Uint8Array([1])}],
+        );
+        const zip = await loadArchive(result.archiveContent);
+        const stylesCss = await zip.file('styles.css')?.async('text');
+
+        expect(stylesCss).toContain('url("mdict-media/images/css-bg.png")');
+        expect(await zip.file('mdict-media/styles/extra.css')?.async('text')).toContain('background:url("../images/css-bg.png")');
+        expect(await zip.file('mdict-media/images/css-bg.png')?.async('uint8array')).toStrictEqual(Uint8Array.of(7, 8, 9));
+        expect(lookupKeys).toStrictEqual(['styles/extra.css', 'images/css-bg.png']);
     });
 
     test('uses file-name fallback metadata and respects explicit overrides', async () => {


### PR DESCRIPTION
## Summary
- speed up direct MDX preparation by indexing MDD resources lazily and materializing only referenced non-CSS assets
- expose detailed prepare-mdx subphase timings and track throttled progress message counts in worker debug output
- keep the existing settings UI unchanged while preserving MDX import behavior with new redirect, CSS dependency, and throttled progress coverage

## Testing
- npx vitest run test/mdx-converter.test.js test/dictionary-worker-handler.test.js test/mdx-import-flow.test.js test/dictionary-import-controller.test.js test/mdx-client.test.js
- npm run test:ts
- npm run test:build
- node ./dev/bin/run-playwright.js test integration.spec.js --project=chromium --workers=1 --reporter=line --grep MDX