### PR TITLE
Add editable dictionary metadata

### DIFF
--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -30,6 +30,7 @@ import {log} from '../core/log.js';
 import {isObjectNotArray} from '../core/object-utilities.js';
 import {reportDiagnostics} from '../core/diagnostics-reporter.js';
 import {safePerformance} from '../core/safe-performance.js';
+import {toError} from '../core/to-error.js';
 import {clone, deferPromise, promiseTimeout} from '../core/utilities.js';
 import {generateAnkiNoteMediaFileName, INVALID_NOTE_ID, isNoteDataValid} from '../data/anki-util.js';
 import {getKebabCase} from '../data/anki-template-util.js';
@@ -58,6 +59,23 @@ const DICTIONARY_AUTO_UPDATE_STATE_STORAGE_KEY = 'manabitanDictionaryAutoUpdateS
 const DICTIONARY_AUTO_UPDATE_ALARM_NAME = 'manabitanDictionaryAutoUpdateHourly';
 const DICTIONARY_AUTO_UPDATE_INTERVAL_MS = 60 * 60 * 1000;
 const SCAN_LENGTH_INFLECTION_BUFFER = 8;
+
+/**
+ * @param {string} value
+ * @returns {string|undefined}
+ */
+function normalizeOptionalDictionaryMetadataText(value) {
+    const normalized = value.trim();
+    return normalized.length > 0 ? normalized : void 0;
+}
+
+/**
+ * @param {Error} error
+ * @param {string} message
+ */
+function appendErrorMessage(error, message) {
+    error.message = `${error.message}; ${message}`;
+}
 
 /**
  * @param {string} previousText
@@ -219,6 +237,7 @@ export class Backend {
             ['getDefaultAnkiFieldTemplates', this._onApiGetDefaultAnkiFieldTemplates.bind(this)],
             ['getDictionaryInfo',            this._onApiGetDictionaryInfo.bind(this)],
             ['deleteDictionaryByTitle',      this._onApiDeleteDictionaryByTitle.bind(this)],
+            ['updateDictionaryMetadata',     this._onApiUpdateDictionaryMetadata.bind(this)],
             ['getDictionaryCounts',          this._onApiGetDictionaryCounts.bind(this)],
             ['checkDictionaryUpdates',       this._onApiCheckDictionaryUpdates.bind(this)],
             ['updateDictionaryByTitle',      this._onApiUpdateDictionaryByTitle.bind(this)],
@@ -1249,6 +1268,11 @@ export class Backend {
             await this._ensureDictionaryDatabaseReady({allowDuringMutation: true});
             await this._dictionaryDatabase.deleteDictionary(dictionaryTitle, 1000, () => {});
         });
+    }
+
+    /** @type {import('api').ApiHandler<'updateDictionaryMetadata'>} */
+    async _onApiUpdateDictionaryMetadata({dictionaryTitle, title, url, description}) {
+        return await this._updateDictionaryMetadata(dictionaryTitle, title, url, description);
     }
 
     /** @type {import('api').ApiHandler<'getDictionaryCounts'>} */
@@ -3602,10 +3626,14 @@ export class Backend {
                 archiveContent.buffer.slice(archiveContent.byteOffset, archiveContent.byteOffset + archiveContent.byteLength),
                 this._createDictionaryImportDetails(),
             );
-            const importedSummary = importResult.result;
-            if (importedSummary === null) {
+            const rawImportedSummary = importResult.result;
+            if (rawImportedSummary === null) {
                 const message = importResult.errors.map((error) => error.message).join('; ') || 'Dictionary import failed';
                 throw new Error(message);
+            }
+            const importedSummary = this._applyDictionaryMetadataOverrides(rawImportedSummary, dictionary);
+            if (importedSummary !== rawImportedSummary) {
+                await this._dictionaryDatabase.updateDictionaryMetadata(rawImportedSummary.title, importedSummary);
             }
 
             await this._applyImportedDictionarySettings(dictionary, importedSummary, updateContext);
@@ -3633,6 +3661,198 @@ export class Backend {
             await this._pruneStaleDictionaryAutoUpdates();
         }
         return {dictionaryTitle: dictionary.title, status: 'skipped', latestRevision, error: failureMessage};
+    }
+
+    /**
+     * @param {import('dictionary-importer').Summary} previousSummary
+     * @param {string} title
+     * @param {string|undefined} url
+     * @param {string|undefined} description
+     * @returns {import('dictionary-importer').Summary}
+     */
+    _createEditedDictionarySummary(previousSummary, title, url, description) {
+        /** @type {import('dictionary-importer').Summary} */
+        const nextSummary = {
+            ...previousSummary,
+            title,
+        };
+        if (typeof url === 'string') {
+            nextSummary.url = url;
+        } else {
+            delete nextSummary.url;
+        }
+        if (typeof description === 'string') {
+            nextSummary.description = description;
+        } else {
+            delete nextSummary.description;
+        }
+
+        const previousMetadataOverrides = isObjectNotArray(previousSummary.metadataOverrides) ? previousSummary.metadataOverrides : null;
+        /** @type {import('dictionary-importer').SummaryMetadataOverrides} */
+        const metadataOverrides = {};
+        let hasMetadataOverrides = false;
+        if (title !== previousSummary.title || typeof previousMetadataOverrides?.title === 'string') {
+            metadataOverrides.title = title;
+            hasMetadataOverrides = true;
+        }
+        if (
+            url !== previousSummary.url ||
+            (previousMetadataOverrides !== null && Object.prototype.hasOwnProperty.call(previousMetadataOverrides, 'url'))
+        ) {
+            metadataOverrides.url = typeof url === 'string' ? url : null;
+            hasMetadataOverrides = true;
+        }
+        if (
+            description !== previousSummary.description ||
+            (previousMetadataOverrides !== null && Object.prototype.hasOwnProperty.call(previousMetadataOverrides, 'description'))
+        ) {
+            metadataOverrides.description = typeof description === 'string' ? description : null;
+            hasMetadataOverrides = true;
+        }
+        if (hasMetadataOverrides) {
+            nextSummary.metadataOverrides = metadataOverrides;
+        } else {
+            delete nextSummary.metadataOverrides;
+        }
+
+        return nextSummary;
+    }
+
+    /**
+     * @param {import('dictionary-importer').Summary} summary
+     * @param {import('dictionary-importer').Summary} previousSummary
+     * @returns {import('dictionary-importer').Summary}
+     */
+    _applyDictionaryMetadataOverrides(summary, previousSummary) {
+        const previousMetadataOverrides = isObjectNotArray(previousSummary.metadataOverrides) ? previousSummary.metadataOverrides : null;
+        if (previousMetadataOverrides === null) {
+            return summary;
+        }
+
+        /** @type {import('dictionary-importer').SummaryMetadataOverrides} */
+        const metadataOverrides = {};
+        let hasMetadataOverrides = false;
+        /** @type {import('dictionary-importer').Summary} */
+        const nextSummary = {
+            ...summary,
+        };
+
+        const titleOverride = typeof previousMetadataOverrides.title === 'string' ? previousMetadataOverrides.title.trim() : '';
+        if (titleOverride.length > 0) {
+            nextSummary.title = titleOverride;
+            metadataOverrides.title = titleOverride;
+            hasMetadataOverrides = true;
+        }
+        if (Object.prototype.hasOwnProperty.call(previousMetadataOverrides, 'url')) {
+            const urlOverride = typeof previousMetadataOverrides.url === 'string' ?
+                normalizeOptionalDictionaryMetadataText(previousMetadataOverrides.url) :
+                void 0;
+            if (typeof urlOverride === 'string') {
+                nextSummary.url = urlOverride;
+                metadataOverrides.url = urlOverride;
+            } else {
+                delete nextSummary.url;
+                metadataOverrides.url = null;
+            }
+            hasMetadataOverrides = true;
+        }
+        if (Object.prototype.hasOwnProperty.call(previousMetadataOverrides, 'description')) {
+            const descriptionOverride = typeof previousMetadataOverrides.description === 'string' ?
+                normalizeOptionalDictionaryMetadataText(previousMetadataOverrides.description) :
+                void 0;
+            if (typeof descriptionOverride === 'string') {
+                nextSummary.description = descriptionOverride;
+                metadataOverrides.description = descriptionOverride;
+            } else {
+                delete nextSummary.description;
+                metadataOverrides.description = null;
+            }
+            hasMetadataOverrides = true;
+        }
+
+        if (!hasMetadataOverrides) {
+            return summary;
+        }
+        nextSummary.metadataOverrides = metadataOverrides;
+        return nextSummary;
+    }
+
+    /**
+     * @param {string} dictionaryTitle
+     * @param {string} title
+     * @param {string} url
+     * @param {string} description
+     * @returns {Promise<import('dictionary-importer').Summary>}
+     */
+    async _updateDictionaryMetadata(dictionaryTitle, title, url, description) {
+        const normalizedTitle = title.trim();
+        if (normalizedTitle.length === 0) {
+            throw new Error('Dictionary name cannot be empty');
+        }
+
+        /** @type {import('dictionary-importer').Summary|null} */
+        let updatedSummary = null;
+        await this._runWithDictionaryMutationLock(async () => {
+            await this._ensureDictionaryDatabaseReady({allowDuringMutation: true});
+            const dictionaries = await this._dictionaryDatabase.getDictionaryInfo();
+            const previousSummary = dictionaries.find((dictionary) => dictionary.title === dictionaryTitle);
+            if (typeof previousSummary === 'undefined') {
+                throw new Error(`Dictionary not found: ${dictionaryTitle}`);
+            }
+
+            if (
+                normalizedTitle !== previousSummary.title &&
+                dictionaries.some((dictionary) => dictionary.title === normalizedTitle)
+            ) {
+                throw new Error(`Dictionary already exists: ${normalizedTitle}`);
+            }
+
+            const normalizedUrl = normalizeOptionalDictionaryMetadataText(url);
+            const normalizedDescription = normalizeOptionalDictionaryMetadataText(description);
+            const nextSummary = this._createEditedDictionarySummary(previousSummary, normalizedTitle, normalizedUrl, normalizedDescription);
+            const titleChanged = nextSummary.title !== previousSummary.title;
+            const updateContext = titleChanged ? this._captureDictionaryUpdateSettings(previousSummary.title) : null;
+            const previousOptions = titleChanged && this._options !== null ? clone(this._options) : null;
+
+            let databaseUpdated = false;
+            try {
+                await this._dictionaryDatabase.updateDictionaryMetadata(previousSummary.title, nextSummary);
+                databaseUpdated = true;
+                if (updateContext !== null) {
+                    await this._applyImportedDictionarySettings(previousSummary, nextSummary, updateContext);
+                }
+            } catch (e) {
+                const error = toError(e);
+                let databaseRolledBack = !databaseUpdated;
+                if (databaseUpdated) {
+                    try {
+                        await this._dictionaryDatabase.updateDictionaryMetadata(nextSummary.title, previousSummary);
+                        databaseRolledBack = true;
+                    } catch (rollbackError) {
+                        appendErrorMessage(error, `failed to rollback dictionary metadata update: ${toError(rollbackError).message}`);
+                    }
+                }
+                if (databaseRolledBack && previousOptions !== null) {
+                    try {
+                        this._applyOptionsSnapshot(previousOptions, 'background');
+                    } catch (restoreError) {
+                        appendErrorMessage(error, `failed to restore in-memory options after metadata update error: ${toError(restoreError).message}`);
+                    }
+                    try {
+                        await this._optionsUtil.save(previousOptions);
+                    } catch (restoreError) {
+                        appendErrorMessage(error, `failed to restore persisted options after metadata update error: ${toError(restoreError).message}`);
+                    }
+                }
+                throw error;
+            }
+            updatedSummary = nextSummary;
+        });
+        await this._handleDatabaseUpdated('dictionary', 'edit');
+        if (updatedSummary === null) {
+            throw new Error('Dictionary metadata update did not complete');
+        }
+        return updatedSummary;
     }
 
     /**
@@ -3946,9 +4166,18 @@ export class Backend {
      * @param {string} source
      */
     async _saveOptions(source) {
-        this._clearProfileConditionsSchemaCache();
         const options = this._getOptionsFull(false);
         await this._optionsUtil.save(options);
+        this._applyOptionsSnapshot(options, source);
+    }
+
+    /**
+     * @param {import('settings').Options} options
+     * @param {string} source
+     */
+    _applyOptionsSnapshot(options, source) {
+        this._clearProfileConditionsSchemaCache();
+        this._options = options;
         this._applyOptions(source);
     }
 

--- a/ext/js/background/offscreen-dictionary-worker.js
+++ b/ext/js/background/offscreen-dictionary-worker.js
@@ -153,6 +153,14 @@ class OffscreenDictionaryWorkerHandler {
                 await this._ensureDatabasePrepared();
                 await this._dictionaryDatabase.deleteDictionary(/** @type {string} */ (params.dictionaryTitle ?? ''), 1000, () => {});
                 return;
+            case 'updateDictionaryMetadataOffscreen':
+                this._assertDatabaseAvailable(action);
+                await this._ensureDatabasePrepared();
+                await this._dictionaryDatabase.updateDictionaryMetadata(
+                    /** @type {string} */ (params.dictionaryTitle ?? ''),
+                    /** @type {import('dictionary-importer').Summary} */ (params.summary ?? {}),
+                );
+                return;
             case 'getDictionaryCountsOffscreen':
                 this._assertDatabaseAvailable(action);
                 await this._ensureDatabasePrepared();

--- a/ext/js/background/offscreen-proxy.js
+++ b/ext/js/background/offscreen-proxy.js
@@ -244,6 +244,15 @@ export class DictionaryDatabaseProxy {
     }
 
     /**
+     * @param {string} dictionaryTitle
+     * @param {import('dictionary-importer').Summary} summary
+     * @returns {Promise<void>}
+     */
+    async updateDictionaryMetadata(dictionaryTitle, summary) {
+        await this._offscreen.sendMessagePromise({action: 'updateDictionaryMetadataOffscreen', params: {dictionaryTitle, summary}});
+    }
+
+    /**
      * @param {string[]} dictionaryNames
      * @param {boolean} getTotal
      * @returns {Promise<import('dictionary-database').DictionaryCounts>}

--- a/ext/js/background/offscreen.js
+++ b/ext/js/background/offscreen.js
@@ -55,6 +55,7 @@ export class Offscreen {
             ['getDictionaryInfoOffscreen',     this._getDictionaryInfoHandler.bind(this)],
             ['getMaxHeadwordLengthOffscreen',  this._getMaxHeadwordLengthHandler.bind(this)],
             ['deleteDictionaryOffscreen',      this._deleteDictionaryHandler.bind(this)],
+            ['updateDictionaryMetadataOffscreen', this._updateDictionaryMetadataHandler.bind(this)],
             ['getDictionaryCountsOffscreen',   this._getDictionaryCountsHandler.bind(this)],
             ['importDictionaryArchiveOffscreen', this._importDictionaryArchiveHandler.bind(this)],
             ['databasePurgeOffscreen',         this._purgeDatabaseHandler.bind(this)],
@@ -221,6 +222,11 @@ export class Offscreen {
     /** @type {import('offscreen').ApiHandler<'deleteDictionaryOffscreen'>} */
     async _deleteDictionaryHandler({dictionaryTitle}) {
         await this._invokeDictionaryWorker('deleteDictionaryOffscreen', {dictionaryTitle});
+    }
+
+    /** @type {import('offscreen').ApiHandler<'updateDictionaryMetadataOffscreen'>} */
+    async _updateDictionaryMetadataHandler({dictionaryTitle, summary}) {
+        await this._invokeDictionaryWorker('updateDictionaryMetadataOffscreen', {dictionaryTitle, summary});
     }
 
     /** @type {import('offscreen').ApiHandler<'getDictionaryCountsOffscreen'>} */

--- a/ext/js/comm/api.js
+++ b/ext/js/comm/api.js
@@ -258,6 +258,17 @@ export class API {
     }
 
     /**
+     * @param {import('api').ApiParam<'updateDictionaryMetadata', 'dictionaryTitle'>} dictionaryTitle
+     * @param {import('api').ApiParam<'updateDictionaryMetadata', 'title'>} title
+     * @param {import('api').ApiParam<'updateDictionaryMetadata', 'url'>} url
+     * @param {import('api').ApiParam<'updateDictionaryMetadata', 'description'>} description
+     * @returns {Promise<import('api').ApiReturn<'updateDictionaryMetadata'>>}
+     */
+    updateDictionaryMetadata(dictionaryTitle, title, url, description) {
+        return this._invoke('updateDictionaryMetadata', {dictionaryTitle, title, url, description});
+    }
+
+    /**
      * @param {import('api').ApiParam<'getDictionaryCounts', 'dictionaryNames'>} dictionaryNames
      * @param {import('api').ApiParam<'getDictionaryCounts', 'getTotal'>} getTotal
      * @returns {Promise<import('api').ApiReturn<'getDictionaryCounts'>>}

--- a/ext/js/dictionary/dictionary-database.js
+++ b/ext/js/dictionary/dictionary-database.js
@@ -2198,6 +2198,88 @@ export class DictionaryDatabase {
     }
 
     /**
+     * @param {string} dictionaryTitle
+     * @param {import('dictionary-importer').Summary} summary
+     * @returns {Promise<void>}
+     */
+    async updateDictionaryMetadata(dictionaryTitle, summary) {
+        const db = this._requireDb();
+        const nextTitle = this._asString(summary.title).trim();
+        if (nextTitle.length === 0) {
+            throw new Error('Dictionary title cannot be empty');
+        }
+
+        const currentTitle = this._asString(dictionaryTitle);
+        const row = db.selectObject(
+            'SELECT id FROM dictionaries WHERE title = $title LIMIT 1',
+            {$title: currentTitle},
+        );
+        if (typeof row === 'undefined') {
+            throw new Error(`Dictionary not found: ${currentTitle}`);
+        }
+        if (
+            nextTitle !== currentTitle &&
+            typeof db.selectValue(
+                'SELECT 1 FROM dictionaries WHERE title = $title LIMIT 1',
+                {$title: nextTitle},
+            ) !== 'undefined'
+        ) {
+            throw new Error(`Dictionary already exists: ${nextTitle}`);
+        }
+
+        /** @type {import('dictionary-importer').Summary} */
+        const nextSummary = {
+            ...summary,
+            title: nextTitle,
+        };
+
+        await this._beginImmediateTransaction(db);
+        let termRecordStoreRenamed = false;
+        try {
+            if (nextTitle !== currentTitle) {
+                await this._termRecordStore.renameDictionary(currentTitle, nextTitle);
+                termRecordStoreRenamed = true;
+                for (const table of ['kanji', 'kanjiMeta', 'termMeta', 'tagMeta', 'media', 'sharedGlossaryArtifacts']) {
+                    db.exec({
+                        sql: `UPDATE ${table} SET dictionary = $nextTitle WHERE dictionary = $currentTitle`,
+                        bind: {$nextTitle: nextTitle, $currentTitle: currentTitle},
+                    });
+                }
+            }
+            db.exec({
+                sql: 'UPDATE dictionaries SET title = $title, version = $version, summaryJson = $summaryJson WHERE id = $id',
+                bind: {
+                    $id: this._asNumber(row.id, -1),
+                    $title: nextTitle,
+                    $version: nextSummary.version,
+                    $summaryJson: JSON.stringify(nextSummary),
+                },
+            });
+            db.exec('COMMIT');
+        } catch (e) {
+            const error = toError(e);
+            try { db.exec('ROLLBACK'); } catch (_) { /* NOP */ }
+            if (termRecordStoreRenamed) {
+                try {
+                    await this._termRecordStore.renameDictionary(nextTitle, currentTitle);
+                } catch (rollbackError) {
+                    error.message = `${error.message}; failed to rollback term-record rename: ${toError(rollbackError).message}`;
+                }
+            }
+            throw error;
+        }
+
+        this._termEntryContentCache.clear();
+        this._termEntryContentIdByHash.clear();
+        this._clearTermEntryContentMetaCaches();
+        this._termExactPresenceCache.clear();
+        this._termPrefixNegativeCache.clear();
+        this._directTermIndexByDictionary.clear();
+        this._sharedGlossaryArtifactMetaByDictionary.clear();
+        this._sharedGlossaryArtifactInflatedByDictionary.clear();
+    }
+
+    /**
      * @template {import('dictionary-database').ObjectStoreName} T
      * @param {T} objectStoreName
      * @param {import('dictionary-database').ObjectStoreData<T>[]} items

--- a/ext/js/dictionary/term-record-opfs-store.js
+++ b/ext/js/dictionary/term-record-opfs-store.js
@@ -643,6 +643,36 @@ export class TermRecordOpfsStore {
     }
 
     /**
+     * @param {string} currentDictionaryName
+     * @param {string} nextDictionaryName
+     * @returns {Promise<void>}
+     */
+    async renameDictionary(currentDictionaryName, nextDictionaryName) {
+        if (currentDictionaryName === nextDictionaryName) {
+            return;
+        }
+
+        let renamed = false;
+        for (const record of this._recordsById.values()) {
+            if (record.dictionary !== currentDictionaryName) { continue; }
+            record.dictionary = nextDictionaryName;
+            renamed = true;
+        }
+
+        const currentShardFileName = this._getShardFileName(currentDictionaryName);
+        if (!renamed && !this._shardStateByFileName.has(currentShardFileName)) {
+            return;
+        }
+
+        this._indexByDictionary.delete(currentDictionaryName);
+        this._indexByDictionary.delete(nextDictionaryName);
+        if (this._deferIndexBuild) {
+            this._indexDirty = true;
+        }
+        await this._rewriteAllShardsFromMemory();
+    }
+
+    /**
      * @param {Iterable<number>} ids
      * @returns {Map<number, TermRecord>}
      */

--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -211,9 +211,10 @@ class DictionaryEntry {
     _onMenuOpen(e) {
         const bodyNode = e.detail.menu.bodyNode;
         const count = this._dictionaryController.dictionaryOptionCount;
+        const mutationDisabled = this._dictionaryController.isDictionaryInTaskQueue(this.dictionaryTitle);
         this._setMenuActionEnabled(bodyNode, 'moveTo', count > 1);
-        const deleteDisabled = this._dictionaryController.isDictionaryInTaskQueue(this.dictionaryTitle);
-        this._setMenuActionEnabled(bodyNode, 'delete', !deleteDisabled);
+        this._setMenuActionEnabled(bodyNode, 'edit', !mutationDisabled);
+        this._setMenuActionEnabled(bodyNode, 'delete', !mutationDisabled);
     }
 
     /**
@@ -226,6 +227,9 @@ class DictionaryEntry {
                 break;
             case 'showDetails':
                 void this._showDetails();
+                break;
+            case 'edit':
+                this._showEditMetadataModal();
                 break;
             case 'moveTo':
                 this._showMoveToModal();
@@ -429,6 +433,30 @@ class DictionaryEntry {
         titleNode.textContent = title;
         input.value = `${this._index + 1}`;
         input.max = `${count}`;
+
+        modal.setVisible(true);
+    }
+
+    /** */
+    _showEditMetadataModal() {
+        const {title, url, description} = this._dictionaryInfo;
+        const modal = this._dictionaryController.modalController.getModal('dictionary-edit-metadata');
+        if (modal === null) { return; }
+        /** @type {HTMLInputElement} */
+        const nameInput = querySelectorNotNull(modal.node, '#dictionary-metadata-name-input');
+        /** @type {HTMLInputElement} */
+        const urlInput = querySelectorNotNull(modal.node, '#dictionary-metadata-url-input');
+        /** @type {HTMLTextAreaElement} */
+        const descriptionInput = querySelectorNotNull(modal.node, '#dictionary-metadata-description-input');
+
+        modal.node.dataset.dictionaryTitle = title;
+        modal.node.dataset.originalTitle = title;
+        modal.node.dataset.originalUrl = url ?? '';
+        modal.node.dataset.originalDescription = description ?? '';
+        nameInput.value = title;
+        urlInput.value = url ?? '';
+        descriptionInput.value = description ?? '';
+        this._dictionaryController.setDictionaryMetadataEditError('');
 
         modal.setVisible(true);
     }
@@ -660,6 +688,10 @@ export class DictionaryController {
         const dictionaryMoveButton = querySelectorNotNull(document, '#dictionary-move-button');
 
         /** @type {HTMLButtonElement} */
+        const dictionaryResetMetadataButton = querySelectorNotNull(document, '#dictionary-reset-metadata-button');
+        /** @type {HTMLButtonElement} */
+        const dictionarySaveMetadataButton = querySelectorNotNull(document, '#dictionary-save-metadata-button');
+        /** @type {HTMLButtonElement} */
         const dictionaryResetAliasButton = querySelectorNotNull(document, '#dictionary-reset-alias-button');
         /** @type {HTMLButtonElement} */
         const dictionarySetAliasButton = querySelectorNotNull(document, '#dictionary-set-alias-button');
@@ -673,6 +705,8 @@ export class DictionaryController {
 
         dictionaryMoveButton.addEventListener('click', this._onDictionaryMoveButtonClick.bind(this), false);
 
+        dictionarySaveMetadataButton.addEventListener('click', this._onDictionarySaveMetadataButtonClick.bind(this), false);
+        dictionaryResetMetadataButton.addEventListener('click', this._onDictionaryResetMetadataButtonClick.bind(this), false);
         dictionarySetAliasButton.addEventListener('click', this._onDictionarySetAliasButtonClick.bind(this), false);
         dictionaryResetAliasButton.addEventListener('click', this._onDictionaryResetAliasButtonClick.bind(this), false);
 
@@ -1140,6 +1174,73 @@ export class DictionaryController {
         if (!Number.isFinite(target) || !Number.isFinite(indexNumber) || indexNumber === target) { return; }
 
         void this.moveDictionaryOptions(indexNumber, target);
+    }
+
+    /** */
+    _onDictionaryResetMetadataButtonClick() {
+        const modal = /** @type {import('./modal.js').Modal} */ (this._modalController.getModal('dictionary-edit-metadata'));
+        /** @type {HTMLInputElement} */
+        const nameInput = querySelectorNotNull(modal.node, '#dictionary-metadata-name-input');
+        /** @type {HTMLInputElement} */
+        const urlInput = querySelectorNotNull(modal.node, '#dictionary-metadata-url-input');
+        /** @type {HTMLTextAreaElement} */
+        const descriptionInput = querySelectorNotNull(modal.node, '#dictionary-metadata-description-input');
+
+        nameInput.value = modal.node.dataset.originalTitle ?? '';
+        urlInput.value = modal.node.dataset.originalUrl ?? '';
+        descriptionInput.value = modal.node.dataset.originalDescription ?? '';
+        this.setDictionaryMetadataEditError('');
+    }
+
+    /** */
+    async _onDictionarySaveMetadataButtonClick() {
+        const modal = /** @type {import('./modal.js').Modal} */ (this._modalController.getModal('dictionary-edit-metadata'));
+        const dictionaryTitle = modal.node.dataset.dictionaryTitle;
+        if (typeof dictionaryTitle !== 'string' || dictionaryTitle.length === 0) { return; }
+
+        /** @type {HTMLInputElement} */
+        const nameInput = querySelectorNotNull(modal.node, '#dictionary-metadata-name-input');
+        /** @type {HTMLInputElement} */
+        const urlInput = querySelectorNotNull(modal.node, '#dictionary-metadata-url-input');
+        /** @type {HTMLTextAreaElement} */
+        const descriptionInput = querySelectorNotNull(modal.node, '#dictionary-metadata-description-input');
+        /** @type {HTMLButtonElement} */
+        const saveButton = querySelectorNotNull(modal.node, '#dictionary-save-metadata-button');
+
+        nameInput.value = nameInput.value.trim();
+        urlInput.value = urlInput.value.trim();
+        if (!nameInput.reportValidity() || !urlInput.reportValidity()) {
+            return;
+        }
+
+        this.setDictionaryMetadataEditError('');
+        saveButton.disabled = true;
+        try {
+            await this._settingsController.application.api.updateDictionaryMetadata(
+                dictionaryTitle,
+                nameInput.value,
+                urlInput.value,
+                descriptionInput.value,
+            );
+            modal.setVisible(false);
+        } catch (e) {
+            const message = e instanceof Error ? e.message : String(e);
+            this.setDictionaryMetadataEditError(message);
+        } finally {
+            saveButton.disabled = false;
+        }
+    }
+
+    /**
+     * @param {string} message
+     */
+    setDictionaryMetadataEditError(message) {
+        const modal = this._modalController.getModal('dictionary-edit-metadata');
+        if (modal === null) { return; }
+        /** @type {HTMLElement} */
+        const errorNode = querySelectorNotNull(modal.node, '#dictionary-edit-metadata-error');
+        errorNode.textContent = message;
+        errorNode.hidden = message.length === 0;
     }
 
     /** */

--- a/ext/js/pages/settings/dictionary-import-controller.js
+++ b/ext/js/pages/settings/dictionary-import-controller.js
@@ -2360,11 +2360,11 @@ export class DictionaryImportController {
             recordLocalPhase,
             async () => {
                 const mdxBytesView = (mdxBytes instanceof Uint8Array ? mdxBytes : new Uint8Array(mdxBytes));
-                const mdxBytesCopyBuffer = mdxBytesView.slice().buffer;
+                const mdxBytesCopyBuffer = new Uint8Array(mdxBytesView).buffer;
 
                 const mddFilesCopy = mddFiles.map(({name, bytes}) => {
                     const bytesView = (bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes));
-                    const bytesCopyBuffer = bytesView.slice().buffer;
+                    const bytesCopyBuffer = new Uint8Array(bytesView).buffer;
                     return {name, bytes: bytesCopyBuffer};
                 });
 

--- a/ext/templates-modals.html
+++ b/ext/templates-modals.html
@@ -310,8 +310,50 @@
         </div>
     </div></div>
 
+    <div id="dictionary-edit-metadata-modal" class="modal" tabindex="-1" role="dialog" hidden><div class="modal-content modal-content-small">
+        <div class="modal-header"><div class="modal-title">Edit Dictionary Metadata</div></div>
+        <div class="modal-body">
+            <div class="settings-item">
+                <div class="settings-item-inner settings-item-inner-wrappable">
+                    <div class="settings-item-left">
+                        <div class="settings-item-label">Name</div>
+                    </div>
+                    <div class="settings-item-right">
+                        <input type="text" id="dictionary-metadata-name-input" required>
+                    </div>
+                </div>
+            </div>
+            <div class="settings-item">
+                <div class="settings-item-inner settings-item-inner-wrappable">
+                    <div class="settings-item-left">
+                        <div class="settings-item-label">URL</div>
+                    </div>
+                    <div class="settings-item-right">
+                        <input type="url" id="dictionary-metadata-url-input" placeholder="https://example.com">
+                    </div>
+                </div>
+            </div>
+            <div class="settings-item">
+                <div class="settings-item-inner settings-item-inner-wrappable">
+                    <div class="settings-item-left">
+                        <div class="settings-item-label">Description</div>
+                    </div>
+                    <div class="settings-item-right">
+                        <textarea id="dictionary-metadata-description-input" rows="5"></textarea>
+                    </div>
+                </div>
+            </div>
+            <div id="dictionary-edit-metadata-error" class="danger-text margin-above" hidden></div>
+        </div>
+        <div class="modal-footer">
+            <button type="button" class="low-emphasis" id="dictionary-reset-metadata-button">Reset</button>
+            <button type="button" class="low-emphasis" data-modal-action="hide">Cancel</button>
+            <button type="button" id="dictionary-save-metadata-button">Save</button>
+        </div>
+    </div></div>
+
     <div id="dictionary-set-alias-modal" class="modal" tabindex="-1" role="dialog" hidden><div class="modal-content modal-content-small">
-        <div class="modal-header"><div class="modal-title">Rename</div></div>
+        <div class="modal-header"><div class="modal-title">Rename Display Name</div></div>
         <div class="modal-body">
             <p>Input the display name for <strong class="dictionary-title"></strong> dictionary:</p>
             <div class="margin-above">

--- a/ext/templates-settings.html
+++ b/ext/templates-settings.html
@@ -103,7 +103,8 @@
 </template>
 <template id="dictionary-menu-template"><div class="popup-menu-container" tabindex="-1" role="dialog"><div class="popup-menu"><div class="popup-menu-body">
     <button type="button" class="popup-menu-item" data-menu-action="showDetails">Details&hellip;</button>
-    <button type="button" class="popup-menu-item" data-menu-action="rename">Rename&hellip;</button>
+    <button type="button" class="popup-menu-item" data-menu-action="edit">Edit metadata&hellip;</button>
+    <button type="button" class="popup-menu-item" data-menu-action="rename">Rename display name&hellip;</button>
     <button type="button" class="popup-menu-item" data-menu-action="moveTo">Move to&hellip;</button>
     <button type="button" class="popup-menu-item" data-menu-action="delete">Delete</button>
 </div></div></div></template>

--- a/test/backend-dictionary-auto-update.test.js
+++ b/test/backend-dictionary-auto-update.test.js
@@ -476,6 +476,7 @@ describe('Backend dictionary auto-update helpers', () => {
             },
         });
 
+        const applyDictionaryMetadataOverrides = vi.fn(getBackendMethod('_applyDictionaryMetadataOverrides'));
         const dictionary = createDictionarySummary({title: 'Custom Title'});
         const archiveContent = new Uint8Array([1, 2, 3, 4]);
         const context = {
@@ -504,6 +505,12 @@ describe('Backend dictionary auto-update helpers', () => {
             _handleDatabaseUpdated: vi.fn(async () => {}),
             _pruneStaleProfileDictionaryOptions: vi.fn(async () => {}),
             _pruneStaleDictionaryAutoUpdates: vi.fn(async () => {}),
+            _applyDictionaryMetadataOverrides(
+                /** @type {import('dictionary-importer').Summary} */ importedSummary,
+                /** @type {import('dictionary-importer').Summary} */ previousSummary,
+            ) {
+                return applyDictionaryMetadataOverrides.call(this, importedSummary, previousSummary);
+            },
         };
         const createDictionaryImportDetails = vi.fn(getBackendMethod('_createDictionaryImportDetails').bind(context));
         Reflect.set(context, '_createDictionaryImportDetails', createDictionaryImportDetails);
@@ -528,6 +535,100 @@ describe('Backend dictionary auto-update helpers', () => {
             dictionary,
             expect.objectContaining({title: 'Custom Title'}),
             expect.any(Object),
+        );
+        expect(context._setDictionaryAutoUpdateError).not.toHaveBeenCalled();
+    });
+
+    test('Dictionary updates preserve stored metadata overrides across re-imports', async () => {
+        vi.stubGlobal('chrome', {
+            runtime: {
+                getManifest: () => ({version: '9.9.9.9'}),
+            },
+        });
+
+        const applyDictionaryMetadataOverrides = getBackendMethod('_applyDictionaryMetadataOverrides');
+        const dictionary = createDictionarySummary({
+            title: 'Custom Title',
+            url: 'https://example.invalid/dictionaries/custom',
+            description: 'Custom description',
+            metadataOverrides: {
+                title: 'Custom Title',
+                url: 'https://example.invalid/dictionaries/custom',
+                description: 'Custom description',
+            },
+        });
+        const archiveContent = new Uint8Array([1, 2, 3, 4]);
+        const updateDictionaryMetadata = vi.fn(async () => {});
+        const context = {
+            _options: {
+                global: {
+                    database: {
+                        prefixWildcardsSupported: true,
+                    },
+                },
+            },
+            _captureDictionaryUpdateSettings: vi.fn(() => ({profilesDictionarySettings: {}, mainDictionaryProfileIds: new Set(), sortFrequencyDictionaryProfileIds: new Set()})),
+            _dictionaryDatabase: {
+                deleteDictionary: vi.fn(async () => {}),
+                updateDictionaryMetadata,
+            },
+            _setDictionaryImportMode: vi.fn(async () => {}),
+            _importDictionaryArchiveHeadless: vi.fn(async () => ({
+                result: createDictionarySummary({
+                    title: 'Archive Title',
+                    revision: '2026.03',
+                    url: 'https://example.invalid/dictionaries/archive',
+                    description: 'Archive description',
+                }),
+                errors: [],
+            })),
+            _applyImportedDictionarySettings: vi.fn(async () => {}),
+            _updateDictionaryAutoUpdateStateAfterSuccess: vi.fn(async () => {}),
+            _setDictionaryAutoUpdateError: vi.fn(async () => {}),
+            _handleDatabaseUpdated: vi.fn(async () => {}),
+            _pruneStaleProfileDictionaryOptions: vi.fn(async () => {}),
+            _pruneStaleDictionaryAutoUpdates: vi.fn(async () => {}),
+            _applyDictionaryMetadataOverrides(
+                /** @type {import('dictionary-importer').Summary} */ importedSummary,
+                /** @type {import('dictionary-importer').Summary} */ previousSummary,
+            ) {
+                return applyDictionaryMetadataOverrides.call(this, importedSummary, previousSummary);
+            },
+        };
+        const createDictionaryImportDetails = vi.fn(getBackendMethod('_createDictionaryImportDetails').bind(context));
+        Reflect.set(context, '_createDictionaryImportDetails', createDictionaryImportDetails);
+
+        const result = await getBackendMethod('_performDictionaryUpdate').call(context, dictionary, archiveContent, '2026.03');
+
+        expect(result).toStrictEqual({
+            dictionaryTitle: 'Custom Title',
+            status: 'updated',
+            latestRevision: '2026.03',
+            error: null,
+        });
+        expect(updateDictionaryMetadata).toHaveBeenCalledTimes(1);
+        expect(updateDictionaryMetadata).toHaveBeenCalledWith('Archive Title', expect.objectContaining({
+            title: 'Custom Title',
+            url: 'https://example.invalid/dictionaries/custom',
+            description: 'Custom description',
+            metadataOverrides: {
+                title: 'Custom Title',
+                url: 'https://example.invalid/dictionaries/custom',
+                description: 'Custom description',
+            },
+        }));
+        expect(context._applyImportedDictionarySettings).toHaveBeenCalledWith(
+            dictionary,
+            expect.objectContaining({
+                title: 'Custom Title',
+                url: 'https://example.invalid/dictionaries/custom',
+                description: 'Custom description',
+            }),
+            expect.any(Object),
+        );
+        expect(context._updateDictionaryAutoUpdateStateAfterSuccess).toHaveBeenCalledWith(
+            dictionary,
+            expect.objectContaining({title: 'Custom Title'}),
         );
         expect(context._setDictionaryAutoUpdateError).not.toHaveBeenCalled();
     });
@@ -646,5 +747,280 @@ describe('Backend dictionary auto-update helpers', () => {
         expect(context._options.global.dictionaryAutoUpdates).toStrictEqual(['https://example.invalid/new-index.json']);
         expect(saveOptions).toHaveBeenCalledTimes(1);
         expect(saveOptions).toHaveBeenCalledWith('background');
+    });
+
+    test('Dictionary metadata edits rename settings-backed references and trim optional fields', async () => {
+        const saveOptions = vi.fn(async () => {});
+        const updateDictionaryMetadata = vi.fn(async () => {});
+        const handleDatabaseUpdated = vi.fn(async () => {});
+        const captureDictionaryUpdateSettings = getBackendMethod('_captureDictionaryUpdateSettings');
+        const applyImportedDictionarySettings = getBackendMethod('_applyImportedDictionarySettings');
+        const createDefaultDictionarySettings = getBackendMethod('_createDefaultDictionarySettings');
+        const createEditedDictionarySummary = getBackendMethod('_createEditedDictionarySummary');
+        const previousSummary = createDictionarySummary({
+            title: 'Old Dictionary',
+            styles: 'old-style',
+        });
+        const context = {
+            _options: {
+                profileCurrent: 0,
+                profiles: [
+                    {
+                        id: 'profile-1',
+                        options: {
+                            dictionaries: [
+                                {
+                                    name: 'Old Dictionary',
+                                    alias: 'Old Dictionary',
+                                    enabled: true,
+                                    allowSecondarySearches: false,
+                                    definitionsCollapsible: 'not-collapsible',
+                                    partsOfSpeechFilter: true,
+                                    useDeinflections: true,
+                                    styles: 'old-style',
+                                },
+                            ],
+                            general: {
+                                mainDictionary: 'Old Dictionary',
+                                sortFrequencyDictionary: 'Old Dictionary',
+                            },
+                            anki: {
+                                cardFormats: [
+                                    {
+                                        fields: {
+                                            expression: {
+                                                value: 'old-dictionary-term',
+                                            },
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                ],
+                global: {
+                    dictionaryAutoUpdates: [],
+                },
+            },
+            _dictionaryDatabase: {
+                getDictionaryInfo: async () => [previousSummary],
+                dictionaryExists: async () => false,
+                updateDictionaryMetadata,
+            },
+            _runWithDictionaryMutationLock: async (
+                /** @type {() => Promise<void>} */ callback,
+                _options = {},
+            ) => { await callback(); },
+            _ensureDictionaryDatabaseReady: async () => {},
+            _handleDatabaseUpdated: handleDatabaseUpdated,
+            _saveOptions: saveOptions,
+            _captureDictionaryUpdateSettings(
+                /** @type {string} */ dictionaryTitle,
+            ) {
+                return captureDictionaryUpdateSettings.call(this, dictionaryTitle);
+            },
+            _applyImportedDictionarySettings(
+                /** @type {import('dictionary-importer').Summary} */ previous,
+                /** @type {import('dictionary-importer').Summary} */ next,
+                /** @type {unknown} */ updateContext,
+            ) {
+                return applyImportedDictionarySettings.call(this, previous, next, updateContext);
+            },
+            _createDefaultDictionarySettings(
+                /** @type {string} */ name,
+                /** @type {boolean} */ enabled,
+                /** @type {string} */ styles,
+            ) {
+                return createDefaultDictionarySettings.call(this, name, enabled, styles);
+            },
+            _createEditedDictionarySummary(
+                /** @type {import('dictionary-importer').Summary} */ previous,
+                /** @type {string} */ nextTitle,
+                /** @type {string|undefined} */ nextUrl,
+                /** @type {string|undefined} */ nextDescription,
+            ) {
+                return createEditedDictionarySummary.call(this, previous, nextTitle, nextUrl, nextDescription);
+            },
+        };
+
+        const result = await getBackendMethod('_updateDictionaryMetadata').call(
+            context,
+            'Old Dictionary',
+            'New Dictionary',
+            ' https://example.invalid/dictionaries/new ',
+            '  Updated description  ',
+        );
+
+        expect(updateDictionaryMetadata).toHaveBeenCalledTimes(1);
+        expect(updateDictionaryMetadata).toHaveBeenCalledWith('Old Dictionary', expect.objectContaining({
+            title: 'New Dictionary',
+            url: 'https://example.invalid/dictionaries/new',
+            description: 'Updated description',
+            metadataOverrides: {
+                title: 'New Dictionary',
+                url: 'https://example.invalid/dictionaries/new',
+                description: 'Updated description',
+            },
+        }));
+        expect(result).toEqual(expect.objectContaining({
+            title: 'New Dictionary',
+            url: 'https://example.invalid/dictionaries/new',
+            description: 'Updated description',
+            metadataOverrides: {
+                title: 'New Dictionary',
+                url: 'https://example.invalid/dictionaries/new',
+                description: 'Updated description',
+            },
+        }));
+        const profile = context._options.profiles[0];
+        expect(profile.options.dictionaries).toStrictEqual([
+            {
+                name: 'New Dictionary',
+                alias: 'New Dictionary',
+                enabled: true,
+                allowSecondarySearches: false,
+                definitionsCollapsible: 'not-collapsible',
+                partsOfSpeechFilter: true,
+                useDeinflections: true,
+                styles: 'old-style',
+            },
+        ]);
+        expect(profile.options.general.mainDictionary).toBe('New Dictionary');
+        expect(profile.options.general.sortFrequencyDictionary).toBe('New Dictionary');
+        expect(profile.options.anki.cardFormats[0].fields.expression.value).toBe('new-dictionary-term');
+        expect(saveOptions).toHaveBeenCalledTimes(1);
+        expect(saveOptions).toHaveBeenCalledWith('background');
+        expect(handleDatabaseUpdated).toHaveBeenCalledTimes(1);
+        expect(handleDatabaseUpdated).toHaveBeenCalledWith('dictionary', 'edit');
+    });
+
+    test('Dictionary metadata edits roll back the rename when saving migrated settings fails', async () => {
+        const updateDictionaryMetadata = vi.fn(async () => {});
+        const saveOptions = vi.fn(async () => {
+            throw new Error('save failed');
+        });
+        const optionsUtilSave = vi.fn(async () => {});
+        const clearProfileConditionsSchemaCache = vi.fn(() => {});
+        const applyOptions = vi.fn(() => {});
+        const captureDictionaryUpdateSettings = getBackendMethod('_captureDictionaryUpdateSettings');
+        const applyImportedDictionarySettings = getBackendMethod('_applyImportedDictionarySettings');
+        const applyOptionsSnapshot = getBackendMethod('_applyOptionsSnapshot');
+        const createDefaultDictionarySettings = getBackendMethod('_createDefaultDictionarySettings');
+        const createEditedDictionarySummary = getBackendMethod('_createEditedDictionarySummary');
+        const previousSummary = createDictionarySummary({
+            title: 'Old Dictionary',
+            styles: 'old-style',
+        });
+        const context = {
+            _options: {
+                profileCurrent: 0,
+                profiles: [
+                    {
+                        id: 'profile-1',
+                        options: {
+                            dictionaries: [
+                                {
+                                    name: 'Old Dictionary',
+                                    alias: 'Old Dictionary',
+                                    enabled: true,
+                                    allowSecondarySearches: false,
+                                    definitionsCollapsible: 'not-collapsible',
+                                    partsOfSpeechFilter: true,
+                                    useDeinflections: true,
+                                    styles: 'old-style',
+                                },
+                            ],
+                            general: {
+                                mainDictionary: 'Old Dictionary',
+                                sortFrequencyDictionary: 'Old Dictionary',
+                            },
+                            anki: {
+                                cardFormats: [
+                                    {
+                                        fields: {
+                                            expression: {
+                                                value: 'old-dictionary-term',
+                                            },
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                ],
+                global: {
+                    dictionaryAutoUpdates: [],
+                },
+            },
+            _dictionaryDatabase: {
+                getDictionaryInfo: async () => [previousSummary],
+                updateDictionaryMetadata,
+            },
+            _optionsUtil: {
+                save: optionsUtilSave,
+            },
+            _runWithDictionaryMutationLock: async (
+                /** @type {() => Promise<void>} */ callback,
+                _options = {},
+            ) => { await callback(); },
+            _ensureDictionaryDatabaseReady: async () => {},
+            _handleDatabaseUpdated: vi.fn(async () => {}),
+            _clearProfileConditionsSchemaCache: clearProfileConditionsSchemaCache,
+            _applyOptions: applyOptions,
+            _saveOptions: saveOptions,
+            _captureDictionaryUpdateSettings(
+                /** @type {string} */ dictionaryTitle,
+            ) {
+                return captureDictionaryUpdateSettings.call(this, dictionaryTitle);
+            },
+            _applyImportedDictionarySettings(
+                /** @type {import('dictionary-importer').Summary} */ previous,
+                /** @type {import('dictionary-importer').Summary} */ next,
+                /** @type {unknown} */ updateContext,
+            ) {
+                return applyImportedDictionarySettings.call(this, previous, next, updateContext);
+            },
+            _createDefaultDictionarySettings(
+                /** @type {string} */ name,
+                /** @type {boolean} */ enabled,
+                /** @type {string} */ styles,
+            ) {
+                return createDefaultDictionarySettings.call(this, name, enabled, styles);
+            },
+            _createEditedDictionarySummary(
+                /** @type {import('dictionary-importer').Summary} */ previous,
+                /** @type {string} */ nextTitle,
+                /** @type {string|undefined} */ nextUrl,
+                /** @type {string|undefined} */ nextDescription,
+            ) {
+                return createEditedDictionarySummary.call(this, previous, nextTitle, nextUrl, nextDescription);
+            },
+            _applyOptionsSnapshot(
+                /** @type {import('settings').Options} */ options,
+                /** @type {string} */ source,
+            ) {
+                return applyOptionsSnapshot.call(this, options, source);
+            },
+        };
+
+        await expect(getBackendMethod('_updateDictionaryMetadata').call(
+            context,
+            'Old Dictionary',
+            'New Dictionary',
+            'https://example.invalid/dictionaries/new',
+            'Updated description',
+        )).rejects.toThrow('save failed');
+
+        expect(updateDictionaryMetadata).toHaveBeenCalledTimes(2);
+        expect(updateDictionaryMetadata).toHaveBeenNthCalledWith(1, 'Old Dictionary', expect.objectContaining({
+            title: 'New Dictionary',
+        }));
+        expect(updateDictionaryMetadata).toHaveBeenNthCalledWith(2, 'New Dictionary', previousSummary);
+        expect(optionsUtilSave).toHaveBeenCalledTimes(1);
+        expect(context._options.profiles[0].options.dictionaries[0]).toMatchObject({
+            name: 'Old Dictionary',
+            alias: 'Old Dictionary',
+        });
+        expect(context._options.profiles[0].options.general.mainDictionary).toBe('Old Dictionary');
     });
 });

--- a/test/backend-mecab-parse.test.js
+++ b/test/backend-mecab-parse.test.js
@@ -32,13 +32,11 @@ describe('Backend._onApiParseText', () => {
                     {name: 'unidic-csj-202302', lines: [parsedLine]},
                 ]),
             },
-            // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/unbound-method
             _textParseMecab: Backend.prototype._textParseMecab,
             _textParseScanning: async () => {
                 throw new Error('Unexpected call to _textParseScanning');
             },
         };
-        // eslint-disable-next-line no-underscore-dangle, @typescript-eslint/unbound-method
         const onApiParseText = Backend.prototype._onApiParseText;
 
         const results = await onApiParseText.call(context, {

--- a/test/database.test.js
+++ b/test/database.test.js
@@ -1246,6 +1246,127 @@ describe('Database', () => {
             }
         });
 
+        test('Updates dictionary metadata and renames dictionary-backed records', async ({expect}) => {
+            const testDictionarySource = await createTestDictionaryArtifactArchiveData('valid-dictionary1', 'Editable Dictionary', 'raw-v4');
+            const dictionaryDatabase = new DictionaryDatabase();
+            await dictionaryDatabase.prepare();
+            try {
+                const dictionaryImporter = createDictionaryImporter(expect);
+                const {result, errors} = await dictionaryImporter.importDictionary(
+                    dictionaryDatabase,
+                    testDictionarySource,
+                    {prefixWildcardsSupported: true, yomitanVersion: '0.0.0.0'},
+                );
+                expect.soft(errors).toStrictEqual([]);
+                if (result === null) {
+                    throw new Error('Expected imported dictionary summary');
+                }
+
+                await dictionaryDatabase.updateDictionaryMetadata('Editable Dictionary', {
+                    ...result,
+                    title: 'Edited Dictionary',
+                    url: 'https://example.invalid/dictionaries/edited',
+                    description: 'Edited description',
+                });
+
+                const info = await dictionaryDatabase.getDictionaryInfo();
+                expect.soft(info.length).toBe(1);
+                expect.soft(info[0]?.title).toBe('Edited Dictionary');
+                expect.soft(info[0]?.url).toBe('https://example.invalid/dictionaries/edited');
+                expect.soft(info[0]?.description).toBe('Edited description');
+                expect.soft(await dictionaryDatabase.dictionaryExists('Editable Dictionary')).toBe(false);
+                expect.soft(await dictionaryDatabase.dictionaryExists('Edited Dictionary')).toBe(true);
+
+                const counts = await dictionaryDatabase.getDictionaryCounts(['Edited Dictionary'], true);
+                expect.soft(counts.counts[0]?.terms).toBeGreaterThan(0);
+
+                const titles = new Map([
+                    ['Edited Dictionary', {alias: 'Edited Dictionary', allowSecondarySearches: false}],
+                ]);
+                const results = await dictionaryDatabase.findTermsBulk(['打'], titles, 'exact');
+                expect.soft(results.length).toBeGreaterThan(0);
+                expect.soft(results.some((entry) => entry.dictionary === 'Edited Dictionary')).toBe(true);
+                expect.soft(results.some((entry) => entry.dictionary === 'Editable Dictionary')).toBe(false);
+
+                const db = dictionaryDatabase._requireDb();
+                for (const table of ['kanji', 'kanjiMeta', 'termMeta', 'tagMeta', 'media']) {
+                    const dictionaries = db.selectObjects(`SELECT DISTINCT dictionary FROM ${table} ORDER BY dictionary ASC`)
+                        .map((row) => row.dictionary);
+                    if (dictionaries.length > 0) {
+                        expect.soft(dictionaries.includes('Editable Dictionary')).toBe(false);
+                        expect.soft(dictionaries.includes('Edited Dictionary')).toBe(true);
+                    }
+                }
+                expect.soft(Number(db.selectValue(
+                    'SELECT COUNT(*) FROM sharedGlossaryArtifacts WHERE dictionary = $dictionary',
+                    {$dictionary: 'Editable Dictionary'},
+                ))).toBe(0);
+                expect.soft(Number(db.selectValue(
+                    'SELECT COUNT(*) FROM sharedGlossaryArtifacts WHERE dictionary = $dictionary',
+                    {$dictionary: 'Edited Dictionary'},
+                ))).toBeGreaterThan(0);
+            } finally {
+                await dictionaryDatabase.close();
+            }
+        });
+
+        test('Dictionary metadata rename rolls back term-record storage when the SQL update fails', async ({expect}) => {
+            const testDictionarySource = await createTestDictionaryArtifactArchiveData('valid-dictionary1', 'Editable Dictionary', 'raw-v4');
+            const dictionaryDatabase = new DictionaryDatabase();
+            await dictionaryDatabase.prepare();
+            try {
+                const dictionaryImporter = createDictionaryImporter(expect);
+                const {result, errors} = await dictionaryImporter.importDictionary(
+                    dictionaryDatabase,
+                    testDictionarySource,
+                    {prefixWildcardsSupported: true, yomitanVersion: '0.0.0.0'},
+                );
+                expect.soft(errors).toStrictEqual([]);
+                if (result === null) {
+                    throw new Error('Expected imported dictionary summary');
+                }
+
+                const db = dictionaryDatabase._requireDb();
+                const exec = db.exec.bind(db);
+                const renameDictionary = vi.spyOn(dictionaryDatabase._termRecordStore, 'renameDictionary');
+                vi.spyOn(db, 'exec').mockImplementation((query) => {
+                    if (
+                        typeof query === 'object' &&
+                        query !== null &&
+                        'sql' in query &&
+                        query.sql === 'UPDATE dictionaries SET title = $title, version = $version, summaryJson = $summaryJson WHERE id = $id'
+                    ) {
+                        throw new Error('Synthetic metadata update failure');
+                    }
+                    return exec(query);
+                });
+
+                await expect(dictionaryDatabase.updateDictionaryMetadata('Editable Dictionary', {
+                    ...result,
+                    title: 'Edited Dictionary',
+                })).rejects.toThrow('Synthetic metadata update failure');
+
+                expect(renameDictionary).toHaveBeenCalledTimes(2);
+                expect(renameDictionary).toHaveBeenNthCalledWith(1, 'Editable Dictionary', 'Edited Dictionary');
+                expect(renameDictionary).toHaveBeenNthCalledWith(2, 'Edited Dictionary', 'Editable Dictionary');
+                expect.soft(await dictionaryDatabase.dictionaryExists('Editable Dictionary')).toBe(true);
+                expect.soft(await dictionaryDatabase.dictionaryExists('Edited Dictionary')).toBe(false);
+
+                const info = await dictionaryDatabase.getDictionaryInfo();
+                expect.soft(info.length).toBe(1);
+                expect.soft(info[0]?.title).toBe('Editable Dictionary');
+
+                const titles = new Map([
+                    ['Editable Dictionary', {alias: 'Editable Dictionary', allowSecondarySearches: false}],
+                ]);
+                const results = await dictionaryDatabase.findTermsBulk(['打'], titles, 'exact');
+                expect.soft(results.length).toBeGreaterThan(0);
+                expect.soft(results.every((entry) => entry.dictionary === 'Editable Dictionary')).toBe(true);
+            } finally {
+                await dictionaryDatabase.close();
+            }
+        });
+
         test('Import data and test', async ({expect}) => {
             const fakeImportDate = testData.expectedSummary.importDate;
 

--- a/types/ext/api.d.ts
+++ b/types/ext/api.d.ts
@@ -298,6 +298,15 @@ type ApiSurface = {
         };
         return: void;
     };
+    updateDictionaryMetadata: {
+        params: {
+            dictionaryTitle: string;
+            title: string;
+            url: string;
+            description: string;
+        };
+        return: DictionaryImporter.Summary;
+    };
     getDictionaryCounts: {
         params: {
             dictionaryNames: string[];

--- a/types/ext/backend.d.ts
+++ b/types/ext/backend.d.ts
@@ -19,7 +19,7 @@ import type * as Api from './api';
 
 export type DatabaseUpdateType = 'dictionary';
 
-export type DatabaseUpdateCause = 'purge' | 'delete' | 'import';
+export type DatabaseUpdateCause = 'purge' | 'delete' | 'import' | 'edit';
 
 export type DictionaryUpdateCheckResult = {
     dictionaryTitle: string;

--- a/types/ext/dictionary-importer.d.ts
+++ b/types/ext/dictionary-importer.d.ts
@@ -86,6 +86,13 @@ export type Summary = {
     targetLanguage?: string;
     frequencyMode?: 'occurrence-based' | 'rank-based';
     importSuccess?: boolean;
+    metadataOverrides?: SummaryMetadataOverrides;
+};
+
+export type SummaryMetadataOverrides = {
+    title?: string;
+    url?: string | null;
+    description?: string | null;
 };
 
 export type SummaryDetails = {

--- a/types/ext/offscreen.d.ts
+++ b/types/ext/offscreen.d.ts
@@ -60,6 +60,13 @@ type ApiSurface = {
         };
         return: void;
     };
+    updateDictionaryMetadataOffscreen: {
+        params: {
+            dictionaryTitle: string;
+            summary: DictionaryImporter.Summary;
+        };
+        return: void;
+    };
     getDictionaryCountsOffscreen: {
         params: {
             dictionaryNames: string[];


### PR DESCRIPTION
## Summary
- add an Edit metadata action to the dictionary settings menu and modal fields for name, URL, and description
- persist dictionary metadata edits through the background/offscreen/database layers, including dictionary title renames and OPFS shard renames
- preserve edited metadata across dictionary updates and add rollback coverage for failed rename/save paths

## Testing
- .\\node_modules\\.bin\\eslint.cmd ext/js/background/backend.js ext/js/dictionary/dictionary-database.js test/backend-dictionary-auto-update.test.js test/database.test.js
- .\\node_modules\\.bin\\tsc.cmd --noEmit -p jsconfig.json
- .\\node_modules\\.bin\\tsc.cmd --noEmit -p test\\jsconfig.json
- npx vitest run test/backend-dictionary-auto-update.test.js
- npx vitest run test/database.test.js -t "Updates dictionary metadata and renames dictionary-backed records|Dictionary metadata rename rolls back term-record storage when the SQL update fails"
- npm run test:build
- npm run test:html
- npx vitest run test/popup-frequency-blur-controller.test.js -t "manual blur mode uses the selected threshold comparison for both frequency orders"

## Notes
- `npm run test:unit` hit an unrelated timeout in `test/popup-frequency-blur-controller.test.js`; the timed out case passed when rerun in isolation.
