### PR TITLE
Add known Anki note type presets

### DIFF
--- a/ext/js/data/anki-note-type-field-util.js
+++ b/ext/js/data/anki-note-type-field-util.js
@@ -186,15 +186,15 @@ function getKnownAnkiNoteTypePreset(modelName, dictionaryEntryType, dynamicField
             };
         case 'crop-theft-vocab':
             return {
-                Word: '{expression}',
-                Reading: '{reading}',
-                PitchPattern: '{pitch-accents}',
-                Audio: '{audio}',
-                Definition: '{glossary-brief}',
+                'Word': '{expression}',
+                'Reading': '{reading}',
+                'PitchPattern': '{pitch-accents}',
+                'Audio': '{audio}',
+                'Definition': '{glossary-brief}',
                 'Example Sentence': '{sentence}',
                 'Example Target': '{search-query}',
-                Frequency: '{frequency-harmonic-rank}',
-                Notes: '',
+                'Frequency': '{frequency-harmonic-rank}',
+                'Notes': '',
             };
         default:
             return null;

--- a/ext/js/data/anki-note-type-field-util.js
+++ b/ext/js/data/anki-note-type-field-util.js
@@ -1,0 +1,237 @@
+/*
+ * Copyright (C) 2026  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {getStandardFieldMarkers} from './anki-template-util.js';
+
+const knownAnkiNoteTypePresets = new Map([
+    ['kiku', 'kiku-lapis'],
+    ['lapis', 'kiku-lapis'],
+    ['senren', 'senren'],
+    ['senren 洗練', 'senren'],
+    ['crop theft vocab', 'crop-theft-vocab'],
+]);
+
+const markerAliases = new Map([
+    ['expression', ['phrase', 'term', 'word']],
+    ['reading', ['expression-reading', 'term-reading', 'word-reading']],
+    ['furigana', ['expression-furigana', 'term-furigana', 'word-furigana']],
+    ['glossary', ['definition', 'meaning']],
+    ['audio', ['sound', 'word-audio', 'term-audio', 'expression-audio']],
+    ['dictionary', ['dict']],
+    ['pitch-accents', ['pitch', 'pitch-accent', 'pitch-pattern']],
+    ['sentence', ['example-sentence']],
+    ['frequency-harmonic-rank', ['freq', 'frequency', 'freq-sort', 'freqency-sort']],
+    ['popup-selection-text', ['selection', 'selection-text']],
+    ['pitch-accent-positions', ['pitch-position']],
+    ['pitch-accent-categories', ['pitch-categories']],
+]);
+
+/**
+ * @param {{
+ *   modelName: string,
+ *   fieldNames: string[],
+ *   dictionaryEntryType: import('dictionary').DictionaryEntryType,
+ *   oldFields?: ?import('settings').AnkiFields,
+ *   dynamicFieldMarkers?: string[],
+ * }} details
+ * @returns {import('settings').AnkiFields}
+ */
+export function buildAnkiFieldsForModel({
+    modelName,
+    fieldNames,
+    dictionaryEntryType,
+    oldFields = null,
+    dynamicFieldMarkers = [],
+}) {
+    const preset = getKnownAnkiNoteTypePreset(modelName, dictionaryEntryType, dynamicFieldMarkers);
+
+    /** @type {import('settings').AnkiFields} */
+    const fields = {};
+    for (let i = 0, ii = fieldNames.length; i < ii; ++i) {
+        const fieldName = fieldNames[i];
+        fields[fieldName] = {
+            value: (
+                preset !== null ?
+                getPresetFieldValue(preset, fieldName) :
+                getDefaultAnkiFieldValue(fieldName, i, dictionaryEntryType, oldFields)
+            ),
+            overwriteMode: 'coalesce',
+        };
+    }
+    return fields;
+}
+
+/**
+ * @param {string} fieldName
+ * @param {number} index
+ * @param {import('dictionary').DictionaryEntryType} dictionaryEntryType
+ * @param {?import('settings').AnkiFields} oldFields
+ * @returns {string}
+ */
+export function getDefaultAnkiFieldValue(fieldName, index, dictionaryEntryType, oldFields) {
+    if (
+        typeof oldFields === 'object' &&
+        oldFields !== null &&
+        Object.prototype.hasOwnProperty.call(oldFields, fieldName)
+    ) {
+        return oldFields[fieldName].value;
+    }
+
+    if (index === 0) {
+        return (dictionaryEntryType === 'kanji' ? '{character}' : '{expression}');
+    }
+
+    const markers = getStandardFieldMarkers(dictionaryEntryType);
+    const hyphenPattern = /-/g;
+    for (const marker of markers) {
+        const names = [marker];
+        const aliases = markerAliases.get(marker);
+        if (typeof aliases !== 'undefined') {
+            names.push(...aliases);
+        }
+
+        let pattern = '^(?:';
+        for (let i = 0, ii = names.length; i < ii; ++i) {
+            const name = names[i];
+            if (i > 0) { pattern += '|'; }
+            pattern += name.replace(hyphenPattern, '[-_ ]*');
+        }
+        pattern += ')$';
+        const patternRegExp = new RegExp(pattern, 'i');
+
+        if (patternRegExp.test(fieldName)) {
+            return `{${marker}}`;
+        }
+    }
+
+    return '';
+}
+
+/**
+ * @param {string} modelName
+ * @param {import('dictionary').DictionaryEntryType} dictionaryEntryType
+ * @param {string[]} dynamicFieldMarkers
+ * @returns {?Record<string, string>}
+ */
+function getKnownAnkiNoteTypePreset(modelName, dictionaryEntryType, dynamicFieldMarkers) {
+    if (dictionaryEntryType !== 'term') { return null; }
+
+    const presetKey = knownAnkiNoteTypePresets.get(normalizeAnkiModelName(modelName));
+    if (typeof presetKey === 'undefined') { return null; }
+
+    const primaryDefinitionMarker = getPrimaryDefinitionMarker(dynamicFieldMarkers);
+    switch (presetKey) {
+        case 'kiku-lapis':
+            return {
+                Expression: '{expression}',
+                ExpressionFurigana: '{furigana-plain}',
+                ExpressionReading: '{reading}',
+                ExpressionAudio: '{audio}',
+                SelectionText: '{popup-selection-text}',
+                MainDefinition: primaryDefinitionMarker,
+                DefinitionPicture: '',
+                Sentence: '{cloze-prefix}<b>{cloze-body}</b>{cloze-suffix}',
+                SentenceFurigana: '',
+                SentenceAudio: '',
+                Picture: '',
+                Glossary: '{glossary}',
+                Hint: '',
+                IsWordAndSentenceCard: '',
+                IsClickCard: '',
+                IsSentenceCard: '',
+                IsAudioCard: '',
+                PitchPosition: '{pitch-accent-positions}',
+                PitchCategories: '{pitch-accent-categories}',
+                Frequency: '{frequencies}',
+                FreqSort: '{frequency-harmonic-rank}',
+                MiscInfo: '{document-title}',
+            };
+        case 'senren':
+            return {
+                word: '{expression}',
+                reading: '{reading}',
+                sentence: '<span class="group">{cloze-prefix}<span class="highlight">{cloze-body}</span>{cloze-suffix}</span>',
+                sentenceFurigana: '<span class="group">{sentence-furigana}</span>',
+                sentenceTranslation: '',
+                sentenceCard: '',
+                audioCard: '',
+                notes: '',
+                selectionText: '{popup-selection-text}',
+                definition: primaryDefinitionMarker,
+                wordAudio: '{audio}',
+                sentenceAudio: '',
+                picture: '',
+                glossary: '{glossary}',
+                pitchAccents: '{pitch-accents}',
+                pitchPositions: '{pitch-accent-positions}',
+                pitchCategories: '{pitch-accent-categories}',
+                frequencies: '{frequencies}',
+                freqSort: '{frequency-harmonic-rank}',
+                miscInfo: '{document-title}',
+                dictionaryPreference: '',
+            };
+        case 'crop-theft-vocab':
+            return {
+                Word: '{expression}',
+                Reading: '{reading}',
+                PitchPattern: '{pitch-accents}',
+                Audio: '{audio}',
+                Definition: '{glossary-brief}',
+                'Example Sentence': '{sentence}',
+                'Example Target': '{search-query}',
+                Frequency: '{frequency-harmonic-rank}',
+                Notes: '',
+            };
+        default:
+            return null;
+    }
+}
+
+/**
+ * @param {Record<string, string>} preset
+ * @param {string} fieldName
+ * @returns {string}
+ */
+function getPresetFieldValue(preset, fieldName) {
+    return Object.prototype.hasOwnProperty.call(preset, fieldName) ? preset[fieldName] : '';
+}
+
+/**
+ * @param {string[]} dynamicFieldMarkers
+ * @returns {string}
+ */
+function getPrimaryDefinitionMarker(dynamicFieldMarkers) {
+    for (const marker of dynamicFieldMarkers) {
+        if (marker.startsWith('single-glossary-')) {
+            return `{${marker}}`;
+        }
+    }
+    return '';
+}
+
+/**
+ * @param {string} modelName
+ * @returns {string}
+ */
+function normalizeAnkiModelName(modelName) {
+    return modelName
+        .normalize('NFKC')
+        .replace(/[^\p{L}\p{N}]+/gu, ' ')
+        .trim()
+        .replace(/\s+/g, ' ')
+        .toLowerCase();
+}

--- a/ext/js/pages/settings/anki-controller.js
+++ b/ext/js/pages/settings/anki-controller.js
@@ -1159,6 +1159,7 @@ class AnkiCardController {
 
         let fieldNames;
         let options;
+        /** @type {import('dictionary-importer').Summary[]} */
         let dictionaryInfo = [];
         try {
             this._modelChangingTo = value;

--- a/ext/js/pages/settings/anki-controller.js
+++ b/ext/js/pages/settings/anki-controller.js
@@ -21,6 +21,7 @@ import {EventListenerCollection} from '../../core/event-listener-collection.js';
 import {ExtensionError} from '../../core/extension-error.js';
 import {log} from '../../core/log.js';
 import {toError} from '../../core/to-error.js';
+import {buildAnkiFieldsForModel, getDefaultAnkiFieldValue} from '../../data/anki-note-type-field-util.js';
 import {getDynamicFieldMarkers, getStandardFieldMarkers} from '../../data/anki-template-util.js';
 import {stringContainsAnyFieldMarker} from '../../data/anki-util.js';
 import {getRequiredPermissionsForAnkiFieldValue, hasPermissions, setPermissionsGranted} from '../../data/permissions-util.js';
@@ -1158,10 +1159,13 @@ class AnkiCardController {
 
         let fieldNames;
         let options;
+        let dictionaryInfo = [];
         try {
             this._modelChangingTo = value;
-            fieldNames = await this._ankiController.getModelFieldNames(value);
-            options = await this._ankiController.settingsController.getOptions();
+            [fieldNames, options] = await Promise.all([
+                this._ankiController.getModelFieldNames(value),
+                this._ankiController.settingsController.getOptions(),
+            ]);
         } catch (e) {
             // Revert
             select.value = this._modelController.value;
@@ -1172,16 +1176,24 @@ class AnkiCardController {
 
         const cardFormat = this._getCardFormat(options.anki, this._cardFormatIndex);
         const oldFields = cardFormat !== null ? cardFormat.fields : null;
-
-        /** @type {import('settings').AnkiFields} */
-        const fields = {};
-        for (let i = 0, ii = fieldNames.length; i < ii; ++i) {
-            const fieldName = fieldNames[i];
-            fields[fieldName] = {
-                value: this._getDefaultFieldValue(fieldName, i, cardFormat.type, oldFields),
-                overwriteMode: 'coalesce',
-            };
+        if (cardFormat.type === 'term') {
+            try {
+                dictionaryInfo = await this._ankiController.settingsController.getDictionaryInfo();
+            } catch (e) {
+                // If dictionary info is unavailable, presets can still be applied without a primary dictionary marker.
+            }
         }
+        const fields = buildAnkiFieldsForModel({
+            modelName: value,
+            fieldNames,
+            dictionaryEntryType: cardFormat.type,
+            oldFields,
+            dynamicFieldMarkers: (
+                cardFormat.type === 'term' ?
+                getDynamicFieldMarkers(options.dictionaries, dictionaryInfo) :
+                []
+            ),
+        });
 
         /** @type {import('settings-modifications').Modification[]} */
         const targets = [
@@ -1272,58 +1284,7 @@ class AnkiCardController {
      * @returns {string}
      */
     _getDefaultFieldValue(fieldName, index, dictionaryEntryType, oldFields) {
-        if (
-            typeof oldFields === 'object' &&
-            oldFields !== null &&
-            Object.prototype.hasOwnProperty.call(oldFields, fieldName)
-        ) {
-            return oldFields[fieldName].value;
-        }
-
-        if (index === 0) {
-            return (dictionaryEntryType === 'kanji' ? '{character}' : '{expression}');
-        }
-
-        const markers = getStandardFieldMarkers(dictionaryEntryType);
-        const markerAliases = new Map([
-            ['expression', ['phrase', 'term', 'word']],
-            ['reading', ['expression-reading', 'term-reading', 'word-reading']],
-            ['furigana', ['expression-furigana', 'term-furigana', 'word-furigana']],
-            ['glossary', ['definition', 'meaning']],
-            ['audio', ['sound', 'word-audio', 'term-audio', 'expression-audio']],
-            ['dictionary', ['dict']],
-            ['pitch-accents', ['pitch', 'pitch-accent', 'pitch-pattern']],
-            ['sentence', ['example-sentence']],
-            ['frequency-harmonic-rank', ['freq', 'frequency', 'freq-sort', 'freqency-sort']],
-            ['popup-selection-text', ['selection']],
-            ['pitch-accent-positions', ['pitch-position']],
-            ['pitch-accent-categories', ['pitch-categories']],
-            ['popup-selection-text', ['selection-text']],
-        ]);
-
-        const hyphenPattern = /-/g;
-        for (const marker of markers) {
-            const names = [marker];
-            const aliases = markerAliases.get(marker);
-            if (typeof aliases !== 'undefined') {
-                names.push(...aliases);
-            }
-
-            let pattern = '^(?:';
-            for (let i = 0, ii = names.length; i < ii; ++i) {
-                const name = names[i];
-                if (i > 0) { pattern += '|'; }
-                pattern += name.replace(hyphenPattern, '[-_ ]*');
-            }
-            pattern += ')$';
-            const patternRegExp = new RegExp(pattern, 'i');
-
-            if (patternRegExp.test(fieldName)) {
-                return `{${marker}}`;
-            }
-        }
-
-        return '';
+        return getDefaultAnkiFieldValue(fieldName, index, dictionaryEntryType, oldFields);
     }
 
     /** @type {import('dictionary').DictionaryEntryType} */

--- a/test/anki-note-type-field-util.test.js
+++ b/test/anki-note-type-field-util.test.js
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2026  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {describe, expect, test} from 'vitest';
+import {buildAnkiFieldsForModel} from '../ext/js/data/anki-note-type-field-util.js';
+
+describe('buildAnkiFieldsForModel', () => {
+    test('builds the Kiku preset and blanks unspecified fields', () => {
+        const fields = buildAnkiFieldsForModel({
+            modelName: 'Kiku',
+            fieldNames: ['Expression', 'MainDefinition', 'Sentence', 'Mystery'],
+            dictionaryEntryType: 'term',
+            dynamicFieldMarkers: ['single-frequency-number-a', 'single-glossary-primary'],
+        });
+
+        expect(fields).toStrictEqual({
+            Expression: {value: '{expression}', overwriteMode: 'coalesce'},
+            MainDefinition: {value: '{single-glossary-primary}', overwriteMode: 'coalesce'},
+            Sentence: {value: '{cloze-prefix}<b>{cloze-body}</b>{cloze-suffix}', overwriteMode: 'coalesce'},
+            Mystery: {value: '', overwriteMode: 'coalesce'},
+        });
+    });
+
+    test('builds the Lapis preset', () => {
+        const fields = buildAnkiFieldsForModel({
+            modelName: 'Lapis',
+            fieldNames: ['ExpressionReading', 'SelectionText', 'PitchCategories', 'MiscInfo'],
+            dictionaryEntryType: 'term',
+            dynamicFieldMarkers: ['single-glossary-primary'],
+        });
+
+        expect(fields).toStrictEqual({
+            ExpressionReading: {value: '{reading}', overwriteMode: 'coalesce'},
+            SelectionText: {value: '{popup-selection-text}', overwriteMode: 'coalesce'},
+            PitchCategories: {value: '{pitch-accent-categories}', overwriteMode: 'coalesce'},
+            MiscInfo: {value: '{document-title}', overwriteMode: 'coalesce'},
+        });
+    });
+
+    test('builds the Senren preset', () => {
+        const fields = buildAnkiFieldsForModel({
+            modelName: 'Senren・洗練',
+            fieldNames: ['word', 'sentence', 'definition', 'pitchAccents', 'dictionaryPreference'],
+            dictionaryEntryType: 'term',
+            dynamicFieldMarkers: ['single-frequency-number-a', 'single-glossary-primary', 'single-glossary-secondary'],
+        });
+
+        expect(fields).toStrictEqual({
+            word: {value: '{expression}', overwriteMode: 'coalesce'},
+            sentence: {value: '<span class="group">{cloze-prefix}<span class="highlight">{cloze-body}</span>{cloze-suffix}</span>', overwriteMode: 'coalesce'},
+            definition: {value: '{single-glossary-primary}', overwriteMode: 'coalesce'},
+            pitchAccents: {value: '{pitch-accents}', overwriteMode: 'coalesce'},
+            dictionaryPreference: {value: '', overwriteMode: 'coalesce'},
+        });
+    });
+
+    test('builds the Crop Theft Vocab preset', () => {
+        const fields = buildAnkiFieldsForModel({
+            modelName: 'Crop Theft Vocab',
+            fieldNames: ['Word', 'Definition', 'Example Sentence', 'Example Target', 'Notes'],
+            dictionaryEntryType: 'term',
+            dynamicFieldMarkers: ['single-glossary-primary'],
+        });
+
+        expect(fields).toStrictEqual({
+            Word: {value: '{expression}', overwriteMode: 'coalesce'},
+            Definition: {value: '{glossary-brief}', overwriteMode: 'coalesce'},
+            'Example Sentence': {value: '{sentence}', overwriteMode: 'coalesce'},
+            'Example Target': {value: '{search-query}', overwriteMode: 'coalesce'},
+            Notes: {value: '', overwriteMode: 'coalesce'},
+        });
+    });
+
+    test('uses the legacy heuristic for unknown models', () => {
+        const fields = buildAnkiFieldsForModel({
+            modelName: 'Custom Model',
+            fieldNames: ['Front', 'Reading', 'Meaning'],
+            dictionaryEntryType: 'term',
+            oldFields: {
+                Reading: {value: 'existing-reading', overwriteMode: 'skip'},
+            },
+        });
+
+        expect(fields).toStrictEqual({
+            Front: {value: '{expression}', overwriteMode: 'coalesce'},
+            Reading: {value: 'existing-reading', overwriteMode: 'coalesce'},
+            Meaning: {value: '{glossary}', overwriteMode: 'coalesce'},
+        });
+    });
+
+    test('uses the first available single glossary marker for primary dictionary fields', () => {
+        const fields = buildAnkiFieldsForModel({
+            modelName: 'Lapis',
+            fieldNames: ['MainDefinition'],
+            dictionaryEntryType: 'term',
+            dynamicFieldMarkers: ['single-frequency-number-a', 'single-glossary-first', 'single-glossary-second'],
+        });
+
+        expect(fields.MainDefinition.value).toBe('{single-glossary-first}');
+    });
+
+    test('leaves primary dictionary fields blank when no single glossary marker is available', () => {
+        const fields = buildAnkiFieldsForModel({
+            modelName: 'Senren',
+            fieldNames: ['definition'],
+            dictionaryEntryType: 'term',
+            dynamicFieldMarkers: ['single-frequency-number-a'],
+        });
+
+        expect(fields.definition.value).toBe('');
+    });
+});

--- a/test/settings-anki-controller.test.js
+++ b/test/settings-anki-controller.test.js
@@ -1,0 +1,235 @@
+/*
+ * Copyright (C) 2026  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {describe, expect, vi} from 'vitest';
+import {EventDispatcher} from '../ext/js/core/event-dispatcher.js';
+import {AnkiController} from '../ext/js/pages/settings/anki-controller.js';
+import {createDomTest} from './fixtures/dom-test.js';
+
+const test = createDomTest();
+
+/**
+ * @augments {EventDispatcher<import('settings-controller').Events>}
+ */
+class MockSettingsController extends EventDispatcher {
+    constructor() {
+        super();
+        /** @type {import('settings').ProfileOptions} */
+        this._options = {
+            anki: {
+                cardFormats: [{
+                    type: 'term',
+                    name: 'Expression',
+                    deck: 'Deck',
+                    model: '',
+                    fields: {
+                        Sentence: {
+                            value: 'custom sentence',
+                            overwriteMode: 'coalesce',
+                        },
+                    },
+                    icon: 'big-circle',
+                }],
+            },
+            dictionaries: [{
+                name: 'Primary Dict',
+                alias: 'Primary Dict',
+                enabled: true,
+                allowSecondarySearches: false,
+                definitionsCollapsible: 'not-collapsible',
+                partsOfSpeechFilter: true,
+                useDeinflections: true,
+                styles: '',
+            }],
+            general: {
+                language: 'ja',
+            },
+        };
+    }
+
+    /** @returns {Promise<import('settings').ProfileOptions>} */
+    async getOptions() {
+        return this._options;
+    }
+
+    /** @returns {Promise<import('dictionary-importer').Summary[]>} */
+    async getDictionaryInfo() {
+        return [
+            {
+                title: 'Primary Dict',
+                revision: '1',
+                sequenced: false,
+                version: 3,
+                importDate: 0,
+                prefixWildcardsSupported: false,
+                styles: '',
+                sourceLanguage: 'ja',
+                counts: {
+                    terms: {total: 1},
+                    termMeta: {total: 0, freq: 0},
+                    kanji: {total: 0},
+                    kanjiMeta: {total: 0},
+                    tagMeta: {total: 0},
+                    media: {total: 0},
+                },
+            },
+        ];
+    }
+
+    /** @returns {import('settings').OptionsContext} */
+    getOptionsContext() {
+        return {index: 0};
+    }
+
+    /**
+     * @param {string} name
+     * @returns {DocumentFragment}
+     */
+    instantiateTemplateFragment(name) {
+        if (name !== 'anki-card-field') {
+            throw new Error(`Unexpected template: ${name}`);
+        }
+        const template = document.createElement('template');
+        template.innerHTML = `
+            <div class="anki-card-field-name-container">
+                <span class="anki-card-field-name"></span>
+            </div>
+            <div class="anki-card-field-value-container input-group">
+                <input type="text" class="anki-card-field-value" autocomplete="off">
+            </div>
+            <div class="anki-card-field-overwrite-container">
+                <select class="anki-card-field-overwrite"></select>
+            </div>
+        `;
+        return template.content.cloneNode(true);
+    }
+
+    /**
+     * @param {import('settings-modifications').Modification[]} targets
+     * @returns {Promise<unknown[]>}
+     */
+    async modifyProfileSettings(targets) {
+        for (const {path, value} of targets) {
+            setObjectProperty(this._options, path, value);
+        }
+        return [];
+    }
+}
+
+/**
+ * @param {import('jsdom').DOMWindow} window
+ * @returns {HTMLElement}
+ */
+function setupAnkiDom(window) {
+    window.document.body.innerHTML = `
+        <div id="anki-error-message"></div>
+        <div id="anki-error-message-details"></div>
+        <div id="anki-error-message-details-container"></div>
+        <button id="anki-error-message-details-toggle"></button>
+        <div id="anki-error-invalid-response-info"></div>
+        <select data-setting="anki.duplicateBehavior"></select>
+        <div id="anki-overwrite-warning"></div>
+        <div id="anki-card-primary"></div>
+        <div id="anki-cards-tabs"></div>
+        <input class="anki-card-name">
+        <select class="anki-card-type"></select>
+        <button class="anki-card-delete-format-button"></button>
+        <div id="anki-card-format-remove-name"></div>
+        <button id="anki-card-format-remove-confirm-button"></button>
+        <div class="anki-card" data-card-format-index="0">
+            <select class="anki-card-deck"></select>
+            <select class="anki-card-model"></select>
+            <div class="anki-card-fields"></div>
+        </div>
+    `;
+    return /** @type {HTMLElement} */ (window.document.querySelector('.anki-card'));
+}
+
+/**
+ * @param {object} target
+ * @param {string} path
+ * @param {unknown} value
+ */
+function setObjectProperty(target, path, value) {
+    const pathParts = path.replace(/\[(\d+)\]/g, '.$1').split('.');
+    /** @type {Record<string, unknown>|unknown[]} */
+    let current = /** @type {Record<string, unknown>|unknown[]} */ (target);
+    for (let i = 0, ii = pathParts.length - 1; i < ii; ++i) {
+        const key = getPathKey(pathParts[i]);
+        current = /** @type {Record<string, unknown>|unknown[]} */ (current[key]);
+    }
+    current[getPathKey(pathParts[pathParts.length - 1])] = value;
+}
+
+/**
+ * @param {string} value
+ * @returns {string|number}
+ */
+function getPathKey(value) {
+    return /^\d+$/.test(value) ? Number.parseInt(value, 10) : value;
+}
+
+describe('AnkiController known note type presets', () => {
+    test('model changes apply known presets and keep the legacy heuristic for unknown models', async ({window}) => {
+        const cardNode = setupAnkiDom(window);
+        const settingsController = new MockSettingsController();
+        const ankiController = new AnkiController(
+            /** @type {import('../ext/js/pages/settings/settings-controller.js').SettingsController} */ (/** @type {unknown} */ (settingsController)),
+            /** @type {import('../ext/js/application.js').Application} */ (/** @type {unknown} */ ({api: {}})),
+            /** @type {import('../ext/js/pages/settings/modal-controller.js').ModalController} */ (/** @type {unknown} */ ({})),
+        );
+
+        ankiController.getAnkiData = vi.fn(async () => ({
+            deckNames: ['Deck'],
+            modelNames: ['Kiku', 'Custom'],
+        }));
+        ankiController.getModelFieldNames = vi.fn(async (model) => {
+            switch (model) {
+                case 'Kiku':
+                    return ['Expression', 'Sentence', 'MainDefinition', 'Mystery'];
+                case 'Custom':
+                    return ['Sentence', 'Reading'];
+                default:
+                    return [];
+            }
+        });
+        ankiController.getRequiredPermissions = vi.fn(() => []);
+
+        const cardController = Reflect.get(ankiController, '_createCardController').call(ankiController, cardNode);
+        await vi.waitFor(() => {
+            expect(cardNode.querySelectorAll('.anki-card-field-name')).toHaveLength(1);
+        });
+
+        await cardController._setModel('Kiku');
+
+        expect(settingsController._options.anki.cardFormats[0].model).toBe('Kiku');
+        expect(settingsController._options.anki.cardFormats[0].fields).toStrictEqual({
+            Expression: {value: '{expression}', overwriteMode: 'coalesce'},
+            Sentence: {value: '{cloze-prefix}<b>{cloze-body}</b>{cloze-suffix}', overwriteMode: 'coalesce'},
+            MainDefinition: {value: '{single-glossary-primary-dict}', overwriteMode: 'coalesce'},
+            Mystery: {value: '', overwriteMode: 'coalesce'},
+        });
+
+        await cardController._setModel('Custom');
+
+        expect(settingsController._options.anki.cardFormats[0].model).toBe('Custom');
+        expect(settingsController._options.anki.cardFormats[0].fields).toStrictEqual({
+            Sentence: {value: '{cloze-prefix}<b>{cloze-body}</b>{cloze-suffix}', overwriteMode: 'coalesce'},
+            Reading: {value: '{reading}', overwriteMode: 'coalesce'},
+        });
+    });
+});

--- a/test/settings-anki-controller.test.js
+++ b/test/settings-anki-controller.test.js
@@ -29,7 +29,7 @@ class MockSettingsController extends EventDispatcher {
     constructor() {
         super();
         /** @type {import('settings').ProfileOptions} */
-        this._options = {
+        this._options = /** @type {import('settings').ProfileOptions} */ (/** @type {unknown} */ ({
             anki: {
                 cardFormats: [{
                     type: 'term',
@@ -58,7 +58,7 @@ class MockSettingsController extends EventDispatcher {
             general: {
                 language: 'ja',
             },
-        };
+        }));
     }
 
     /** @returns {Promise<import('settings').ProfileOptions>} */
@@ -115,7 +115,7 @@ class MockSettingsController extends EventDispatcher {
                 <select class="anki-card-field-overwrite"></select>
             </div>
         `;
-        return template.content.cloneNode(true);
+        return /** @type {DocumentFragment} */ (template.content.cloneNode(true));
     }
 
     /**
@@ -123,8 +123,9 @@ class MockSettingsController extends EventDispatcher {
      * @returns {Promise<unknown[]>}
      */
     async modifyProfileSettings(targets) {
-        for (const {path, value} of targets) {
-            setObjectProperty(this._options, path, value);
+        for (const target of targets) {
+            if (target.action !== 'set') { continue; }
+            setObjectProperty(this._options, target.path, target.value);
         }
         return [];
     }
@@ -166,11 +167,11 @@ function setupAnkiDom(window) {
  */
 function setObjectProperty(target, path, value) {
     const pathParts = path.replace(/\[(\d+)\]/g, '.$1').split('.');
-    /** @type {Record<string, unknown>|unknown[]} */
-    let current = /** @type {Record<string, unknown>|unknown[]} */ (target);
+    /** @type {any} */
+    let current = target;
     for (let i = 0, ii = pathParts.length - 1; i < ii; ++i) {
         const key = getPathKey(pathParts[i]);
-        current = /** @type {Record<string, unknown>|unknown[]} */ (current[key]);
+        current = current[key];
     }
     current[getPathKey(pathParts[pathParts.length - 1])] = value;
 }


### PR DESCRIPTION
## Summary
- add a pure Anki note-type field builder for known note types
- apply curated field mappings when users select Kiku, Lapis, Senren, or Crop Theft Vocab in settings
- keep the legacy heuristic for unknown models and add focused unit/settings tests

## Testing
- npm run test:unit -- test/anki-note-type-field-util.test.js test/settings-anki-controller.test.js