### PR TITLE
Cache Anki duplicate lookups by scope

### DIFF
--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -31,6 +31,7 @@ import {isObjectNotArray} from '../core/object-utilities.js';
 import {reportDiagnostics} from '../core/diagnostics-reporter.js';
 import {safePerformance} from '../core/safe-performance.js';
 import {clone, deferPromise, promiseTimeout} from '../core/utilities.js';
+import {createAnkiNoteDuplicateSearchDetails} from '../data/anki-note-query-util.js';
 import {generateAnkiNoteMediaFileName, INVALID_NOTE_ID, isNoteDataValid} from '../data/anki-util.js';
 import {getKebabCase} from '../data/anki-template-util.js';
 import {arrayBufferToBase64, base64ToArrayBuffer} from '../data/array-buffer-util.js';
@@ -266,6 +267,8 @@ export class Backend {
         this._yomitanApi = new YomitanApi(this._apiMap, this._offscreen);
         /** @type {CacheMap<string, {originalTextLength: number, textSegments: import('api').ParseTextSegment[]}>} */
         this._textParseCache = new CacheMap(10000, 3600000); // 1 hour idle time, ~32MB per 1000 entries for Japanese
+        /** @type {Map<string, {status: 'pending'|'ready'|'error', fieldNameLower: string, query: string, noteIdsByFieldValue: Map<string, number[]>}>} */
+        this._ankiDuplicateCache = new Map();
         /** @type {Record<string, unknown>|null} */
         this._startupDiagnosticsSnapshot = null;
         /** @type {boolean} */
@@ -480,6 +483,7 @@ export class Backend {
                 this._applyOptions('background');
                 recordPhase('applyOptions(background)', startedAt);
             }
+            void this._warmAnkiDuplicateCacheStartupBuckets();
 
             {
                 const startedAt = safePerformance.now();
@@ -840,12 +844,21 @@ export class Backend {
 
     /** @type {import('api').ApiHandler<'addAnkiNote'>} */
     async _onApiAddAnkiNote({note}) {
-        return await this._anki.addNote(note);
+        const noteId = await this._anki.addNote(note);
+        if (typeof noteId === 'number') {
+            this._addAnkiDuplicateCacheNote(note, noteId);
+        }
+        return noteId;
     }
 
     /** @type {import('api').ApiHandler<'updateAnkiNote'>} */
     async _onApiUpdateAnkiNote({noteWithId}) {
-        return await this._anki.updateNoteFields(noteWithId);
+        const result = await this._anki.updateNoteFields(noteWithId);
+        if (typeof noteWithId.id === 'number') {
+            this._removeAnkiDuplicateCacheNoteId(noteWithId.id);
+            this._addAnkiDuplicateCacheNote(noteWithId, noteWithId.id);
+        }
+        return result;
     }
 
     /**
@@ -909,6 +922,27 @@ export class Backend {
 
     /**
      * @param {import('anki').Note[]} notes
+     * @param {import('anki').Note[]} notesStrippedNoDuplicates
+     * @returns {Promise<{ note: import('anki').Note, isDuplicate: boolean }[]>}
+     */
+    async _findDuplicatesLive(notes, notesStrippedNoDuplicates) {
+        try {
+            return await this._findDuplicates(notes, notesStrippedNoDuplicates);
+        } catch (e) {
+            // User has older anki-connect that does not support canAddNotesWithErrorDetail
+            if (e instanceof ExtensionError && e.message.includes('Anki error: unsupported action')) {
+                const strippedNotesAllowDuplicates = notesStrippedNoDuplicates.map((note) => ({
+                    ...note,
+                    options: {...note.options, allowDuplicate: true},
+                }));
+                return await this._findDuplicatesFallback(notes, notesStrippedNoDuplicates, strippedNotesAllowDuplicates);
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * @param {import('anki').Note[]} notes
      * @returns {Promise<{canAddArray: import('backend').CanAddResults, strippedNotes: import('anki').Note[]}>}
      */
     async partitionAddibleNotes(notes) {
@@ -921,22 +955,247 @@ export class Backend {
             note.options.allowDuplicate = false;
         }
 
-        let canAddArray;
+        const canAddArray = await this._findDuplicatesWithCache(notes, strippedNotes);
+        return {canAddArray, strippedNotes};
+    }
+
+    /**
+     * @param {import('anki').Note} note
+     * @param {'exact'|'any'} [fieldValueMode='exact']
+     * @returns {?({
+     *   key: string,
+     * } & NonNullable<ReturnType<typeof createAnkiNoteDuplicateSearchDetails>>)}
+     */
+    _getAnkiDuplicateCacheDescriptor(note, fieldValueMode = 'exact') {
+        const details = createAnkiNoteDuplicateSearchDetails(note, fieldValueMode);
+        if (details === null) { return null; }
+
+        const key = JSON.stringify([
+            this._anki.server ?? '',
+            this._anki.apiKey ?? '',
+            details.duplicateScope,
+            details.deckName ?? '',
+            details.checkChildren,
+            details.checkAllModels,
+            details.checkAllModels ? '' : details.modelName,
+            details.fieldNameLower,
+        ]);
+        return {key, ...details};
+    }
+
+    /**
+     * @param {import('settings').AnkiCardFormat} cardFormat
+     * @param {import('settings').AnkiOptions} ankiOptions
+     * @param {string} firstFieldName
+     * @returns {import('anki').Note}
+     */
+    _createAnkiDuplicateCacheStartupNote(cardFormat, ankiOptions, firstFieldName) {
+        return {
+            fields: {[firstFieldName]: ''},
+            tags: [],
+            deckName: cardFormat.deck,
+            modelName: cardFormat.model,
+            options: {
+                allowDuplicate: false,
+                duplicateScope: ankiOptions.duplicateScope,
+                duplicateScopeOptions: {
+                    deckName: null,
+                    checkChildren: false,
+                    checkAllModels: ankiOptions.duplicateScopeCheckAllModels,
+                },
+            },
+        };
+    }
+
+    /**
+     * @returns {Array<{
+     *   key: string,
+     *   query: string,
+     *   fieldName: string,
+     *   fieldNameLower: string,
+     *   fieldValue: string,
+     *   duplicateScope: 'collection'|'deck',
+     *   deckName: string|null,
+     *   checkChildren: boolean,
+     *   checkAllModels: boolean,
+     *   modelName: string,
+     * }>}
+     */
+    _getAnkiDuplicateCacheStartupDescriptors() {
+        if (!this._anki.enabled) { return []; }
+
+        const options = this._getProfileOptions({current: true}, false);
+        /** @type {Map<string, ReturnType<Backend['_getAnkiDuplicateCacheDescriptor']>>} */
+        const descriptorsByKey = new Map();
+        for (const cardFormat of options.anki.cardFormats) {
+            const [firstFieldName] = Object.keys(cardFormat.fields);
+            if (typeof firstFieldName !== 'string') { continue; }
+
+            const descriptor = this._getAnkiDuplicateCacheDescriptor(
+                this._createAnkiDuplicateCacheStartupNote(cardFormat, options.anki, firstFieldName),
+                'any',
+            );
+            if (descriptor === null || descriptorsByKey.has(descriptor.key)) { continue; }
+            descriptorsByKey.set(descriptor.key, descriptor);
+        }
+        return [...descriptorsByKey.values()];
+    }
+
+    /**
+     * @returns {Promise<void>}
+     */
+    async _warmAnkiDuplicateCacheStartupBuckets() {
+        for (const descriptor of this._getAnkiDuplicateCacheStartupDescriptors()) {
+            if (this._ankiDuplicateCache.has(descriptor.key)) { continue; }
+
+            const bucket = {
+                status: /** @type {'pending'} */ ('pending'),
+                fieldNameLower: descriptor.fieldNameLower,
+                query: descriptor.query,
+                noteIdsByFieldValue: new Map(),
+            };
+            this._ankiDuplicateCache.set(descriptor.key, bucket);
+            void this._warmAnkiDuplicateCacheBucket(bucket);
+        }
+    }
+
+    /**
+     * @param {{status: 'pending'|'ready'|'error', fieldNameLower: string, query: string, noteIdsByFieldValue: Map<string, number[]>}} bucket
+     * @returns {Promise<void>}
+     */
+    async _warmAnkiDuplicateCacheBucket(bucket) {
         try {
-            canAddArray = await this._findDuplicates(notes, strippedNotes);
+            const noteIds = await this._anki.findNotes(bucket.query);
+            const notesInfo = (noteIds.length > 0 ? await this._anki.notesInfo(noteIds) : []);
+            /** @type {Map<string, number[]>} */
+            const noteIdsByFieldValue = new Map();
+            for (const noteInfo of notesInfo) {
+                if (noteInfo === null) { continue; }
+                const fieldValue = this._getAnkiDuplicateCacheFieldValueFromNoteInfo(noteInfo, bucket.fieldNameLower);
+                if (fieldValue === null) { continue; }
+
+                let fieldNoteIds = noteIdsByFieldValue.get(fieldValue);
+                if (typeof fieldNoteIds === 'undefined') {
+                    fieldNoteIds = [];
+                    noteIdsByFieldValue.set(fieldValue, fieldNoteIds);
+                }
+                fieldNoteIds.push(noteInfo.noteId);
+            }
+            bucket.noteIdsByFieldValue = noteIdsByFieldValue;
+            bucket.status = 'ready';
         } catch (e) {
-            // User has older anki-connect that does not support canAddNotesWithErrorDetail
-            if (e instanceof ExtensionError && e.message.includes('Anki error: unsupported action')) {
-                const strippedNotesAllowDuplicates = strippedNotes.map((note) => ({
-                    ...note,
-                    options: {...note.options, allowDuplicate: true},
-                }));
-                canAddArray = await this._findDuplicatesFallback(notes, strippedNotes, strippedNotesAllowDuplicates);
-            } else {
-                throw e;
+            bucket.status = 'error';
+            log.error(e);
+        }
+    }
+
+    /**
+     * @param {import('anki').NoteInfo} noteInfo
+     * @param {string} fieldNameLower
+     * @returns {?string}
+     */
+    _getAnkiDuplicateCacheFieldValueFromNoteInfo(noteInfo, fieldNameLower) {
+        for (const [fieldName, fieldInfo] of Object.entries(noteInfo.fields)) {
+            if (fieldName.toLowerCase() !== fieldNameLower) { continue; }
+            return typeof fieldInfo.value === 'string' ? fieldInfo.value : null;
+        }
+        return null;
+    }
+
+    /**
+     * @param {import('anki').Note} note
+     * @returns {number[]|null}
+     */
+    _getAnkiDuplicateCacheNoteIds(note) {
+        const descriptor = this._getAnkiDuplicateCacheDescriptor(note);
+        if (descriptor === null) { return null; }
+
+        const bucket = this._ankiDuplicateCache.get(descriptor.key);
+        if (typeof bucket === 'undefined' || bucket.status !== 'ready') { return null; }
+
+        return [...(bucket.noteIdsByFieldValue.get(descriptor.fieldValue) ?? [])];
+    }
+
+    /**
+     * @param {import('anki').Note} note
+     * @param {number} noteId
+     */
+    _addAnkiDuplicateCacheNote(note, noteId) {
+        const descriptor = this._getAnkiDuplicateCacheDescriptor(note);
+        if (descriptor === null) { return; }
+
+        const bucket = this._ankiDuplicateCache.get(descriptor.key);
+        if (typeof bucket === 'undefined' || bucket.status !== 'ready') { return; }
+
+        let noteIds = bucket.noteIdsByFieldValue.get(descriptor.fieldValue);
+        if (typeof noteIds === 'undefined') {
+            noteIds = [];
+            bucket.noteIdsByFieldValue.set(descriptor.fieldValue, noteIds);
+        }
+        if (!noteIds.includes(noteId)) {
+            noteIds.push(noteId);
+        }
+    }
+
+    /**
+     * @param {number} noteId
+     */
+    _removeAnkiDuplicateCacheNoteId(noteId) {
+        for (const bucket of this._ankiDuplicateCache.values()) {
+            if (bucket.status !== 'ready') { continue; }
+            for (const [fieldValue, noteIds] of bucket.noteIdsByFieldValue.entries()) {
+                const filteredNoteIds = noteIds.filter((cachedNoteId) => cachedNoteId !== noteId);
+                if (filteredNoteIds.length === noteIds.length) { continue; }
+                if (filteredNoteIds.length === 0) {
+                    bucket.noteIdsByFieldValue.delete(fieldValue);
+                } else {
+                    bucket.noteIdsByFieldValue.set(fieldValue, filteredNoteIds);
+                }
             }
         }
-        return {canAddArray, strippedNotes};
+    }
+
+    /**
+     * @param {import('anki').Note[]} notes
+     * @param {import('anki').Note[]} strippedNotes
+     * @returns {Promise<Array<{note: import('anki').Note, isDuplicate: boolean, cachedNoteIds: number[]|null}>>}
+     */
+    async _findDuplicatesWithCache(notes, strippedNotes) {
+        /** @type {Array<{note: import('anki').Note, isDuplicate: boolean, cachedNoteIds: number[]|null}>} */
+        const results = new Array(notes.length);
+        /** @type {import('anki').Note[]} */
+        const fallbackNotes = [];
+        /** @type {import('anki').Note[]} */
+        const fallbackStrippedNotes = [];
+        /** @type {number[]} */
+        const fallbackIndices = [];
+
+        for (let i = 0, ii = strippedNotes.length; i < ii; ++i) {
+            const cachedNoteIds = this._getAnkiDuplicateCacheNoteIds(strippedNotes[i]);
+            if (cachedNoteIds !== null) {
+                results[i] = {
+                    note: notes[i],
+                    isDuplicate: cachedNoteIds.length > 0,
+                    cachedNoteIds,
+                };
+            } else {
+                fallbackNotes.push(notes[i]);
+                fallbackStrippedNotes.push(strippedNotes[i]);
+                fallbackIndices.push(i);
+            }
+        }
+
+        if (fallbackIndices.length > 0) {
+            const fallbackResults = await this._findDuplicatesLive(fallbackNotes, fallbackStrippedNotes);
+            for (let i = 0, ii = fallbackResults.length; i < ii; ++i) {
+                results[fallbackIndices[i]] = {
+                    ...fallbackResults[i],
+                    cachedNoteIds: null,
+                };
+            }
+        }
+
+        return results;
     }
 
     /** @type {import('api').ApiHandler<'getAnkiNoteInfo'>} */
@@ -952,10 +1211,16 @@ export class Backend {
             const duplicateNoteIndices = [];
 
             for (let i = 0; i < canAddArray.length; i++) {
-                if (canAddArray[i].isDuplicate) {
-                    duplicateNotes.push(strippedNotes[i]);
-                    duplicateNoteIndices.push(i);
+                const {cachedNoteIds, isDuplicate} = canAddArray[i];
+                if (!isDuplicate) { continue; }
+
+                if (Array.isArray(cachedNoteIds)) {
+                    duplicateNoteIdsByIndex[i] = (cachedNoteIds.length > 0 ? cachedNoteIds : [INVALID_NOTE_ID]);
+                    continue;
                 }
+
+                duplicateNotes.push(strippedNotes[i]);
+                duplicateNoteIndices.push(i);
             }
 
             const duplicateNoteIdResults =
@@ -1876,6 +2141,7 @@ export class Backend {
         void this._accessibilityController.update(this._getOptionsFull(false));
 
         this._textParseCache.clear();
+        this._ankiDuplicateCache.clear();
 
         this._sendMessageAllTabsIgnoreResponse({action: 'applicationOptionsUpdated', params: {source}});
     }

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -1025,7 +1025,7 @@ export class Backend {
         if (!this._anki.enabled) { return []; }
 
         const options = this._getProfileOptions({current: true}, false);
-        /** @type {Map<string, ReturnType<Backend['_getAnkiDuplicateCacheDescriptor']>>} */
+        /** @type {Map<string, NonNullable<ReturnType<Backend['_getAnkiDuplicateCacheDescriptor']>>>} */
         const descriptorsByKey = new Map();
         for (const cardFormat of options.anki.cardFormats) {
             const [firstFieldName] = Object.keys(cardFormat.fields);

--- a/ext/js/comm/anki-connect.js
+++ b/ext/js/comm/anki-connect.js
@@ -19,7 +19,7 @@
 import {ExtensionError} from '../core/extension-error.js';
 import {parseJson} from '../core/json.js';
 import {isObjectNotArray} from '../core/object-utilities.js';
-import {getRootDeckName} from '../data/anki-util.js';
+import {createAnkiNoteDuplicateSearchDetails} from '../data/anki-note-query-util.js';
 
 /**
  * This class controls communication with Anki via the AnkiConnect plugin.
@@ -317,7 +317,12 @@ export class AnkiConnect {
         const allNoteIds = [];
 
         for (const note of notes) {
-            const query = this._getNoteQuery(note);
+            const duplicateSearchDetails = createAnkiNoteDuplicateSearchDetails(note);
+            if (duplicateSearchDetails === null) {
+                allNoteIds.push([]);
+                continue;
+            }
+            const {query} = duplicateSearchDetails;
             let actionsTargets = actionsTargetsMap.get(query);
             if (typeof actionsTargets === 'undefined') {
                 actionsTargets = [];
@@ -522,61 +527,6 @@ export class AnkiConnect {
             throw this._createUnexpectedResultError('array', result);
         }
         return result;
-    }
-
-    /**
-     * @param {string} text
-     * @returns {string}
-     */
-    _escapeQuery(text) {
-        return text.replace(/"/g, '');
-    }
-
-    /**
-     * @param {import('anki').NoteFields} fields
-     * @returns {string}
-     */
-    _fieldsToQuery(fields) {
-        const fieldNames = Object.keys(fields);
-        if (fieldNames.length === 0) {
-            return '';
-        }
-
-        const key = fieldNames[0];
-        return `"${key.toLowerCase()}:${this._escapeQuery(fields[key])}"`;
-    }
-
-    /**
-     * @param {import('anki').Note} note
-     * @returns {?('collection'|'deck'|'deck-root')}
-     */
-    _getDuplicateScopeFromNote(note) {
-        const {options} = note;
-        if (typeof options === 'object' && options !== null) {
-            const {duplicateScope} = options;
-            if (typeof duplicateScope !== 'undefined') {
-                return duplicateScope;
-            }
-        }
-        return null;
-    }
-
-    /**
-     * @param {import('anki').Note} note
-     * @returns {string}
-     */
-    _getNoteQuery(note) {
-        let query = '';
-        switch (this._getDuplicateScopeFromNote(note)) {
-            case 'deck':
-                query = `"deck:${this._escapeQuery(note.deckName)}" `;
-                break;
-            case 'deck-root':
-                query = `"deck:${this._escapeQuery(getRootDeckName(note.deckName))}" `;
-                break;
-        }
-        query += this._fieldsToQuery(note.fields);
-        return query;
     }
 
     /**

--- a/ext/js/data/anki-note-query-util.js
+++ b/ext/js/data/anki-note-query-util.js
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2026  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {getRootDeckName} from './anki-util.js';
+
+/**
+ * @param {string} text
+ * @returns {string}
+ */
+function escapeAnkiSearchValue(text) {
+    return text.replace(/"/g, '');
+}
+
+/**
+ * @param {string} key
+ * @param {string} value
+ * @param {boolean} [negative=false]
+ * @returns {string}
+ */
+function createAnkiSearchToken(key, value, negative = false) {
+    return `"${negative ? '-' : ''}${key}:${escapeAnkiSearchValue(value)}"`;
+}
+
+/**
+ * @param {import('anki').Note} note
+ * @returns {?{name: string, value: string}}
+ */
+export function getAnkiNotePrimaryField(note) {
+    if (typeof note !== 'object' || note === null) { return null; }
+    const {fields} = note;
+    if (typeof fields !== 'object' || fields === null) { return null; }
+
+    for (const [name, value] of Object.entries(fields)) {
+        if (typeof value === 'string') {
+            return {name, value};
+        }
+    }
+
+    return null;
+}
+
+/**
+ * @param {import('anki').Note} note
+ * @returns {{
+ *   duplicateScope: 'collection'|'deck',
+ *   deckName: string|null,
+ *   checkChildren: boolean,
+ *   checkAllModels: boolean,
+ * }}
+ */
+export function normalizeAnkiDuplicateScope(note) {
+    const options = (
+        typeof note === 'object' &&
+        note !== null &&
+        typeof note.options === 'object' &&
+        note.options !== null
+    ) ? note.options : null;
+    const duplicateScopeRaw = typeof options?.duplicateScope === 'string' ? options.duplicateScope : 'collection';
+    const duplicateScopeOptions = (
+        typeof options?.duplicateScopeOptions === 'object' &&
+        options.duplicateScopeOptions !== null
+    ) ? options.duplicateScopeOptions : null;
+
+    let deckName = typeof duplicateScopeOptions?.deckName === 'string' ? duplicateScopeOptions.deckName : '';
+    if (deckName.length === 0) {
+        deckName = typeof note.deckName === 'string' ? note.deckName : '';
+    }
+    let checkChildren = duplicateScopeOptions?.checkChildren === true;
+    const checkAllModels = duplicateScopeOptions?.checkAllModels === true;
+
+    switch (duplicateScopeRaw) {
+        case 'deck-root':
+            deckName = getRootDeckName(deckName);
+            checkChildren = true;
+            return {
+                duplicateScope: 'deck',
+                deckName,
+                checkChildren,
+                checkAllModels,
+            };
+        case 'deck':
+            return {
+                duplicateScope: 'deck',
+                deckName,
+                checkChildren,
+                checkAllModels,
+            };
+        default:
+            return {
+                duplicateScope: 'collection',
+                deckName: null,
+                checkChildren: false,
+                checkAllModels,
+            };
+    }
+}
+
+/**
+ * @param {import('anki').Note} note
+ * @param {'exact'|'any'} [fieldValueMode='exact']
+ * @returns {?{
+ *   query: string,
+ *   fieldName: string,
+ *   fieldNameLower: string,
+ *   fieldValue: string,
+ *   duplicateScope: 'collection'|'deck',
+ *   deckName: string|null,
+ *   checkChildren: boolean,
+ *   checkAllModels: boolean,
+ *   modelName: string,
+ * }}
+ */
+export function createAnkiNoteDuplicateSearchDetails(note, fieldValueMode = 'exact') {
+    const primaryField = getAnkiNotePrimaryField(note);
+    if (primaryField === null) { return null; }
+
+    const {duplicateScope, deckName, checkChildren, checkAllModels} = normalizeAnkiDuplicateScope(note);
+    const modelName = typeof note.modelName === 'string' ? note.modelName : '';
+
+    /** @type {string[]} */
+    const queryParts = [];
+    if (duplicateScope === 'deck') {
+        if (typeof deckName !== 'string' || deckName.length === 0) { return null; }
+        queryParts.push(createAnkiSearchToken('deck', deckName));
+        if (!checkChildren) {
+            queryParts.push(createAnkiSearchToken('deck', `${deckName}::*`, true));
+        }
+    }
+
+    if (!checkAllModels) {
+        if (modelName.length === 0) { return null; }
+        queryParts.push(createAnkiSearchToken('note', modelName));
+    }
+
+    queryParts.push(createAnkiSearchToken(primaryField.name.toLowerCase(), fieldValueMode === 'any' ? '*' : primaryField.value));
+
+    return {
+        query: queryParts.join(' '),
+        fieldName: primaryField.name,
+        fieldNameLower: primaryField.name.toLowerCase(),
+        fieldValue: primaryField.value,
+        duplicateScope,
+        deckName,
+        checkChildren,
+        checkAllModels,
+        modelName,
+    };
+}

--- a/ext/js/data/anki-note-query-util.js
+++ b/ext/js/data/anki-note-query-util.js
@@ -68,12 +68,18 @@ export function normalizeAnkiDuplicateScope(note) {
         note !== null &&
         typeof note.options === 'object' &&
         note.options !== null
-    ) ? note.options : null;
-    const duplicateScopeRaw = typeof options?.duplicateScope === 'string' ? options.duplicateScope : 'collection';
+    ) ?
+        note.options :
+        null;
+    const duplicateScopeRaw = typeof options?.duplicateScope === 'string' ?
+        options.duplicateScope :
+        'collection';
     const duplicateScopeOptions = (
         typeof options?.duplicateScopeOptions === 'object' &&
         options.duplicateScopeOptions !== null
-    ) ? options.duplicateScopeOptions : null;
+    ) ?
+        options.duplicateScopeOptions :
+        null;
 
     let deckName = typeof duplicateScopeOptions?.deckName === 'string' ? duplicateScopeOptions.deckName : '';
     if (deckName.length === 0) {

--- a/test/backend-anki-deduplication.test.js
+++ b/test/backend-anki-deduplication.test.js
@@ -25,6 +25,36 @@ vi.mock('../ext/lib/kanji-processor.js', () => ({
     convertVariants: (text) => text,
 }));
 
+vi.mock('../ext/js/comm/yomitan-api.js', () => ({
+    YomitanApi: class {
+        async setEnabled() {}
+    },
+}));
+
+vi.mock('../ext/js/dictionary/dictionary-database.js', () => ({
+    DictionaryDatabase: class {},
+}));
+
+vi.mock('../ext/js/dictionary/dictionary-worker.js', () => ({
+    DictionaryWorker: class {},
+}));
+
+vi.mock('../ext/js/language/translator.js', () => ({
+    Translator: class {},
+}));
+
+vi.mock('../ext/js/language/languages.js', () => ({
+    getLanguageSummaries: () => [],
+    isTextLookupWorthy: () => true,
+}));
+
+vi.mock('../ext/js/language/ja/japanese.js', () => ({
+    distributeFuriganaInflected: () => [],
+    getKanaScriptType: () => null,
+    isCodePointJapanese: () => false,
+    convertKatakanaToHiragana: (text) => text,
+}));
+
 const {Backend} = await import('../ext/js/background/backend.js');
 
 /**
@@ -67,12 +97,99 @@ function createNote(front, back) {
 }
 
 /**
+ * @param {Partial<import('settings').AnkiCardFormat>} [overrides]
+ * @returns {import('settings').AnkiCardFormat}
+ */
+function createCardFormat(overrides = {}) {
+    return {
+        type: 'term',
+        name: 'Test',
+        deck: 'deck',
+        model: 'model',
+        fields: {
+            Front: {value: '{expression}', overwriteMode: 'overwrite'},
+            Back: {value: '{glossary}', overwriteMode: 'overwrite'},
+        },
+        icon: 'big-circle',
+        ...overrides,
+    };
+}
+
+/**
+ * @param {{
+ *   duplicateScope?: import('settings').AnkiDuplicateScope,
+ *   duplicateScopeCheckAllModels?: boolean,
+ *   cardFormats?: import('settings').AnkiCardFormat[],
+ * }} [overrides]
+ * @returns {import('settings').ProfileOptions}
+ */
+function createProfileOptions(overrides = {}) {
+    const {
+        duplicateScope = 'collection',
+        duplicateScopeCheckAllModels = false,
+        cardFormats = [createCardFormat()],
+    } = overrides;
+    return /** @type {import('settings').ProfileOptions} */ ({
+        anki: {
+            enable: true,
+            duplicateScope,
+            duplicateScopeCheckAllModels,
+            cardFormats,
+        },
+    });
+}
+
+/**
+ * @param {import('anki').Note} note
+ * @returns {import('anki').Note}
+ */
+function createDuplicateProbeNote(note) {
+    const [firstFieldName] = Object.keys(note.fields);
+    return {
+        ...note,
+        fields: {[firstFieldName]: note.fields[firstFieldName]},
+        options: {...note.options, allowDuplicate: false},
+    };
+}
+
+/**
+ * @param {number} noteId
+ * @param {string} fieldName
+ * @param {string} fieldValue
+ * @param {string} [modelName='model']
+ * @returns {import('anki').NoteInfo}
+ */
+function createNoteInfo(noteId, fieldName, fieldValue, modelName = 'model') {
+    return {
+        noteId,
+        fields: {
+            [fieldName]: {value: fieldValue, order: 0},
+        },
+        modelName,
+        cards: [noteId + 1000],
+        cardsInfo: [],
+        tags: [],
+    };
+}
+
+/**
  * @param {import('anki').CanAddNotesDetail[]} canAddNotesWithErrorDetail
  * @param {number[][]} duplicateNoteIds
+ * @param {{
+ *   profileOptions?: import('settings').ProfileOptions,
+ *   findNotes?: ReturnType<typeof vi.fn>,
+ *   findNoteIds?: ReturnType<typeof vi.fn>,
+ *   notesInfo?: ReturnType<typeof vi.fn>,
+ *   cardsInfo?: ReturnType<typeof vi.fn>,
+ *   canAddNotesWithErrorDetailFn?: ReturnType<typeof vi.fn>,
+ *   canAddNotes?: ReturnType<typeof vi.fn>,
+ *   addNote?: ReturnType<typeof vi.fn>,
+ *   updateNoteFields?: ReturnType<typeof vi.fn>,
+ * }} [overrides]
  * @returns {any}
  */
-function createBackendContext(canAddNotesWithErrorDetail, duplicateNoteIds) {
-    const notesInfo = vi.fn(async (/** @type {number[]} */ noteIds) => noteIds.map((/** @type {number} */ noteId) => ({
+function createBackendContext(canAddNotesWithErrorDetail, duplicateNoteIds, overrides = {}) {
+    const notesInfo = overrides.notesInfo ?? vi.fn(async (/** @type {number[]} */ noteIds) => noteIds.map((/** @type {number} */ noteId) => ({
         noteId,
         fields: {},
         modelName: 'Model',
@@ -80,7 +197,7 @@ function createBackendContext(canAddNotesWithErrorDetail, duplicateNoteIds) {
         cardsInfo: [],
         tags: [],
     })));
-    const cardsInfo = vi.fn(async (/** @type {number[]} */ cardIds) => cardIds.map((/** @type {number} */ cardId) => ({
+    const cardsInfo = overrides.cardsInfo ?? vi.fn(async (/** @type {number[]} */ cardIds) => cardIds.map((/** @type {number} */ cardId) => ({
         noteId: cardId - 1000,
         cardId,
         cardState: 0,
@@ -88,20 +205,97 @@ function createBackendContext(canAddNotesWithErrorDetail, duplicateNoteIds) {
     })));
     return /** @type {any} */ ({
         _anki: {
-            canAddNotesWithErrorDetail: vi.fn(async () => canAddNotesWithErrorDetail),
-            findNoteIds: vi.fn(async () => duplicateNoteIds),
+            server: 'http://anki.invalid',
+            apiKey: null,
+            enabled: true,
+            canAddNotesWithErrorDetail: overrides.canAddNotesWithErrorDetailFn ?? vi.fn(async () => canAddNotesWithErrorDetail),
+            canAddNotes: overrides.canAddNotes ?? vi.fn(async () => canAddNotesWithErrorDetail.map(({canAdd}) => canAdd)),
+            findNotes: overrides.findNotes ?? vi.fn(async () => []),
+            findNoteIds: overrides.findNoteIds ?? vi.fn(async () => duplicateNoteIds),
             notesInfo,
             cardsInfo,
+            addNote: overrides.addNote ?? vi.fn(async () => null),
+            updateNoteFields: overrides.updateNoteFields ?? vi.fn(async () => null),
         },
+        _ankiDuplicateCache: new Map(),
+        _getProfileOptions: overrides.profileOptions ? vi.fn(() => overrides.profileOptions) : vi.fn(() => createProfileOptions()),
         _stripNotesArray: getBackendMethod('_stripNotesArray'),
         _findDuplicates: getBackendMethod('_findDuplicates'),
         _findDuplicatesFallback: getBackendMethod('_findDuplicatesFallback'),
+        _findDuplicatesLive: getBackendMethod('_findDuplicatesLive'),
+        _getAnkiDuplicateCacheDescriptor: getBackendMethod('_getAnkiDuplicateCacheDescriptor'),
+        _createAnkiDuplicateCacheStartupNote: getBackendMethod('_createAnkiDuplicateCacheStartupNote'),
+        _getAnkiDuplicateCacheStartupDescriptors: getBackendMethod('_getAnkiDuplicateCacheStartupDescriptors'),
+        _warmAnkiDuplicateCacheStartupBuckets: getBackendMethod('_warmAnkiDuplicateCacheStartupBuckets'),
+        _warmAnkiDuplicateCacheBucket: getBackendMethod('_warmAnkiDuplicateCacheBucket'),
+        _getAnkiDuplicateCacheFieldValueFromNoteInfo: getBackendMethod('_getAnkiDuplicateCacheFieldValueFromNoteInfo'),
+        _getAnkiDuplicateCacheNoteIds: getBackendMethod('_getAnkiDuplicateCacheNoteIds'),
+        _addAnkiDuplicateCacheNote: getBackendMethod('_addAnkiDuplicateCacheNote'),
+        _removeAnkiDuplicateCacheNoteId: getBackendMethod('_removeAnkiDuplicateCacheNoteId'),
+        _findDuplicatesWithCache: getBackendMethod('_findDuplicatesWithCache'),
         partitionAddibleNotes: getBackendMethod('partitionAddibleNotes'),
         _notesCardsInfoBatched: getBackendMethod('_notesCardsInfoBatched'),
     });
 }
 
+/**
+ * @param {any} context
+ * @param {import('anki').Note} note
+ * @param {'pending'|'ready'|'error'} status
+ * @param {Map<string, number[]>} [noteIdsByFieldValue]
+ * @returns {any}
+ */
+function setDuplicateCacheBucket(context, note, status, noteIdsByFieldValue = new Map()) {
+    const descriptor = /** @type {any} */ (
+        getBackendMethod('_getAnkiDuplicateCacheDescriptor').call(context, createDuplicateProbeNote(note))
+    );
+    context._ankiDuplicateCache.set(descriptor.key, {
+        status,
+        fieldNameLower: descriptor.fieldNameLower,
+        query: descriptor.query,
+        noteIdsByFieldValue,
+    });
+    return descriptor;
+}
+
 describe('Backend Anki deduplication', () => {
+    test.each([
+        [
+            'collection scope',
+            createProfileOptions({duplicateScope: 'collection'}),
+            '"note:model" "front:*"',
+        ],
+        [
+            'exact deck scope',
+            createProfileOptions({
+                duplicateScope: 'deck',
+                cardFormats: [createCardFormat({deck: 'Deck'})],
+            }),
+            '"deck:Deck" "-deck:Deck::*" "note:model" "front:*"',
+        ],
+        [
+            'deck-root scope',
+            createProfileOptions({
+                duplicateScope: 'deck-root',
+                cardFormats: [createCardFormat({deck: 'Root::Child'})],
+            }),
+            '"deck:Root" "note:model" "front:*"',
+        ],
+        [
+            'all-model collection scope',
+            createProfileOptions({duplicateScopeCheckAllModels: true}),
+            '"front:*"',
+        ],
+    ])('startup warmup builds the right %s query', (_label, profileOptions, expectedQuery) => {
+        const context = createBackendContext([], [], {profileOptions});
+
+        const [descriptor] = /** @type {any[]} */ (
+            getBackendMethod('_getAnkiDuplicateCacheStartupDescriptors').call(context)
+        );
+
+        expect(descriptor?.query).toBe(expectedQuery);
+    });
+
     test('getAnkiNoteInfo looks up duplicate note ids using stripped probe notes', async () => {
         const notes = [
             createNote('term-1', 'back-field-1'),
@@ -160,6 +354,67 @@ describe('Backend Anki deduplication', () => {
         ]);
     });
 
+    test('getAnkiNoteInfo uses ready duplicate cache buckets before live Anki duplicate checks', async () => {
+        const note = createNote('cached-term', 'back-field');
+        const context = createBackendContext([
+            {canAdd: false, error: 'cannot create note because it is a duplicate'},
+        ], [[42]]);
+        const descriptor = setDuplicateCacheBucket(
+            context,
+            note,
+            'ready',
+            new Map([['cached-term', [777]]]),
+        );
+
+        const result = /** @type {import('anki').NoteInfoWrapper[]} */ (
+            await getBackendMethod('_onApiGetAnkiNoteInfo').call(context, {notes: [note], fetchAdditionalInfo: false})
+        );
+
+        expect(descriptor.query).toBe('"note:model" "front:cached-term"');
+        expect(context._anki.canAddNotesWithErrorDetail).not.toHaveBeenCalled();
+        expect(context._anki.findNoteIds).not.toHaveBeenCalled();
+        expect(result).toStrictEqual([
+            {canAdd: true, valid: true, isDuplicate: true, noteIds: [777], noteInfos: []},
+        ]);
+    });
+
+    test('pending duplicate cache buckets fall back to live Anki duplicate checks', async () => {
+        const note = createNote('pending-term', 'back-field');
+        const context = createBackendContext([
+            {canAdd: false, error: 'cannot create note because it is a duplicate'},
+        ], [[42]]);
+        setDuplicateCacheBucket(context, note, 'pending');
+
+        const result = /** @type {import('anki').NoteInfoWrapper[]} */ (
+            await getBackendMethod('_onApiGetAnkiNoteInfo').call(context, {
+                notes: [note],
+                fetchAdditionalInfo: false,
+                fetchDuplicateNoteIds: false,
+            })
+        );
+
+        expect(context._anki.canAddNotesWithErrorDetail).toHaveBeenCalledTimes(1);
+        expect(result).toStrictEqual([
+            {canAdd: true, valid: true, isDuplicate: true, noteIds: null, noteInfos: []},
+        ]);
+    });
+
+    test('fallback duplicate checks do not populate the startup cache', async () => {
+        const note = createNote('uncached-term', 'back-field');
+        const context = createBackendContext([
+            {canAdd: true, error: null},
+        ], []);
+
+        await getBackendMethod('_onApiGetAnkiNoteInfo').call(context, {
+            notes: [note],
+            fetchAdditionalInfo: false,
+            fetchDuplicateNoteIds: false,
+        });
+
+        expect(context._anki.canAddNotesWithErrorDetail).toHaveBeenCalledTimes(1);
+        expect(context._ankiDuplicateCache.size).toBe(0);
+    });
+
     test('getAnkiNoteInfo batches additional note lookups across duplicates', async () => {
         const notes = [
             createNote('term-1', 'back-field-1'),
@@ -181,5 +436,57 @@ describe('Backend Anki deduplication', () => {
         expect(result.map(({isDuplicate}) => isDuplicate)).toStrictEqual([true, true]);
         expect(result.map(({noteInfos}) => noteInfos?.[0]?.noteId ?? null)).toStrictEqual([101, 202]);
         expect(result.map(({noteInfos}) => noteInfos?.[0]?.cardsInfo.length ?? 0)).toStrictEqual([1, 1]);
+    });
+
+    test('startup warmup caches duplicate field values by query bucket', async () => {
+        const findNotes = vi.fn(async () => [11, 12]);
+        const notesInfo = vi.fn(async () => [
+            createNoteInfo(11, 'Front', 'alpha'),
+            createNoteInfo(12, 'Front', 'beta'),
+        ]);
+        const context = createBackendContext([], [], {
+            profileOptions: createProfileOptions(),
+            findNotes,
+            notesInfo,
+        });
+
+        await getBackendMethod('_warmAnkiDuplicateCacheStartupBuckets').call(context);
+        await vi.waitFor(() => {
+            expect(findNotes).toHaveBeenCalledWith('"note:model" "front:*"');
+            const [bucket] = context._ankiDuplicateCache.values();
+            expect(bucket?.status).toBe('ready');
+        });
+
+        const [bucket] = context._ankiDuplicateCache.values();
+        expect(bucket?.noteIdsByFieldValue.get('alpha')).toStrictEqual([11]);
+        expect(bucket?.noteIdsByFieldValue.get('beta')).toStrictEqual([12]);
+    });
+
+    test('backend add and update note operations keep ready duplicate cache buckets in sync', async () => {
+        const addNote = vi.fn(async () => 301);
+        const updateNoteFields = vi.fn(async () => null);
+        const note = createNote('initial-term', 'back-field');
+        const context = createBackendContext([], [], {addNote, updateNoteFields});
+        setDuplicateCacheBucket(context, note, 'ready');
+
+        await getBackendMethod('_onApiAddAnkiNote').call(context, {note});
+
+        let [bucket] = context._ankiDuplicateCache.values();
+        expect(bucket?.noteIdsByFieldValue.get('initial-term')).toStrictEqual([301]);
+
+        const updatedNote = {
+            ...note,
+            id: 301,
+            fields: {
+                Front: 'updated-term',
+                Back: 'back-field',
+            },
+        };
+
+        await getBackendMethod('_onApiUpdateAnkiNote').call(context, {noteWithId: updatedNote});
+
+        [bucket] = context._ankiDuplicateCache.values();
+        expect(bucket?.noteIdsByFieldValue.get('initial-term')).toBeUndefined();
+        expect(bucket?.noteIdsByFieldValue.get('updated-term')).toStrictEqual([301]);
     });
 });

--- a/test/backend-anki-deduplication.test.js
+++ b/test/backend-anki-deduplication.test.js
@@ -52,6 +52,10 @@ vi.mock('../ext/js/language/ja/japanese.js', () => ({
     distributeFuriganaInflected: () => [],
     getKanaScriptType: () => null,
     isCodePointJapanese: () => false,
+    /**
+     * @param {string} text
+     * @returns {string}
+     */
     convertKatakanaToHiragana: (text) => text,
 }));
 

--- a/test/e2e/anki-mock-state.js
+++ b/test/e2e/anki-mock-state.js
@@ -82,37 +82,50 @@ function getPrimaryField(fields) {
 
 /**
  * @param {string} query
- * @returns {{deckQuery: string|null, fieldName: string|null, fieldValue: string|null}}
+ * @returns {{deckQuery: string|null, excludedDeckQueries: string[], noteName: string|null, fieldName: string|null, fieldValue: string|null}}
  */
 function parseFindNotesQuery(query) {
     /** @type {string[]} */
     const tokens = [];
-    const pattern = /"([^"]+)"/g;
+    const pattern = /"([^"]*)"|(\S+)/g;
     while (true) {
         const match = pattern.exec(query);
         if (match === null) { break; }
-        tokens.push(match[1]);
-    }
-    if (tokens.length === 0 && query.trim().length > 0) {
-        tokens.push(query.trim());
+        tokens.push(typeof match[1] === 'string' ? match[1] : String(match[2] || ''));
     }
     let deckQuery = null;
+    /** @type {string[]} */
+    const excludedDeckQueries = [];
+    let noteName = null;
     let fieldName = null;
     let fieldValue = null;
-    for (const token of tokens) {
+    for (let token of tokens) {
+        let negative = false;
+        if (token.startsWith('-')) {
+            negative = true;
+            token = token.substring(1);
+        }
         const index = token.indexOf(':');
         if (index < 0) { continue; }
         const key = token.slice(0, index).trim();
         const value = token.slice(index + 1).trim();
         if (key.length === 0) { continue; }
         if (key.toLowerCase() === 'deck') {
-            deckQuery = value;
-        } else {
+            if (negative) {
+                excludedDeckQueries.push(value);
+            } else {
+                deckQuery = value;
+            }
+        } else if (key.toLowerCase() === 'note') {
+            if (!negative) {
+                noteName = value;
+            }
+        } else if (!negative) {
             fieldName = key;
             fieldValue = value;
         }
     }
-    return {deckQuery, fieldName, fieldValue};
+    return {deckQuery, excludedDeckQueries, noteName, fieldName, fieldValue};
 }
 
 /**
@@ -364,10 +377,16 @@ export function createAnkiMockState() {
             }
             case 'findNotes': {
                 const query = String(payload.query || '');
-                const {deckQuery, fieldName, fieldValue} = parseFindNotesQuery(query);
+                const {deckQuery, excludedDeckQueries, noteName, fieldName, fieldValue} = parseFindNotesQuery(query);
                 return notes.filter((item) => {
                     if (!item.findable) { return false; }
                     if (deckQuery !== null && !matchesDeckQuery(item, deckQuery)) {
+                        return false;
+                    }
+                    if (excludedDeckQueries.some((value) => matchesDeckQuery(item, value))) {
+                        return false;
+                    }
+                    if (noteName !== null && item.modelName.toLowerCase() !== noteName.toLowerCase()) {
                         return false;
                     }
                     if (fieldName !== null && fieldValue !== null) {

--- a/types/ext/backend.d.ts
+++ b/types/ext/backend.d.ts
@@ -49,6 +49,12 @@ export type TabInfo = {
 
 export type FindTabsPredicate = (tabInfo: TabInfo) => boolean | Promise<boolean>;
 
-export type CanAddResults = {note: import('anki').Note, isDuplicate: boolean}[];
+export type CanAddResult = {
+    note: import('anki').Note;
+    isDuplicate: boolean;
+    cachedNoteIds?: import('anki').NoteId[] | null;
+};
+
+export type CanAddResults = CanAddResult[];
 
 export type Mode = 'existingOrNewTab' | 'newTab' | 'popup';


### PR DESCRIPTION
## Summary
- add a shared Anki duplicate-query helper that normalizes scope, deck exactness, deck-root handling, and same-model vs all-model queries
- warm service-worker-lifetime duplicate buckets on startup and use them in `getAnkiNoteInfo()` before falling back to live Anki checks
- keep warmed buckets locally in sync for backend-mediated add/update note operations and extend dedupe tests plus the Anki mock query parser

## Testing
- `npx vitest run test/backend-anki-deduplication.test.js test/display-anki.test.js test/anki-note-builder.test.js`
- `npm run test:build`
- `npx eslint ext/js/background/backend.js ext/js/comm/anki-connect.js test/backend-anki-deduplication.test.js test/e2e/anki-mock-state.js`

## Notes
- cache lifetime matches the MV3 background service worker lifetime
- cache misses still use live Anki calls and do not backfill the startup cache