### PR TITLE
Add per-dictionary auto-update schedules

### DIFF
--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -37,6 +37,11 @@ import {arrayBufferToBase64, base64ToArrayBuffer} from '../data/array-buffer-uti
 import {JsonSchema} from '../data/json-schema.js';
 import {OptionsUtil} from '../data/options-util.js';
 import {getAllPermissions, hasPermissions, hasRequiredPermissionsForOptions} from '../data/permissions-util.js';
+import {
+    isDictionaryAutoUpdateSchedule,
+    normalizeDictionarySummary,
+    setDictionarySummaryAutoUpdate,
+} from '../dictionary/dictionary-auto-update-util.js';
 import {compareRevisions} from '../dictionary/dictionary-data-util.js';
 import {DictionaryDatabase} from '../dictionary/dictionary-database.js';
 import {DictionaryWorker} from '../dictionary/dictionary-worker.js';
@@ -72,6 +77,45 @@ function canAppendUngroupedParserCharacter(previousText, character) {
     const previousKanaScript = getKanaScriptType(previousCharacter);
     const currentKanaScript = getKanaScriptType(character);
     return previousKanaScript === null || currentKanaScript === null || previousKanaScript === currentKanaScript;
+}
+
+/**
+ * @param {string[]} values1
+ * @param {string[]} values2
+ * @returns {boolean}
+ */
+function areSortedStringArraysEqual(values1, values2) {
+    if (values1.length !== values2.length) {
+        return false;
+    }
+    for (let i = 0; i < values1.length; ++i) {
+        if (values1[i] !== values2[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * @param {import('dictionary-importer').Summary} summary1
+ * @param {import('dictionary-importer').Summary} summary2
+ * @returns {boolean}
+ */
+function hasDictionaryAutoUpdateMetadataChanged(summary1, summary2) {
+    const rawAutoUpdate1 = (
+        typeof summary1.autoUpdate === 'object' &&
+        summary1.autoUpdate !== null &&
+        !Array.isArray(summary1.autoUpdate)
+    ) ? /** @type {import('dictionary-importer').DictionaryAutoUpdateInfo} */ (summary1.autoUpdate) : null;
+    if (rawAutoUpdate1 === null) {
+        return true;
+    }
+    const autoUpdate2 = /** @type {import('dictionary-importer').DictionaryAutoUpdateInfo} */ (normalizeDictionarySummary(summary2).autoUpdate);
+    return (
+        rawAutoUpdate1.schedule !== autoUpdate2.schedule ||
+        rawAutoUpdate1.lastUpdatedAt !== autoUpdate2.lastUpdatedAt ||
+        rawAutoUpdate1.nextUpdateAt !== autoUpdate2.nextUpdateAt
+    );
 }
 
 /**
@@ -222,6 +266,7 @@ export class Backend {
             ['getDictionaryCounts',          this._onApiGetDictionaryCounts.bind(this)],
             ['checkDictionaryUpdates',       this._onApiCheckDictionaryUpdates.bind(this)],
             ['updateDictionaryByTitle',      this._onApiUpdateDictionaryByTitle.bind(this)],
+            ['setDictionaryUpdateSchedule',  this._onApiSetDictionaryUpdateSchedule.bind(this)],
             ['setDictionaryImportMode',      this._onApiSetDictionaryImportMode.bind(this)],
             ['purgeDatabase',                this._onApiPurgeDatabase.bind(this)],
             ['exportDictionaryDatabase',     this._onApiExportDictionaryDatabase.bind(this)],
@@ -491,6 +536,9 @@ export class Backend {
 
             await measureAsyncPhase('ensureDictionaryAutoUpdateAlarm', async () => {
                 await this._ensureDictionaryAutoUpdateAlarm();
+            });
+            await measureAsyncPhase('backfillDictionaryAutoUpdateSummarySchedules', async () => {
+                await this._backfillDictionaryAutoUpdateSummarySchedules();
             });
             void this._runDictionaryAutoUpdatePass('prepare');
 
@@ -1267,6 +1315,11 @@ export class Backend {
         return await this._updateDictionaryByTitle(dictionaryTitle, true);
     }
 
+    /** @type {import('api').ApiHandler<'setDictionaryUpdateSchedule'>} */
+    async _onApiSetDictionaryUpdateSchedule({dictionaryTitle, schedule}) {
+        return await this._setDictionaryUpdateSchedule(dictionaryTitle, schedule);
+    }
+
     /** @type {import('api').ApiHandler<'setDictionaryImportMode'>} */
     async _onApiSetDictionaryImportMode({active}) {
         await this._setDictionaryImportMode(active);
@@ -1335,9 +1388,11 @@ export class Backend {
 
     /** @type {import('api').ApiHandler<'setAllSettings'>} */
     async _onApiSetAllSettings({value, source}) {
+        const previousDictionaryAutoUpdates = this._getSortedDictionaryAutoUpdateIndexUrls();
         this._optionsUtil.validate(value);
         this._options = clone(value);
         await this._saveOptions(source);
+        await this._syncDictionaryAutoUpdateSummariesAfterOptionsChange(previousDictionaryAutoUpdates);
     }
 
     /** @type {import('api').ApiHandlerNoExtraArgs<'getOrCreateSearchPopup'>} */
@@ -1648,6 +1703,7 @@ export class Backend {
      * @returns {Promise<import('core').Response<import('settings-modifications').ModificationResult>[]>}
      */
     async _modifySettings(targets, source) {
+        const previousDictionaryAutoUpdates = this._getSortedDictionaryAutoUpdateIndexUrls();
         /** @type {import('core').Response<import('settings-modifications').ModificationResult>[]} */
         const results = [];
         for (const target of targets) {
@@ -1659,7 +1715,31 @@ export class Backend {
             }
         }
         await this._saveOptions(source);
+        await this._syncDictionaryAutoUpdateSummariesAfterOptionsChange(previousDictionaryAutoUpdates);
         return results;
+    }
+
+    /**
+     * @returns {string[]}
+     */
+    _getSortedDictionaryAutoUpdateIndexUrls() {
+        const options = this._options;
+        if (options === null) {
+            return [];
+        }
+        return [...new Set(options.global.dictionaryAutoUpdates)].sort((a, b) => a.localeCompare(b));
+    }
+
+    /**
+     * @param {string[]} previousDictionaryAutoUpdates
+     * @returns {Promise<void>}
+     */
+    async _syncDictionaryAutoUpdateSummariesAfterOptionsChange(previousDictionaryAutoUpdates) {
+        const nextDictionaryAutoUpdates = this._getSortedDictionaryAutoUpdateIndexUrls();
+        if (areSortedStringArraysEqual(previousDictionaryAutoUpdates, nextDictionaryAutoUpdates)) {
+            return;
+        }
+        await this._syncDictionaryAutoUpdateSummarySchedulesWithGlobalSettings();
     }
 
     /**
@@ -3607,9 +3687,13 @@ export class Backend {
                 const message = importResult.errors.map((error) => error.message).join('; ') || 'Dictionary import failed';
                 throw new Error(message);
             }
+            const persistedSummary = await this._setDictionarySummaryByTitle(
+                importedSummary.title,
+                this._createUpdatedDictionarySummaryAfterImport(dictionary, importedSummary),
+            );
 
-            await this._applyImportedDictionarySettings(dictionary, importedSummary, updateContext);
-            await this._updateDictionaryAutoUpdateStateAfterSuccess(dictionary, importedSummary);
+            await this._applyImportedDictionarySettings(dictionary, persistedSummary, updateContext);
+            await this._updateDictionaryAutoUpdateStateAfterSuccess(dictionary, persistedSummary);
             updateSucceeded = true;
         } catch (e) {
             const error = e instanceof Error ? e : new Error(String(e));
@@ -3661,6 +3745,75 @@ export class Backend {
             prefixWildcardsSupported: options?.global.database.prefixWildcardsSupported === true,
             yomitanVersion: chrome.runtime.getManifest().version,
         };
+    }
+
+    /**
+     * @param {string} dictionaryTitle
+     * @param {import('dictionary-importer').Summary} summary
+     * @returns {Promise<import('dictionary-importer').Summary>}
+     */
+    async _setDictionarySummaryByTitle(dictionaryTitle, summary) {
+        const persistedSummary = await this._dictionaryDatabase.updateDictionarySummaryByTitle(dictionaryTitle, summary);
+        if (persistedSummary === null) {
+            throw new Error(`Dictionary not found: ${dictionaryTitle}`);
+        }
+        return persistedSummary;
+    }
+
+    /**
+     * @param {import('dictionary-importer').Summary} previousSummary
+     * @param {import('dictionary-importer').Summary} importedSummary
+     * @returns {import('dictionary-importer').Summary}
+     */
+    _createUpdatedDictionarySummaryAfterImport(previousSummary, importedSummary) {
+        const normalizedPreviousSummary = normalizeDictionarySummary(previousSummary);
+        const normalizedImportedSummary = normalizeDictionarySummary(importedSummary);
+        const previousAutoUpdate = /** @type {import('dictionary-importer').DictionaryAutoUpdateInfo} */ (normalizedPreviousSummary.autoUpdate);
+        const nextSchedule = (
+            normalizedImportedSummary.isUpdatable === true
+        ) ? previousAutoUpdate.schedule : 'manual';
+        return setDictionarySummaryAutoUpdate(normalizedImportedSummary, {
+            schedule: nextSchedule,
+            lastUpdatedAt: normalizedImportedSummary.importDate,
+        });
+    }
+
+    /**
+     * @param {string} dictionaryTitle
+     * @param {import('dictionary-importer').DictionaryAutoUpdateSchedule} schedule
+     * @returns {Promise<import('dictionary-importer').Summary>}
+     */
+    async _setDictionaryUpdateSchedule(dictionaryTitle, schedule) {
+        if (!isDictionaryAutoUpdateSchedule(schedule)) {
+            throw new Error(`Invalid dictionary auto-update schedule: ${String(schedule)}`);
+        }
+
+        const result = await this._runWithDictionaryMutationLock(async () => {
+            await this._ensureDictionaryDatabaseReady({allowDuringMutation: true});
+            const dictionaries = await this._dictionaryDatabase.getDictionaryInfo();
+            const dictionary = dictionaries.find((item) => item.title === dictionaryTitle);
+            if (typeof dictionary === 'undefined') {
+                throw new Error(`Dictionary not found: ${dictionaryTitle}`);
+            }
+
+            const normalizedDictionary = normalizeDictionarySummary(dictionary);
+            if (schedule !== 'manual' && normalizedDictionary.isUpdatable !== true) {
+                throw new Error(`Dictionary is not updatable: ${dictionaryTitle}`);
+            }
+
+            const nextSummary = setDictionarySummaryAutoUpdate(normalizedDictionary, {schedule});
+            const persistedSummary = (
+                hasDictionaryAutoUpdateMetadataChanged(normalizedDictionary, nextSummary) ?
+                    await this._setDictionarySummaryByTitle(dictionaryTitle, nextSummary) :
+                    normalizedDictionary
+            );
+            await this._syncGlobalDictionaryAutoUpdateOptionsFromSummaries({allowDuringMutation: true});
+            return persistedSummary;
+        });
+        if (typeof result === 'undefined') {
+            throw new Error(`Failed to update dictionary schedule: ${dictionaryTitle}`);
+        }
+        return result;
     }
 
     /**
@@ -3765,17 +3918,8 @@ export class Backend {
             }
         }
 
-        const oldIndexUrl = previousSummary.indexUrl;
-        const newIndexUrl = importedSummary.indexUrl;
-        if (typeof oldIndexUrl === 'string') {
-            const enabledIndexUrls = new Set(options.global.dictionaryAutoUpdates);
-            if (enabledIndexUrls.delete(oldIndexUrl) && typeof newIndexUrl === 'string' && importedSummary.isUpdatable === true) {
-                enabledIndexUrls.add(newIndexUrl);
-            }
-            options.global.dictionaryAutoUpdates = [...enabledIndexUrls].sort((a, b) => a.localeCompare(b));
-        }
-
         await this._saveOptions('background');
+        await this._syncGlobalDictionaryAutoUpdateOptionsFromSummaries({allowDuringMutation: true});
     }
 
     /**
@@ -3795,6 +3939,94 @@ export class Backend {
             useDeinflections: true,
             styles: styles ?? '',
         };
+    }
+
+    /**
+     * @param {{allowDuringMutation?: boolean}} [root0]
+     * @returns {Promise<void>}
+     */
+    async _syncGlobalDictionaryAutoUpdateOptionsFromSummaries({allowDuringMutation = false} = {}) {
+        const options = this._options;
+        if (options === null) {
+            return;
+        }
+        await this._ensureDictionaryDatabaseReady({allowDuringMutation});
+        const dictionaries = await this._dictionaryDatabase.getDictionaryInfo();
+        const nextIndexUrls = [...new Set(
+            dictionaries
+                .filter((dictionary) => dictionary.isUpdatable === true && typeof dictionary.indexUrl === 'string')
+                .filter((dictionary) => (
+                    /** @type {import('dictionary-importer').DictionaryAutoUpdateInfo} */ (
+                        normalizeDictionarySummary(dictionary).autoUpdate
+                    )
+                ).schedule === 'hourly')
+                .map((dictionary) => /** @type {string} */ (dictionary.indexUrl)),
+        )].sort((a, b) => a.localeCompare(b));
+        if (areSortedStringArraysEqual(this._getSortedDictionaryAutoUpdateIndexUrls(), nextIndexUrls)) {
+            return;
+        }
+        options.global.dictionaryAutoUpdates = nextIndexUrls;
+        await this._saveOptions('background');
+    }
+
+    /**
+     * @returns {Promise<void>}
+     */
+    async _backfillDictionaryAutoUpdateSummarySchedules() {
+        const options = this._options;
+        if (options === null || options.global.dictionaryAutoUpdates.length === 0) {
+            return;
+        }
+        await this._runWithDictionaryMutationLock(async () => {
+            await this._ensureDictionaryDatabaseReady({allowDuringMutation: true});
+            const enabledIndexUrls = new Set(options.global.dictionaryAutoUpdates);
+            const dictionaries = await this._dictionaryDatabase.getDictionaryInfo();
+            for (const dictionary of dictionaries) {
+                const normalizedDictionary = normalizeDictionarySummary(dictionary);
+                const indexUrl = normalizedDictionary.indexUrl;
+                if (
+                    normalizedDictionary.isUpdatable !== true ||
+                    typeof indexUrl !== 'string' ||
+                    !enabledIndexUrls.has(indexUrl)
+                ) {
+                    continue;
+                }
+                const nextSummary = setDictionarySummaryAutoUpdate(normalizedDictionary, {schedule: 'hourly'});
+                if (!hasDictionaryAutoUpdateMetadataChanged(normalizedDictionary, nextSummary)) {
+                    continue;
+                }
+                await this._setDictionarySummaryByTitle(normalizedDictionary.title, nextSummary);
+            }
+        });
+    }
+
+    /**
+     * @returns {Promise<void>}
+     */
+    async _syncDictionaryAutoUpdateSummarySchedulesWithGlobalSettings() {
+        const options = this._options;
+        if (options === null) {
+            return;
+        }
+        await this._runWithDictionaryMutationLock(async () => {
+            await this._ensureDictionaryDatabaseReady({allowDuringMutation: true});
+            const enabledIndexUrls = new Set(options.global.dictionaryAutoUpdates);
+            const dictionaries = await this._dictionaryDatabase.getDictionaryInfo();
+            for (const dictionary of dictionaries) {
+                const normalizedDictionary = normalizeDictionarySummary(dictionary);
+                const indexUrl = normalizedDictionary.indexUrl;
+                if (typeof indexUrl !== 'string' || indexUrl.length === 0) {
+                    continue;
+                }
+                const nextSummary = setDictionarySummaryAutoUpdate(normalizedDictionary, {
+                    schedule: enabledIndexUrls.has(indexUrl) ? 'hourly' : 'manual',
+                });
+                if (!hasDictionaryAutoUpdateMetadataChanged(normalizedDictionary, nextSummary)) {
+                    continue;
+                }
+                await this._setDictionarySummaryByTitle(normalizedDictionary.title, nextSummary);
+            }
+        });
     }
 
     /**

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -38,6 +38,7 @@ import {JsonSchema} from '../data/json-schema.js';
 import {OptionsUtil} from '../data/options-util.js';
 import {getAllPermissions, hasPermissions, hasRequiredPermissionsForOptions} from '../data/permissions-util.js';
 import {
+    getNextDictionaryAutoUpdateTime,
     isDictionaryAutoUpdateSchedule,
     normalizeDictionarySummary,
     setDictionarySummaryAutoUpdate,
@@ -61,7 +62,6 @@ import {injectStylesheet} from './script-manager.js';
 const STARTUP_DIAGNOSTICS_STORAGE_KEY = 'manabitanStartupDiagnostics';
 const DICTIONARY_AUTO_UPDATE_STATE_STORAGE_KEY = 'manabitanDictionaryAutoUpdateState';
 const DICTIONARY_AUTO_UPDATE_ALARM_NAME = 'manabitanDictionaryAutoUpdateHourly';
-const DICTIONARY_AUTO_UPDATE_INTERVAL_MS = 60 * 60 * 1000;
 const SCAN_LENGTH_INFLECTION_BUFFER = 8;
 
 /**
@@ -106,7 +106,9 @@ function hasDictionaryAutoUpdateMetadataChanged(summary1, summary2) {
         typeof summary1.autoUpdate === 'object' &&
         summary1.autoUpdate !== null &&
         !Array.isArray(summary1.autoUpdate)
-    ) ? /** @type {import('dictionary-importer').DictionaryAutoUpdateInfo} */ (summary1.autoUpdate) : null;
+    ) ?
+        /** @type {import('dictionary-importer').DictionaryAutoUpdateInfo} */ (summary1.autoUpdate) :
+        null;
     if (rawAutoUpdate1 === null) {
         return true;
     }
@@ -3398,34 +3400,31 @@ export class Backend {
             if (options === null) {
                 return;
             }
-            const enabledIndexUrls = new Set(options.global.dictionaryAutoUpdates);
-            if (enabledIndexUrls.size === 0) {
+            await this._ensureDictionaryDatabaseReady();
+            const dictionaries = (await this._dictionaryDatabase.getDictionaryInfo()).map((dictionary) => normalizeDictionarySummary(dictionary));
+            const now = Date.now();
+            const scheduledDictionaries = dictionaries.filter((dictionary) => {
+                const autoUpdate = /** @type {import('dictionary-importer').DictionaryAutoUpdateInfo} */ (dictionary.autoUpdate);
+                return (
+                    dictionary.isUpdatable === true &&
+                    autoUpdate.schedule !== 'manual' &&
+                    typeof autoUpdate.nextUpdateAt === 'number'
+                );
+            });
+            if (scheduledDictionaries.length === 0) {
                 return;
             }
 
-            await this._ensureDictionaryDatabaseReady();
-            const dictionaries = await this._dictionaryDatabase.getDictionaryInfo();
-            const state = await this._getDictionaryAutoUpdateState();
-            const now = Date.now();
-            const dueDictionaries = dictionaries
+            const dueDictionaries = scheduledDictionaries
                 .filter((dictionary) => {
-                    const indexUrl = dictionary.indexUrl;
-                    if (
-                        dictionary.isUpdatable !== true ||
-                        typeof indexUrl !== 'string' ||
-                        indexUrl.length === 0 ||
-                        !enabledIndexUrls.has(indexUrl)
-                    ) {
-                        return false;
-                    }
-                    const lastAttemptAt = state[indexUrl]?.lastAttemptAt ?? 0;
-                    return (now - lastAttemptAt) >= DICTIONARY_AUTO_UPDATE_INTERVAL_MS;
+                    const autoUpdate = /** @type {import('dictionary-importer').DictionaryAutoUpdateInfo} */ (dictionary.autoUpdate);
+                    return (typeof autoUpdate.nextUpdateAt === 'number' && autoUpdate.nextUpdateAt <= now);
                 })
                 .sort((a, b) => a.title.localeCompare(b.title));
 
             reportDiagnostics('dictionary-auto-update-pass-begin', {
                 reason,
-                enabledCount: enabledIndexUrls.size,
+                enabledCount: scheduledDictionaries.length,
                 dueCount: dueDictionaries.length,
             });
 
@@ -3434,7 +3433,11 @@ export class Backend {
                     break;
                 }
                 const [checkResult] = await this._checkDictionaryUpdates([dictionary.title]);
-                if (typeof checkResult === 'undefined' || !checkResult.hasUpdate) {
+                if (typeof checkResult === 'undefined' || checkResult.error !== null) {
+                    continue;
+                }
+                if (!checkResult.hasUpdate) {
+                    await this._advanceDictionaryAutoUpdateScheduleAfterSuccessfulCheck(dictionary.title, Date.now());
                     continue;
                 }
                 await this._updateDictionaryByTitle(dictionary.title, false, checkResult);
@@ -3645,8 +3648,8 @@ export class Backend {
                 return /** @type {import('backend').DictionaryUpdateResult} */ ({dictionaryTitle, status: 'skipped', latestRevision: checkResult.latestRevision, error: null});
             }
             if (!waitForLock) {
-                const enabledIndexUrls = new Set(this._options?.global.dictionaryAutoUpdates ?? []);
-                if (!enabledIndexUrls.has(latestDictionary.indexUrl)) {
+                const latestAutoUpdate = /** @type {import('dictionary-importer').DictionaryAutoUpdateInfo} */ (normalizeDictionarySummary(latestDictionary).autoUpdate);
+                if (latestAutoUpdate.schedule === 'manual') {
                     return /** @type {import('backend').DictionaryUpdateResult} */ ({dictionaryTitle, status: 'skipped', latestRevision: checkResult.latestRevision, error: null});
                 }
             }
@@ -3761,6 +3764,38 @@ export class Backend {
     }
 
     /**
+     * @param {string} dictionaryTitle
+     * @param {number} referenceTimestamp
+     * @returns {Promise<import('dictionary-importer').Summary|null>}
+     */
+    async _advanceDictionaryAutoUpdateScheduleAfterSuccessfulCheck(dictionaryTitle, referenceTimestamp) {
+        const result = await this._runWithDictionaryMutationLock(async () => {
+            await this._ensureDictionaryDatabaseReady({allowDuringMutation: true});
+            const dictionaries = await this._dictionaryDatabase.getDictionaryInfo();
+            const dictionary = dictionaries.find((item) => item.title === dictionaryTitle);
+            if (typeof dictionary === 'undefined') {
+                return null;
+            }
+
+            const normalizedDictionary = normalizeDictionarySummary(dictionary);
+            const normalizedAutoUpdate = /** @type {import('dictionary-importer').DictionaryAutoUpdateInfo} */ (normalizedDictionary.autoUpdate);
+            if (normalizedDictionary.isUpdatable !== true || normalizedAutoUpdate.schedule === 'manual') {
+                return normalizedDictionary;
+            }
+
+            const nextSummary = setDictionarySummaryAutoUpdate(normalizedDictionary, {
+                nextUpdateAt: getNextDictionaryAutoUpdateTime(normalizedAutoUpdate.schedule, referenceTimestamp),
+            });
+            return (
+                hasDictionaryAutoUpdateMetadataChanged(normalizedDictionary, nextSummary) ?
+                    await this._setDictionarySummaryByTitle(dictionaryTitle, nextSummary) :
+                    normalizedDictionary
+            );
+        });
+        return (typeof result === 'undefined' ? null : result);
+    }
+
+    /**
      * @param {import('dictionary-importer').Summary} previousSummary
      * @param {import('dictionary-importer').Summary} importedSummary
      * @returns {import('dictionary-importer').Summary}
@@ -3771,7 +3806,9 @@ export class Backend {
         const previousAutoUpdate = /** @type {import('dictionary-importer').DictionaryAutoUpdateInfo} */ (normalizedPreviousSummary.autoUpdate);
         const nextSchedule = (
             normalizedImportedSummary.isUpdatable === true
-        ) ? previousAutoUpdate.schedule : 'manual';
+        ) ?
+            previousAutoUpdate.schedule :
+            'manual';
         return setDictionarySummaryAutoUpdate(normalizedImportedSummary, {
             schedule: nextSchedule,
             lastUpdatedAt: normalizedImportedSummary.importDate,
@@ -4019,9 +4056,15 @@ export class Backend {
                 if (typeof indexUrl !== 'string' || indexUrl.length === 0) {
                     continue;
                 }
-                const nextSchedule = enabledIndexUrls.has(indexUrl) ? 'hourly' : (
-                    normalizedAutoUpdate.schedule === 'hourly' ? 'manual' : normalizedAutoUpdate.schedule
-                );
+                /** @type {import('dictionary-importer').DictionaryAutoUpdateSchedule} */
+                let nextSchedule;
+                if (enabledIndexUrls.has(indexUrl)) {
+                    nextSchedule = 'hourly';
+                } else if (normalizedAutoUpdate.schedule === 'hourly') {
+                    nextSchedule = 'manual';
+                } else {
+                    nextSchedule = normalizedAutoUpdate.schedule;
+                }
                 const nextSummary = setDictionarySummaryAutoUpdate(normalizedDictionary, {
                     schedule: nextSchedule,
                 });

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -4014,12 +4014,16 @@ export class Backend {
             const dictionaries = await this._dictionaryDatabase.getDictionaryInfo();
             for (const dictionary of dictionaries) {
                 const normalizedDictionary = normalizeDictionarySummary(dictionary);
+                const normalizedAutoUpdate = /** @type {import('dictionary-importer').DictionaryAutoUpdateInfo} */ (normalizedDictionary.autoUpdate);
                 const indexUrl = normalizedDictionary.indexUrl;
                 if (typeof indexUrl !== 'string' || indexUrl.length === 0) {
                     continue;
                 }
+                const nextSchedule = enabledIndexUrls.has(indexUrl) ? 'hourly' : (
+                    normalizedAutoUpdate.schedule === 'hourly' ? 'manual' : normalizedAutoUpdate.schedule
+                );
                 const nextSummary = setDictionarySummaryAutoUpdate(normalizedDictionary, {
-                    schedule: enabledIndexUrls.has(indexUrl) ? 'hourly' : 'manual',
+                    schedule: nextSchedule,
                 });
                 if (!hasDictionaryAutoUpdateMetadataChanged(normalizedDictionary, nextSummary)) {
                     continue;

--- a/ext/js/background/offscreen-dictionary-worker.js
+++ b/ext/js/background/offscreen-dictionary-worker.js
@@ -144,6 +144,13 @@ class OffscreenDictionaryWorkerHandler {
                 this._assertDatabaseAvailable(action);
                 await this._ensureDatabasePrepared();
                 return await this._dictionaryDatabase.getDictionaryInfo();
+            case 'updateDictionarySummaryByTitleOffscreen':
+                this._assertDatabaseAvailable(action);
+                await this._ensureDatabasePrepared();
+                return await this._dictionaryDatabase.updateDictionarySummaryByTitle(
+                    /** @type {string} */ (params.dictionaryTitle ?? ''),
+                    /** @type {import('dictionary-importer').Summary} */ (params.summary ?? {}),
+                );
             case 'getMaxHeadwordLengthOffscreen':
                 this._assertDatabaseAvailable(action);
                 await this._ensureDatabasePrepared();

--- a/ext/js/background/offscreen-proxy.js
+++ b/ext/js/background/offscreen-proxy.js
@@ -227,6 +227,15 @@ export class DictionaryDatabaseProxy {
     }
 
     /**
+     * @param {string} dictionaryTitle
+     * @param {import('dictionary-importer').Summary} summary
+     * @returns {Promise<import('dictionary-importer').Summary|null>}
+     */
+    async updateDictionarySummaryByTitle(dictionaryTitle, summary) {
+        return await this._offscreen.sendMessagePromise({action: 'updateDictionarySummaryByTitleOffscreen', params: {dictionaryTitle, summary}});
+    }
+
+    /**
      * @returns {Promise<number>}
      */
     async getMaxHeadwordLength() {

--- a/ext/js/background/offscreen.js
+++ b/ext/js/background/offscreen.js
@@ -53,6 +53,7 @@ export class Offscreen {
             ['databaseRefreshOffscreen',       this._refreshDatabaseHandler.bind(this)],
             ['databaseSetSuspendedOffscreen',  this._setDatabaseSuspendedHandler.bind(this)],
             ['getDictionaryInfoOffscreen',     this._getDictionaryInfoHandler.bind(this)],
+            ['updateDictionarySummaryByTitleOffscreen', this._updateDictionarySummaryByTitleHandler.bind(this)],
             ['getMaxHeadwordLengthOffscreen',  this._getMaxHeadwordLengthHandler.bind(this)],
             ['deleteDictionaryOffscreen',      this._deleteDictionaryHandler.bind(this)],
             ['getDictionaryCountsOffscreen',   this._getDictionaryCountsHandler.bind(this)],
@@ -196,6 +197,11 @@ export class Offscreen {
     /** @type {import('offscreen').ApiHandler<'getDictionaryInfoOffscreen'>} */
     async _getDictionaryInfoHandler() {
         return await this._invokeDictionaryWorker('getDictionaryInfoOffscreen', {});
+    }
+
+    /** @type {import('offscreen').ApiHandler<'updateDictionarySummaryByTitleOffscreen'>} */
+    async _updateDictionarySummaryByTitleHandler({dictionaryTitle, summary}) {
+        return await this._invokeDictionaryWorker('updateDictionarySummaryByTitleOffscreen', {dictionaryTitle, summary});
     }
 
     /** @type {import('offscreen').ApiHandler<'getMaxHeadwordLengthOffscreen'>} */

--- a/ext/js/comm/api.js
+++ b/ext/js/comm/api.js
@@ -283,6 +283,15 @@ export class API {
     }
 
     /**
+     * @param {import('api').ApiParam<'setDictionaryUpdateSchedule', 'dictionaryTitle'>} dictionaryTitle
+     * @param {import('api').ApiParam<'setDictionaryUpdateSchedule', 'schedule'>} schedule
+     * @returns {Promise<import('api').ApiReturn<'setDictionaryUpdateSchedule'>>}
+     */
+    setDictionaryUpdateSchedule(dictionaryTitle, schedule) {
+        return this._invoke('setDictionaryUpdateSchedule', {dictionaryTitle, schedule});
+    }
+
+    /**
      * @param {import('api').ApiParam<'setDictionaryImportMode', 'active'>} active
      * @returns {Promise<import('api').ApiReturn<'setDictionaryImportMode'>>}
      */

--- a/ext/js/dictionary/dictionary-auto-update-util.js
+++ b/ext/js/dictionary/dictionary-auto-update-util.js
@@ -55,15 +55,21 @@ export function getNextDictionaryAutoUpdateTime(schedule, referenceTimestamp) {
 /**
  * @param {import('dictionary-importer').DictionaryAutoUpdateSchedule} schedule
  * @param {number|null|undefined} lastUpdatedAt
+ * @param {number|null|undefined} [nextUpdateAt]
  * @returns {import('dictionary-importer').DictionaryAutoUpdateInfo}
  */
-export function createDictionaryAutoUpdate(schedule, lastUpdatedAt) {
+export function createDictionaryAutoUpdate(schedule, lastUpdatedAt, nextUpdateAt = void 0) {
     const normalizedSchedule = isDictionaryAutoUpdateSchedule(schedule) ? schedule : 'manual';
     const normalizedLastUpdatedAt = normalizeTimestamp(lastUpdatedAt);
+    const normalizedNextUpdateAt = normalizeTimestamp(nextUpdateAt);
     return {
         schedule: normalizedSchedule,
         lastUpdatedAt: normalizedLastUpdatedAt,
-        nextUpdateAt: getNextDictionaryAutoUpdateTime(normalizedSchedule, normalizedLastUpdatedAt),
+        nextUpdateAt: (
+            normalizedSchedule === 'manual' ?
+                null :
+                normalizedNextUpdateAt ?? getNextDictionaryAutoUpdateTime(normalizedSchedule, normalizedLastUpdatedAt)
+        ),
     };
 }
 
@@ -76,20 +82,27 @@ export function normalizeDictionarySummary(summary) {
         typeof summary === 'object' &&
         summary !== null &&
         !Array.isArray(summary)
-    ) ? summary : /** @type {import('dictionary-importer').Summary} */ ({});
+    ) ?
+        summary :
+        /** @type {import('dictionary-importer').Summary} */ ({});
     const importDate = normalizeTimestamp(normalizedSummary.importDate);
-    /** @type {{schedule?: unknown, lastUpdatedAt?: unknown}} */
+    /** @type {{schedule?: unknown, lastUpdatedAt?: unknown, nextUpdateAt?: unknown}} */
     const rawAutoUpdate = (
         typeof normalizedSummary.autoUpdate === 'object' &&
         normalizedSummary.autoUpdate !== null &&
         !Array.isArray(normalizedSummary.autoUpdate)
-    ) ? normalizedSummary.autoUpdate : {};
+    ) ?
+        normalizedSummary.autoUpdate :
+        {};
     const schedule = (
         normalizedSummary.isUpdatable === true &&
         isDictionaryAutoUpdateSchedule(rawAutoUpdate.schedule)
-    ) ? rawAutoUpdate.schedule : 'manual';
+    ) ?
+        rawAutoUpdate.schedule :
+        'manual';
     const lastUpdatedAt = normalizeTimestamp(rawAutoUpdate.lastUpdatedAt) ?? importDate;
-    const autoUpdate = createDictionaryAutoUpdate(schedule, lastUpdatedAt);
+    const nextUpdateAt = normalizeTimestamp(rawAutoUpdate.nextUpdateAt);
+    const autoUpdate = createDictionaryAutoUpdate(schedule, lastUpdatedAt, nextUpdateAt);
     return {
         ...normalizedSummary,
         autoUpdate,
@@ -98,21 +111,36 @@ export function normalizeDictionarySummary(summary) {
 
 /**
  * @param {import('dictionary-importer').Summary} summary
- * @param {{schedule?: import('dictionary-importer').DictionaryAutoUpdateSchedule, lastUpdatedAt?: number|null}} [details]
+ * @param {{schedule?: import('dictionary-importer').DictionaryAutoUpdateSchedule, lastUpdatedAt?: number|null, nextUpdateAt?: number|null}} [details]
  * @returns {import('dictionary-importer').Summary}
  */
 export function setDictionarySummaryAutoUpdate(summary, details = {}) {
     const normalizedSummary = normalizeDictionarySummary(summary);
-    const {schedule, lastUpdatedAt} = details;
+    const {schedule, lastUpdatedAt, nextUpdateAt} = details;
     const normalizedAutoUpdate = /** @type {import('dictionary-importer').DictionaryAutoUpdateInfo} */ (normalizedSummary.autoUpdate);
     const requestedSchedule = typeof schedule === 'undefined' ? normalizedAutoUpdate.schedule : schedule;
     const nextSchedule = (
         normalizedSummary.isUpdatable === true &&
         isDictionaryAutoUpdateSchedule(requestedSchedule)
-    ) ? requestedSchedule : 'manual';
-    const nextLastUpdatedAt = normalizeTimestamp(lastUpdatedAt) ?? normalizedAutoUpdate.lastUpdatedAt;
+    ) ?
+        requestedSchedule :
+        'manual';
+    const nextLastUpdatedAt = Object.prototype.hasOwnProperty.call(details, 'lastUpdatedAt') ?
+        normalizeTimestamp(lastUpdatedAt) :
+        normalizedAutoUpdate.lastUpdatedAt;
+    let nextNextUpdateAt;
+    if (Object.prototype.hasOwnProperty.call(details, 'nextUpdateAt')) {
+        nextNextUpdateAt = normalizeTimestamp(nextUpdateAt);
+    } else if (
+        nextSchedule === normalizedAutoUpdate.schedule &&
+        nextLastUpdatedAt === normalizedAutoUpdate.lastUpdatedAt
+    ) {
+        nextNextUpdateAt = normalizedAutoUpdate.nextUpdateAt;
+    } else {
+        nextNextUpdateAt = null;
+    }
     return {
         ...normalizedSummary,
-        autoUpdate: createDictionaryAutoUpdate(nextSchedule, nextLastUpdatedAt),
+        autoUpdate: createDictionaryAutoUpdate(nextSchedule, nextLastUpdatedAt, nextNextUpdateAt),
     };
 }

--- a/ext/js/dictionary/dictionary-auto-update-util.js
+++ b/ext/js/dictionary/dictionary-auto-update-util.js
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2026  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const DICTIONARY_AUTO_UPDATE_INTERVALS_MS = Object.freeze({
+    manual: null,
+    hourly: 60 * 60 * 1000,
+    daily: 24 * 60 * 60 * 1000,
+    weekly: 7 * 24 * 60 * 60 * 1000,
+});
+
+/**
+ * @param {unknown} value
+ * @returns {number|null}
+ */
+function normalizeTimestamp(value) {
+    return (typeof value === 'number' && Number.isFinite(value)) ? value : null;
+}
+
+/**
+ * @param {unknown} value
+ * @returns {value is import('dictionary-importer').DictionaryAutoUpdateSchedule}
+ */
+export function isDictionaryAutoUpdateSchedule(value) {
+    return (
+        typeof value === 'string' &&
+        Object.prototype.hasOwnProperty.call(DICTIONARY_AUTO_UPDATE_INTERVALS_MS, value)
+    );
+}
+
+/**
+ * @param {import('dictionary-importer').DictionaryAutoUpdateSchedule} schedule
+ * @param {number|null|undefined} referenceTimestamp
+ * @returns {number|null}
+ */
+export function getNextDictionaryAutoUpdateTime(schedule, referenceTimestamp) {
+    const interval = isDictionaryAutoUpdateSchedule(schedule) ? DICTIONARY_AUTO_UPDATE_INTERVALS_MS[schedule] : null;
+    const normalizedReferenceTimestamp = normalizeTimestamp(referenceTimestamp);
+    return (interval !== null && normalizedReferenceTimestamp !== null) ? normalizedReferenceTimestamp + interval : null;
+}
+
+/**
+ * @param {import('dictionary-importer').DictionaryAutoUpdateSchedule} schedule
+ * @param {number|null|undefined} lastUpdatedAt
+ * @returns {import('dictionary-importer').DictionaryAutoUpdateInfo}
+ */
+export function createDictionaryAutoUpdate(schedule, lastUpdatedAt) {
+    const normalizedSchedule = isDictionaryAutoUpdateSchedule(schedule) ? schedule : 'manual';
+    const normalizedLastUpdatedAt = normalizeTimestamp(lastUpdatedAt);
+    return {
+        schedule: normalizedSchedule,
+        lastUpdatedAt: normalizedLastUpdatedAt,
+        nextUpdateAt: getNextDictionaryAutoUpdateTime(normalizedSchedule, normalizedLastUpdatedAt),
+    };
+}
+
+/**
+ * @param {import('dictionary-importer').Summary} summary
+ * @returns {import('dictionary-importer').Summary}
+ */
+export function normalizeDictionarySummary(summary) {
+    const normalizedSummary = (
+        typeof summary === 'object' &&
+        summary !== null &&
+        !Array.isArray(summary)
+    ) ? summary : /** @type {import('dictionary-importer').Summary} */ ({});
+    const importDate = normalizeTimestamp(normalizedSummary.importDate);
+    /** @type {{schedule?: unknown, lastUpdatedAt?: unknown}} */
+    const rawAutoUpdate = (
+        typeof normalizedSummary.autoUpdate === 'object' &&
+        normalizedSummary.autoUpdate !== null &&
+        !Array.isArray(normalizedSummary.autoUpdate)
+    ) ? normalizedSummary.autoUpdate : {};
+    const schedule = (
+        normalizedSummary.isUpdatable === true &&
+        isDictionaryAutoUpdateSchedule(rawAutoUpdate.schedule)
+    ) ? rawAutoUpdate.schedule : 'manual';
+    const lastUpdatedAt = normalizeTimestamp(rawAutoUpdate.lastUpdatedAt) ?? importDate;
+    const autoUpdate = createDictionaryAutoUpdate(schedule, lastUpdatedAt);
+    return {
+        ...normalizedSummary,
+        autoUpdate,
+    };
+}
+
+/**
+ * @param {import('dictionary-importer').Summary} summary
+ * @param {{schedule?: import('dictionary-importer').DictionaryAutoUpdateSchedule, lastUpdatedAt?: number|null}} [details]
+ * @returns {import('dictionary-importer').Summary}
+ */
+export function setDictionarySummaryAutoUpdate(summary, details = {}) {
+    const normalizedSummary = normalizeDictionarySummary(summary);
+    const {schedule, lastUpdatedAt} = details;
+    const normalizedAutoUpdate = /** @type {import('dictionary-importer').DictionaryAutoUpdateInfo} */ (normalizedSummary.autoUpdate);
+    const requestedSchedule = typeof schedule === 'undefined' ? normalizedAutoUpdate.schedule : schedule;
+    const nextSchedule = (
+        normalizedSummary.isUpdatable === true &&
+        isDictionaryAutoUpdateSchedule(requestedSchedule)
+    ) ? requestedSchedule : 'manual';
+    const nextLastUpdatedAt = normalizeTimestamp(lastUpdatedAt) ?? normalizedAutoUpdate.lastUpdatedAt;
+    return {
+        ...normalizedSummary,
+        autoUpdate: createDictionaryAutoUpdate(nextSchedule, nextLastUpdatedAt),
+    };
+}

--- a/ext/js/dictionary/dictionary-database.js
+++ b/ext/js/dictionary/dictionary-database.js
@@ -50,6 +50,7 @@ import {
 import {decompress as zstdDecompress} from '../../lib/zstd-wasm.js';
 import {TermContentOpfsStore} from './term-content-opfs-store.js';
 import {TermRecordOpfsStore} from './term-record-opfs-store.js';
+import {normalizeDictionarySummary} from './dictionary-auto-update-util.js';
 
 const CURRENT_DICTIONARY_SCHEMA_VERSION = 4;
 const TERM_ENTRY_CONTENT_CACHE_MAX_ENTRIES = 4096;
@@ -1930,7 +1931,31 @@ export class DictionaryDatabase {
     async getDictionaryInfo() {
         const db = this._requireDb();
         const rows = db.selectObjects('SELECT summaryJson FROM dictionaries ORDER BY id ASC');
-        return rows.map((row) => /** @type {import('dictionary-importer').Summary} */ (this._safeParseJson(this._asString(row.summaryJson), {})));
+        return rows.map((row) => normalizeDictionarySummary(/** @type {import('dictionary-importer').Summary} */ (this._safeParseJson(this._asString(row.summaryJson), {}))));
+    }
+
+    /**
+     * @param {string} dictionaryTitle
+     * @param {import('dictionary-importer').Summary} summary
+     * @returns {Promise<import('dictionary-importer').Summary|null>}
+     */
+    async updateDictionarySummaryByTitle(dictionaryTitle, summary) {
+        const db = this._requireDb();
+        const row = db.selectObject('SELECT id FROM dictionaries WHERE title = $title ORDER BY id ASC LIMIT 1', {$title: dictionaryTitle});
+        if (typeof row !== 'object' || typeof row?.id === 'undefined') {
+            return null;
+        }
+        const normalizedSummary = normalizeDictionarySummary(summary);
+        const stmt = this._getCachedStatement('UPDATE dictionaries SET title = $title, version = $version, summaryJson = $summaryJson WHERE id = $id');
+        stmt.reset(true);
+        stmt.bind({
+            $id: this._asNumber(row.id, -1),
+            $title: normalizedSummary.title,
+            $version: normalizedSummary.version,
+            $summaryJson: JSON.stringify(normalizedSummary),
+        });
+        stmt.step();
+        return normalizedSummary;
     }
 
     /**

--- a/ext/js/dictionary/dictionary-importer.js
+++ b/ext/js/dictionary/dictionary-importer.js
@@ -42,6 +42,7 @@ import {
 } from './zstd-term-content.js';
 import {decompress as zstdDecompress} from '../../lib/zstd-wasm.js';
 import {compareRevisions} from './dictionary-data-util.js';
+import {createDictionaryAutoUpdate} from './dictionary-auto-update-util.js';
 import {createMdxImportData} from './mdx/mdx-converter.js';
 import {consumeLastTermBankWasmParseProfile, parseTermBankWithWasmChunks} from './term-bank-wasm-parser.js';
 
@@ -1505,17 +1506,19 @@ export class DictionaryImporter {
             styles,
             importSuccess,
         } = details;
+        const importDate = Date.now();
         /** @type {import('dictionary-importer').Summary} */
         const summary = {
             title: dictionaryTitle,
             revision: index.revision,
             sequenced: typeof indexSequenced === 'boolean' && indexSequenced,
             version,
-            importDate: Date.now(),
+            importDate,
             prefixWildcardsSupported,
             counts,
             styles,
             importSuccess,
+            autoUpdate: createDictionaryAutoUpdate('manual', importDate),
         };
 
         const {minimumYomitanVersion, author, url, description, attribution, frequencyMode, isUpdatable, sourceLanguage, targetLanguage} = index;

--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -21,6 +21,62 @@ import {log} from '../../core/log.js';
 import {deferPromise} from '../../core/utilities.js';
 import {querySelectorNotNull} from '../../dom/query-selector.js';
 
+const DICTIONARY_AUTO_UPDATE_SCHEDULE_SET = new Set(['manual', 'hourly', 'daily', 'weekly']);
+const DICTIONARY_AUTO_UPDATE_SCHEDULE_LABELS = Object.freeze({
+    manual: 'Manual',
+    hourly: 'Hourly',
+    daily: 'Daily',
+    weekly: 'Weekly',
+});
+const DICTIONARY_AUTO_UPDATE_SCHEDULE_DESCRIPTIONS = Object.freeze({
+    manual: 'Updates must be started manually.',
+    hourly: 'Checks for updates every hour and installs them automatically.',
+    daily: 'Checks for updates every day and installs them automatically.',
+    weekly: 'Checks for updates every week and installs them automatically.',
+});
+const DICTIONARY_AUTO_UPDATE_DATE_TIME_FORMATTER = new Intl.DateTimeFormat([], {dateStyle: 'medium', timeStyle: 'short'});
+
+/**
+ * @param {string} value
+ * @returns {value is import('dictionary-importer').DictionaryAutoUpdateSchedule}
+ */
+function isDictionaryAutoUpdateSchedule(value) {
+    return DICTIONARY_AUTO_UPDATE_SCHEDULE_SET.has(value);
+}
+
+/**
+ * @param {string} [schedule='']
+ * @returns {import('dictionary-importer').DictionaryAutoUpdateSchedule}
+ */
+function normalizeDictionaryAutoUpdateSchedule(schedule = '') {
+    return isDictionaryAutoUpdateSchedule(schedule) ? schedule : 'manual';
+}
+
+/**
+ * @param {import('dictionary-importer').DictionaryAutoUpdateSchedule} schedule
+ * @returns {string}
+ */
+function getDictionaryAutoUpdateScheduleLabel(schedule) {
+    return DICTIONARY_AUTO_UPDATE_SCHEDULE_LABELS[schedule];
+}
+
+/**
+ * @param {import('dictionary-importer').DictionaryAutoUpdateSchedule} schedule
+ * @returns {string}
+ */
+function getDictionaryAutoUpdateScheduleDescription(schedule) {
+    return DICTIONARY_AUTO_UPDATE_SCHEDULE_DESCRIPTIONS[schedule];
+}
+
+/**
+ * @param {number|undefined|null} timestamp
+ * @param {string} fallback
+ * @returns {string}
+ */
+function formatDictionaryAutoUpdateTimestamp(timestamp, fallback) {
+    return (typeof timestamp === 'number' && Number.isFinite(timestamp)) ? DICTIONARY_AUTO_UPDATE_DATE_TIME_FORMATTER.format(timestamp) : fallback;
+}
+
 class DictionaryEntry {
     /**
      * @param {DictionaryController} dictionaryController
@@ -194,6 +250,20 @@ class DictionaryEntry {
         this._aliasNode.dispatchEvent(new CustomEvent('change', {bubbles: true}));
     }
 
+    /**
+     * @param {import('dictionary-importer').Summary} dictionaryInfo
+     */
+    updateDictionaryInfo(dictionaryInfo) {
+        this._dictionaryInfo = dictionaryInfo;
+    }
+
+    /**
+     * @returns {Promise<void>}
+     */
+    async showDetails() {
+        await this._showDetails();
+    }
+
     // Private
 
     /** */
@@ -263,7 +333,7 @@ class DictionaryEntry {
 
     /** */
     _onOutdatedButtonClick() {
-        void this._showDetails();
+        void this.showDetails();
     }
 
     /** */
@@ -273,12 +343,12 @@ class DictionaryEntry {
 
     /** */
     _onIntegrityButtonClick() {
-        void this._showDetails();
+        void this.showDetails();
     }
 
     /** */
     async _showDetails() {
-        const {title, revision, version, counts, prefixWildcardsSupported, isUpdatable, indexUrl, downloadUrl} = this._dictionaryInfo;
+        const {title, revision, version, counts, prefixWildcardsSupported, isUpdatable, indexUrl, downloadUrl, autoUpdate} = this._dictionaryInfo;
 
         const modal = this._dictionaryController.modalController.getModal('dictionary-details');
         if (modal === null) { return; }
@@ -303,9 +373,12 @@ class DictionaryEntry {
         const useDeinflectionsToggle = querySelectorNotNull(useDeinflectionsSetting, '.dictionary-use-deinflections-toggle');
         /** @type {HTMLElement} */
         const autoUpdateSetting = querySelectorNotNull(modal.node, '.dictionary-auto-update-setting');
-        /** @type {HTMLInputElement} */
-        const autoUpdateToggle = querySelectorNotNull(autoUpdateSetting, '.dictionary-auto-update-toggle');
+        /** @type {HTMLSelectElement} */
+        const autoUpdateSelect = querySelectorNotNull(autoUpdateSetting, '.dictionary-auto-update-select');
+        /** @type {HTMLElement} */
+        const autoUpdateDescription = querySelectorNotNull(autoUpdateSetting, '.dictionary-auto-update-description');
 
+        modal.node.dataset.dictionaryTitle = title;
         titleElement.textContent = title;
         versionElement.textContent = `rev.${revision}`;
         outdateElement.hidden = (version >= 3);
@@ -318,12 +391,13 @@ class DictionaryEntry {
 
         const canAutoUpdate = (isUpdatable === true && typeof indexUrl === 'string' && typeof downloadUrl === 'string');
         autoUpdateSetting.hidden = !canAutoUpdate;
-        autoUpdateToggle.checked = false;
-        delete autoUpdateToggle.dataset.indexUrl;
+        const autoUpdateSchedule = normalizeDictionaryAutoUpdateSchedule(autoUpdate?.schedule);
+        autoUpdateSelect.value = autoUpdateSchedule;
+        autoUpdateSelect.dataset.currentSchedule = autoUpdateSchedule;
+        autoUpdateDescription.textContent = getDictionaryAutoUpdateScheduleDescription(autoUpdateSchedule);
+        delete autoUpdateSelect.dataset.dictionaryTitle;
         if (canAutoUpdate) {
-            const optionsFull = await this._dictionaryController.settingsController.getOptionsFull();
-            autoUpdateToggle.checked = optionsFull.global.dictionaryAutoUpdates.includes(indexUrl);
-            autoUpdateToggle.dataset.indexUrl = indexUrl;
+            autoUpdateSelect.dataset.dictionaryTitle = title;
         }
 
         this._setupDetails(detailsTableElement);
@@ -336,29 +410,45 @@ class DictionaryEntry {
      * @returns {boolean}
      */
     _setupDetails(detailsTable) {
-        /** @type {Partial<Record<keyof (typeof this._dictionaryInfo & typeof this._dictionaryInfo.counts), string>>} */
-        const targets = {
-            author: 'Author',
-            url: 'URL',
-            description: 'Description',
-            attribution: 'Attribution',
-            sourceLanguage: 'Source Language',
-            targetLanguage: 'Target Language',
-            terms: 'Term Count',
-            termMeta: 'Term Meta Count',
-            kanji: 'Kanji Count',
-            kanjiMeta: 'Kanji Meta Count',
-            tagMeta: 'Tag Count',
-            media: 'Media Count',
-            importSuccess: 'Import Success',
-        };
-
         const dictionaryInfo = {...this._dictionaryInfo, ...this._dictionaryInfo.counts};
         const fragment = document.createDocumentFragment();
         let any = false;
-        for (const [key, label] of /** @type {([keyof (typeof this._dictionaryInfo & typeof this._dictionaryInfo.counts), string])[]} */ (Object.entries(targets))) {
+        /**
+         * @param {string} type
+         * @param {string} label
+         * @param {string} displayText
+         * @param {keyof import('dictionary-database').DictionaryCountGroup|null} [databaseCountKey]
+         */
+        const appendDetailsRow = (type, label, displayText, databaseCountKey = null) => {
+            if (!displayText) { return; }
+            const details = /** @type {HTMLElement} */ (this._dictionaryController.instantiateTemplate('dictionary-details-entry'));
+            details.dataset.type = type;
+
+            /** @type {HTMLElement} */
+            const labelElement = querySelectorNotNull(details, '.dictionary-details-entry-label');
+            /** @type {HTMLElement} */
+            const infoElement = querySelectorNotNull(details, '.dictionary-details-entry-info');
+
+            labelElement.textContent = `${label}:`;
+            if (databaseCountKey !== null && this._databaseCounts && this._databaseCounts[databaseCountKey]) {
+                displayText = 'Expected: ' + displayText + ' (Database: ' + this._databaseCounts[databaseCountKey] + ')';
+            }
+            infoElement.textContent = displayText;
+            fragment.appendChild(details);
+            any = true;
+        };
+        /** @type {([keyof (typeof this._dictionaryInfo & typeof this._dictionaryInfo.counts), string])[]} */
+        const metadataTargets = [
+            ['author', 'Author'],
+            ['url', 'URL'],
+            ['description', 'Description'],
+            ['attribution', 'Attribution'],
+            ['sourceLanguage', 'Source Language'],
+            ['targetLanguage', 'Target Language'],
+        ];
+        for (const [key, label] of metadataTargets) {
             const info = dictionaryInfo[key];
-            let displayText = ((_info) => {
+            const displayText = ((_info) => {
                 if (typeof _info === 'string') { return _info; }
                 if (_info && typeof _info === 'object' && 'total' in _info) {
                     return _info.total ? `${_info.total}` : false;
@@ -367,23 +457,42 @@ class DictionaryEntry {
                 return false;
             })(info);
             if (!displayText) { continue; }
-
-            const details = /** @type {HTMLElement} */ (this._dictionaryController.instantiateTemplate('dictionary-details-entry'));
-            details.dataset.type = key;
-
-            /** @type {HTMLElement} */
-            const labelElement = querySelectorNotNull(details, '.dictionary-details-entry-label');
-            /** @type {HTMLElement} */
-            const infoElement = querySelectorNotNull(details, '.dictionary-details-entry-info');
-
-            labelElement.textContent = `${label}:`;
-            if (this._databaseCounts && this._databaseCounts[key]) {
-                displayText = 'Expected: ' + displayText + ' (Database: ' + this._databaseCounts[key] + ')';
-            }
-            infoElement.textContent = displayText;
-            fragment.appendChild(details);
-
-            any = true;
+            appendDetailsRow(String(key), label, displayText);
+        }
+        if (this._dictionaryInfo.isUpdatable === true) {
+            const autoUpdateSchedule = normalizeDictionaryAutoUpdateSchedule(this._dictionaryInfo.autoUpdate?.schedule);
+            appendDetailsRow('autoUpdateSchedule', 'Update Schedule', getDictionaryAutoUpdateScheduleLabel(autoUpdateSchedule));
+            appendDetailsRow('autoUpdateLastUpdated', 'Last Updated', formatDictionaryAutoUpdateTimestamp(this._dictionaryInfo.autoUpdate?.lastUpdatedAt, 'Not available'));
+            appendDetailsRow(
+                'autoUpdateNextScheduled',
+                'Next Scheduled Update',
+                this._dictionaryInfo.autoUpdate?.nextUpdateAt === null ?
+                    'Not scheduled' :
+                    formatDictionaryAutoUpdateTimestamp(this._dictionaryInfo.autoUpdate?.nextUpdateAt, 'Not scheduled'),
+            );
+        }
+        /** @type {([keyof import('dictionary-importer').SummaryCounts, string])[]} */
+        const countTargets = [
+            ['terms', 'Term Count'],
+            ['termMeta', 'Term Meta Count'],
+            ['kanji', 'Kanji Count'],
+            ['kanjiMeta', 'Kanji Meta Count'],
+            ['tagMeta', 'Tag Count'],
+            ['media', 'Media Count'],
+        ];
+        for (const [key, label] of countTargets) {
+            const info = dictionaryInfo[key];
+            const displayText = ((_info) => {
+                if (_info && typeof _info === 'object' && 'total' in _info) {
+                    return _info.total ? `${_info.total}` : false;
+                }
+                return false;
+            })(info);
+            if (!displayText) { continue; }
+            appendDetailsRow(String(key), label, displayText, key);
+        }
+        if (typeof this._dictionaryInfo.importSuccess === 'boolean') {
+            appendDetailsRow('importSuccess', 'Import Success', this._dictionaryInfo.importSuccess.toString());
         }
 
         detailsTable.textContent = '';
@@ -669,7 +778,7 @@ export class DictionaryController {
         this._allCheckbox.addEventListener('change', this._onAllCheckboxChange.bind(this), false);
         dictionaryDeleteButton.addEventListener('click', this._onDictionaryConfirmDelete.bind(this), false);
         dictionaryUpdateButton.addEventListener('click', this._onDictionaryConfirmUpdate.bind(this), false);
-        /** @type {HTMLInputElement} */ (querySelectorNotNull(document, '.dictionary-auto-update-toggle')).addEventListener('change', this._onDictionaryAutoUpdateToggleChange.bind(this), false);
+        /** @type {HTMLSelectElement} */ (querySelectorNotNull(document, '.dictionary-auto-update-select')).addEventListener('change', this._onDictionaryAutoUpdateSelectChange.bind(this), false);
 
         dictionaryMoveButton.addEventListener('click', this._onDictionaryMoveButtonClick.bind(this), false);
 
@@ -1077,24 +1186,40 @@ export class DictionaryController {
     /**
      * @param {Event} e
      */
-    async _onDictionaryAutoUpdateToggleChange(e) {
-        const toggle = /** @type {HTMLInputElement} */ (e.currentTarget);
-        const indexUrl = toggle.dataset.indexUrl;
-        if (typeof indexUrl !== 'string' || indexUrl.length === 0) {
+    async _onDictionaryAutoUpdateSelectChange(e) {
+        const select = /** @type {HTMLSelectElement} */ (e.currentTarget);
+        const autoUpdateSetting = select.closest('.dictionary-auto-update-setting');
+        const autoUpdateDescription = autoUpdateSetting?.querySelector('.dictionary-auto-update-description');
+        const dictionaryTitle = select.dataset.dictionaryTitle;
+        if (typeof dictionaryTitle !== 'string' || dictionaryTitle.length === 0) {
             return;
         }
-        const optionsFull = await this._settingsController.getOptionsFull();
-        const nextIndexUrls = new Set(optionsFull.global.dictionaryAutoUpdates);
-        if (toggle.checked) {
-            nextIndexUrls.add(indexUrl);
-        } else {
-            nextIndexUrls.delete(indexUrl);
+        const previousSchedule = normalizeDictionaryAutoUpdateSchedule(select.dataset.currentSchedule);
+        const nextSchedule = select.value;
+        if (!isDictionaryAutoUpdateSchedule(nextSchedule)) {
+            select.value = previousSchedule;
+            return;
         }
-        await this._settingsController.modifyGlobalSettings([{
-            action: 'set',
-            path: 'dictionaryAutoUpdates',
-            value: [...nextIndexUrls].sort((a, b) => a.localeCompare(b)),
-        }]);
+        if (nextSchedule === previousSchedule) {
+            return;
+        }
+        if (autoUpdateDescription instanceof HTMLElement) {
+            autoUpdateDescription.textContent = getDictionaryAutoUpdateScheduleDescription(nextSchedule);
+        }
+        select.disabled = true;
+        try {
+            const dictionaryInfo = await this._settingsController.application.api.setDictionaryUpdateSchedule(dictionaryTitle, nextSchedule);
+            this._updateDictionaryInfo(dictionaryInfo);
+            await this._refreshDictionaryDetailsModal(dictionaryInfo.title);
+        } catch (error) {
+            select.value = previousSchedule;
+            if (autoUpdateDescription instanceof HTMLElement) {
+                autoUpdateDescription.textContent = getDictionaryAutoUpdateScheduleDescription(previousSchedule);
+            }
+            log.error(error);
+        } finally {
+            select.disabled = false;
+        }
     }
 
     /**
@@ -1107,6 +1232,37 @@ export class DictionaryController {
                 break;
             }
         }
+    }
+
+    /**
+     * @param {import('dictionary-importer').Summary} dictionaryInfo
+     */
+    _updateDictionaryInfo(dictionaryInfo) {
+        const dictionaries = this._dictionaries;
+        if (dictionaries !== null) {
+            const dictionaryIndex = dictionaries.findIndex(({title}) => title === dictionaryInfo.title);
+            if (dictionaryIndex >= 0) {
+                dictionaries[dictionaryIndex] = dictionaryInfo;
+            }
+        }
+        const entry = this._dictionaryEntries.find(({dictionaryTitle}) => dictionaryTitle === dictionaryInfo.title);
+        entry?.updateDictionaryInfo(dictionaryInfo);
+    }
+
+    /**
+     * @param {string} dictionaryTitle
+     * @returns {Promise<void>}
+     */
+    async _refreshDictionaryDetailsModal(dictionaryTitle) {
+        const modal = this._modalController.getModal('dictionary-details');
+        if (modal === null || modal.node.hidden || modal.node.dataset.dictionaryTitle !== dictionaryTitle) {
+            return;
+        }
+        const entry = this._dictionaryEntries.find(({dictionaryTitle: entryDictionaryTitle}) => entryDictionaryTitle === dictionaryTitle);
+        if (typeof entry === 'undefined') {
+            return;
+        }
+        await entry.showDetails();
     }
 
     /**

--- a/ext/templates-modals.html
+++ b/ext/templates-modals.html
@@ -255,15 +255,20 @@
                 <div class="settings-item-inner">
                     <div class="settings-item-left">
                         <div class="settings-item-label">
-                            Automatic hourly updates
+                            Automatic updates
                         </div>
                     </div>
                     <div class="settings-item-right">
-                        <label class="toggle"><input type="checkbox" class="dictionary-auto-update-toggle"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
+                        <select class="dictionary-auto-update-select medium-width">
+                            <option value="manual">Manual</option>
+                            <option value="hourly">Hourly</option>
+                            <option value="daily">Daily</option>
+                            <option value="weekly">Weekly</option>
+                        </select>
                     </div>
                 </div>
-                <div class="settings-item-children">
-                    Check for updates every hour and install them automatically.
+                <div class="settings-item-children dictionary-auto-update-description">
+                    Updates must be started manually.
                 </div>
             </div>
             <hr>

--- a/test/backend-dictionary-auto-update.test.js
+++ b/test/backend-dictionary-auto-update.test.js
@@ -387,6 +387,40 @@ describe('Backend dictionary auto-update helpers', () => {
         await expect(getBackendMethod('_setDictionaryUpdateSchedule').call(context, 'Test Dictionary', 'daily')).rejects.toThrow('Dictionary is not updatable');
     });
 
+    test('Successful scheduled no-update checks advance nextUpdateAt without changing lastUpdatedAt', async () => {
+        let currentDictionary = createDictionarySummary({
+            autoUpdate: {
+                schedule: 'daily',
+                lastUpdatedAt: 100,
+                nextUpdateAt: 150,
+            },
+        });
+        const updateDictionarySummaryByTitle = vi.fn(async (_dictionaryTitle, summary) => {
+            currentDictionary = summary;
+            return summary;
+        });
+        const context = {
+            _runWithDictionaryMutationLock: vi.fn(async (callback) => await callback()),
+            _ensureDictionaryDatabaseReady: async () => {},
+            _dictionaryDatabase: {
+                getDictionaryInfo: async () => [currentDictionary],
+                updateDictionarySummaryByTitle,
+            },
+            _setDictionarySummaryByTitle: getBackendMethod('_setDictionarySummaryByTitle'),
+        };
+
+        const updatedSummary = /** @type {import('dictionary-importer').Summary} */ (
+            await getBackendMethod('_advanceDictionaryAutoUpdateScheduleAfterSuccessfulCheck').call(context, 'Test Dictionary', 500)
+        );
+
+        expect(updatedSummary.autoUpdate).toStrictEqual({
+            schedule: 'daily',
+            lastUpdatedAt: 100,
+            nextUpdateAt: 500 + DICTIONARY_AUTO_UPDATE_DAY_MS,
+        });
+        expect(updateDictionarySummaryByTitle).toHaveBeenCalledTimes(1);
+    });
+
     test('HEAD 304 check updates validators without fetching the index body', async () => {
         const dictionary = createDictionarySummary();
         /** @type {Record<string, {etag?: string, lastModified?: string, lastAttemptAt?: number, lastSuccessfulCheckAt?: number, lastSeenRevision?: string, lastError?: string|null}>} */
@@ -535,67 +569,212 @@ describe('Backend dictionary auto-update helpers', () => {
         });
     });
 
-    test('Auto-update pass only checks enabled dictionaries that are due', async () => {
+    test('Auto-update pass only checks scheduled dictionaries that are due by nextUpdateAt', async () => {
         vi.spyOn(Date, 'now').mockReturnValue(2 * DICTIONARY_AUTO_UPDATE_INTERVAL_MS);
-        const checkDictionaryUpdates = vi.fn(async () => [createCheckResult()]);
+        const checkDictionaryUpdates = vi.fn(async (dictionaryTitles) => [createCheckResult({dictionaryTitle: dictionaryTitles[0]})]);
         const updateDictionaryByTitle = vi.fn(async () => ({status: 'updated'}));
+        const advanceDictionaryAutoUpdateScheduleAfterSuccessfulCheck = vi.fn(async () => null);
         const context = {
             _dictionaryAutoUpdatePassPromise: null,
             _dictionaryImportModeActive: false,
             _options: {
                 global: {
-                    dictionaryAutoUpdates: [
-                        'https://example.invalid/due.json',
-                        'https://example.invalid/recent.json',
-                    ],
+                    dictionaryAutoUpdates: [],
                 },
             },
             _ensureDictionaryDatabaseReady: async () => {},
             _dictionaryDatabase: {
                 getDictionaryInfo: async () => [
-                    createDictionarySummary({title: 'Recent', indexUrl: 'https://example.invalid/recent.json'}),
-                    createDictionarySummary({title: 'Due', indexUrl: 'https://example.invalid/due.json'}),
                     createDictionarySummary({
-                        title: 'Daily Metadata Only',
+                        title: 'Weekly Due',
+                        indexUrl: 'https://example.invalid/weekly.json',
+                        autoUpdate: {
+                            schedule: 'weekly',
+                            lastUpdatedAt: 0,
+                            nextUpdateAt: DICTIONARY_AUTO_UPDATE_INTERVAL_MS,
+                        },
+                    }),
+                    createDictionarySummary({
+                        title: 'Recent Daily',
                         indexUrl: 'https://example.invalid/daily.json',
                         autoUpdate: {
                             schedule: 'daily',
                             lastUpdatedAt: 0,
-                            nextUpdateAt: DICTIONARY_AUTO_UPDATE_DAY_MS,
+                            nextUpdateAt: 3 * DICTIONARY_AUTO_UPDATE_DAY_MS,
+                        },
+                    }),
+                    createDictionarySummary({
+                        title: 'Due Hourly',
+                        indexUrl: 'https://example.invalid/due.json',
+                        autoUpdate: {
+                            schedule: 'hourly',
+                            lastUpdatedAt: 0,
+                            nextUpdateAt: 0,
+                        },
+                    }),
+                    createDictionarySummary({
+                        title: 'Manual',
+                        indexUrl: 'https://example.invalid/manual.json',
+                        autoUpdate: {
+                            schedule: 'manual',
+                            lastUpdatedAt: 0,
+                            nextUpdateAt: null,
                         },
                     }),
                     createDictionarySummary({title: 'Static', isUpdatable: false, indexUrl: 'https://example.invalid/static.json'}),
                 ],
             },
-            _getDictionaryAutoUpdateState: async () => ({
-                'https://example.invalid/due.json': {lastAttemptAt: 0},
-                'https://example.invalid/recent.json': {lastAttemptAt: (2 * DICTIONARY_AUTO_UPDATE_INTERVAL_MS) - 1},
-                'https://example.invalid/daily.json': {lastAttemptAt: 0},
-            }),
             _checkDictionaryUpdates: checkDictionaryUpdates,
             _updateDictionaryByTitle: updateDictionaryByTitle,
+            _advanceDictionaryAutoUpdateScheduleAfterSuccessfulCheck: advanceDictionaryAutoUpdateScheduleAfterSuccessfulCheck,
+        };
+
+        await getBackendMethod('_runDictionaryAutoUpdatePass').call(context, 'alarm');
+
+        expect(checkDictionaryUpdates.mock.calls.map(([dictionaryTitles]) => dictionaryTitles)).toStrictEqual([
+            ['Due Hourly'],
+            ['Weekly Due'],
+        ]);
+        expect(updateDictionaryByTitle).toHaveBeenCalledTimes(2);
+        expect(updateDictionaryByTitle).toHaveBeenNthCalledWith(1, 'Due Hourly', false, expect.objectContaining({
+            dictionaryTitle: 'Due Hourly',
+            hasUpdate: true,
+        }));
+        expect(updateDictionaryByTitle).toHaveBeenNthCalledWith(2, 'Weekly Due', false, expect.objectContaining({
+            dictionaryTitle: 'Weekly Due',
+            hasUpdate: true,
+        }));
+        expect(advanceDictionaryAutoUpdateScheduleAfterSuccessfulCheck).not.toHaveBeenCalled();
+        expect(context._dictionaryAutoUpdatePassPromise).toBeNull();
+    });
+
+    test('Auto-update pass advances nextUpdateAt after successful scheduled checks with no update', async () => {
+        vi.spyOn(Date, 'now').mockReturnValue(500);
+        const checkDictionaryUpdates = vi.fn(async () => [createCheckResult({
+            dictionaryTitle: 'Daily Due',
+            hasUpdate: false,
+            latestRevision: '1',
+        })]);
+        const updateDictionaryByTitle = vi.fn(async () => ({status: 'updated'}));
+        const advanceDictionaryAutoUpdateScheduleAfterSuccessfulCheck = vi.fn(async () => null);
+        const context = {
+            _dictionaryAutoUpdatePassPromise: null,
+            _dictionaryImportModeActive: false,
+            _options: {
+                global: {
+                    dictionaryAutoUpdates: [],
+                },
+            },
+            _ensureDictionaryDatabaseReady: async () => {},
+            _dictionaryDatabase: {
+                getDictionaryInfo: async () => [createDictionarySummary({
+                    title: 'Daily Due',
+                    indexUrl: 'https://example.invalid/daily.json',
+                    autoUpdate: {
+                        schedule: 'daily',
+                        lastUpdatedAt: 10,
+                        nextUpdateAt: 0,
+                    },
+                })],
+            },
+            _checkDictionaryUpdates: checkDictionaryUpdates,
+            _updateDictionaryByTitle: updateDictionaryByTitle,
+            _advanceDictionaryAutoUpdateScheduleAfterSuccessfulCheck: advanceDictionaryAutoUpdateScheduleAfterSuccessfulCheck,
         };
 
         await getBackendMethod('_runDictionaryAutoUpdatePass').call(context, 'alarm');
 
         expect(checkDictionaryUpdates).toHaveBeenCalledTimes(1);
-        expect(checkDictionaryUpdates).toHaveBeenCalledWith(['Due']);
+        expect(checkDictionaryUpdates).toHaveBeenCalledWith(['Daily Due']);
+        expect(updateDictionaryByTitle).not.toHaveBeenCalled();
+        expect(advanceDictionaryAutoUpdateScheduleAfterSuccessfulCheck).toHaveBeenCalledTimes(1);
+        expect(advanceDictionaryAutoUpdateScheduleAfterSuccessfulCheck).toHaveBeenCalledWith('Daily Due', 500);
+    });
+
+    test('Auto-update pass leaves overdue schedules unchanged when scheduled checks or updates fail', async () => {
+        vi.spyOn(Date, 'now').mockReturnValue(750);
+        const checkDictionaryUpdates = vi.fn(async (dictionaryTitles) => {
+            const dictionaryTitle = dictionaryTitles[0];
+            if (dictionaryTitle === 'Check Failure') {
+                return [createCheckResult({
+                    dictionaryTitle,
+                    hasUpdate: false,
+                    error: 'network error',
+                })];
+            }
+            return [createCheckResult({dictionaryTitle})];
+        });
+        const updateDictionaryByTitle = vi.fn(async () => ({
+            dictionaryTitle: 'Update Failure',
+            status: 'skipped',
+            latestRevision: '2',
+            error: 'import failed',
+        }));
+        const advanceDictionaryAutoUpdateScheduleAfterSuccessfulCheck = vi.fn(async () => null);
+        const context = {
+            _dictionaryAutoUpdatePassPromise: null,
+            _dictionaryImportModeActive: false,
+            _options: {
+                global: {
+                    dictionaryAutoUpdates: [],
+                },
+            },
+            _ensureDictionaryDatabaseReady: async () => {},
+            _dictionaryDatabase: {
+                getDictionaryInfo: async () => [
+                    createDictionarySummary({
+                        title: 'Check Failure',
+                        indexUrl: 'https://example.invalid/check.json',
+                        autoUpdate: {
+                            schedule: 'daily',
+                            lastUpdatedAt: 10,
+                            nextUpdateAt: 0,
+                        },
+                    }),
+                    createDictionarySummary({
+                        title: 'Update Failure',
+                        indexUrl: 'https://example.invalid/update.json',
+                        autoUpdate: {
+                            schedule: 'weekly',
+                            lastUpdatedAt: 20,
+                            nextUpdateAt: 0,
+                        },
+                    }),
+                ],
+            },
+            _checkDictionaryUpdates: checkDictionaryUpdates,
+            _updateDictionaryByTitle: updateDictionaryByTitle,
+            _advanceDictionaryAutoUpdateScheduleAfterSuccessfulCheck: advanceDictionaryAutoUpdateScheduleAfterSuccessfulCheck,
+        };
+
+        await getBackendMethod('_runDictionaryAutoUpdatePass').call(context, 'alarm');
+
+        expect(checkDictionaryUpdates.mock.calls.map(([dictionaryTitles]) => dictionaryTitles)).toStrictEqual([
+            ['Check Failure'],
+            ['Update Failure'],
+        ]);
         expect(updateDictionaryByTitle).toHaveBeenCalledTimes(1);
-        expect(updateDictionaryByTitle).toHaveBeenCalledWith('Due', false, expect.objectContaining({
-            dictionaryTitle: 'Test Dictionary',
+        expect(updateDictionaryByTitle).toHaveBeenCalledWith('Update Failure', false, expect.objectContaining({
+            dictionaryTitle: 'Update Failure',
             hasUpdate: true,
         }));
-        expect(context._dictionaryAutoUpdatePassPromise).toBeNull();
+        expect(advanceDictionaryAutoUpdateScheduleAfterSuccessfulCheck).not.toHaveBeenCalled();
     });
 
     test('Auto-update update skips when the mutation lock is busy', async () => {
-        const dictionary = createDictionarySummary();
+        const dictionary = createDictionarySummary({
+            autoUpdate: {
+                schedule: 'daily',
+                lastUpdatedAt: 0,
+                nextUpdateAt: 0,
+            },
+        });
         const fetchAnonymous = vi.fn(async () => new Response(new Uint8Array([1, 2, 3]), {status: 200}));
         const performDictionaryUpdate = vi.fn(async () => ({status: 'updated'}));
         const context = {
             _options: {
                 global: {
-                    dictionaryAutoUpdates: ['https://example.invalid/index.json'],
+                    dictionaryAutoUpdates: [],
                 },
             },
             _ensureDictionaryDatabaseReady: async () => {},
@@ -625,8 +804,71 @@ describe('Backend dictionary auto-update helpers', () => {
         expect(performDictionaryUpdate).not.toHaveBeenCalled();
     });
 
-    test('Auto-update update aborts when hourly updates were disabled before commit', async () => {
-        const dictionary = createDictionarySummary();
+    test('Auto-update update allows scheduled non-hourly dictionaries when the hourly compatibility list is empty', async () => {
+        const dictionary = createDictionarySummary({
+            autoUpdate: {
+                schedule: 'daily',
+                lastUpdatedAt: 0,
+                nextUpdateAt: 0,
+            },
+        });
+        const performDictionaryUpdate = vi.fn(async () => ({
+            dictionaryTitle: 'Test Dictionary',
+            status: 'updated',
+            latestRevision: '2',
+            error: null,
+        }));
+        const context = {
+            _options: {
+                global: {
+                    dictionaryAutoUpdates: [],
+                },
+            },
+            _ensureDictionaryDatabaseReady: async () => {},
+            _dictionaryDatabase: {
+                getDictionaryInfo: vi.fn()
+                    .mockResolvedValueOnce([dictionary])
+                    .mockResolvedValueOnce([dictionary]),
+            },
+            _requestBuilder: {
+                fetchAnonymous: vi.fn(async () => new Response(new Uint8Array([1, 2, 3]), {status: 200})),
+            },
+            _setDictionaryAutoUpdateError: vi.fn(async () => {}),
+            _runWithDictionaryMutationLock: vi.fn(async (callback) => await callback()),
+            _performDictionaryUpdate: performDictionaryUpdate,
+        };
+
+        const result = await getBackendMethod('_updateDictionaryByTitle').call(
+            context,
+            'Test Dictionary',
+            false,
+            createCheckResult(),
+        );
+
+        expect(result).toStrictEqual({
+            dictionaryTitle: 'Test Dictionary',
+            status: 'updated',
+            latestRevision: '2',
+            error: null,
+        });
+        expect(performDictionaryUpdate).toHaveBeenCalledTimes(1);
+    });
+
+    test('Auto-update update aborts when automatic updates were disabled before commit', async () => {
+        const scheduledDictionary = createDictionarySummary({
+            autoUpdate: {
+                schedule: 'daily',
+                lastUpdatedAt: 0,
+                nextUpdateAt: 0,
+            },
+        });
+        const disabledDictionary = createDictionarySummary({
+            autoUpdate: {
+                schedule: 'manual',
+                lastUpdatedAt: 0,
+                nextUpdateAt: null,
+            },
+        });
         const performDictionaryUpdate = vi.fn(async () => ({status: 'updated'}));
         const context = {
             _options: {
@@ -636,7 +878,9 @@ describe('Backend dictionary auto-update helpers', () => {
             },
             _ensureDictionaryDatabaseReady: async () => {},
             _dictionaryDatabase: {
-                getDictionaryInfo: vi.fn(async () => [dictionary]),
+                getDictionaryInfo: vi.fn()
+                    .mockResolvedValueOnce([scheduledDictionary])
+                    .mockResolvedValueOnce([disabledDictionary]),
             },
             _requestBuilder: {
                 fetchAnonymous: vi.fn(async () => new Response(new Uint8Array([1, 2, 3]), {status: 200})),

--- a/test/backend-dictionary-auto-update.test.js
+++ b/test/backend-dictionary-auto-update.test.js
@@ -237,7 +237,7 @@ describe('Backend dictionary auto-update helpers', () => {
         });
     });
 
-    test('Global hourly auto-update settings sync dictionary summary schedules between hourly and manual', async () => {
+    test('Global hourly auto-update settings sync hourly schedules without clearing non-hourly metadata', async () => {
         let currentDictionaries = /** @type {import('dictionary-importer').Summary[]} */ ([
             createDictionarySummary({
                 autoUpdate: {
@@ -277,16 +277,16 @@ describe('Backend dictionary auto-update helpers', () => {
 
         await getBackendMethod('_syncDictionaryAutoUpdateSummarySchedulesWithGlobalSettings').call(context);
 
-        expect(updateDictionarySummaryByTitle).toHaveBeenCalledTimes(2);
+        expect(updateDictionarySummaryByTitle).toHaveBeenCalledTimes(1);
         expect(currentDictionaries[0].autoUpdate).toStrictEqual({
             schedule: 'hourly',
             lastUpdatedAt: 10,
             nextUpdateAt: 10 + DICTIONARY_AUTO_UPDATE_INTERVAL_MS,
         });
         expect(currentDictionaries[1].autoUpdate).toStrictEqual({
-            schedule: 'manual',
+            schedule: 'daily',
             lastUpdatedAt: 20,
-            nextUpdateAt: null,
+            nextUpdateAt: 20 + DICTIONARY_AUTO_UPDATE_DAY_MS,
         });
     });
 

--- a/test/backend-dictionary-auto-update.test.js
+++ b/test/backend-dictionary-auto-update.test.js
@@ -28,6 +28,8 @@ vi.mock('../ext/lib/kanji-processor.js', () => ({
 const {Backend} = await import('../ext/js/background/backend.js');
 
 const DICTIONARY_AUTO_UPDATE_INTERVAL_MS = 60 * 60 * 1000;
+const DICTIONARY_AUTO_UPDATE_DAY_MS = 24 * DICTIONARY_AUTO_UPDATE_INTERVAL_MS;
+const DICTIONARY_AUTO_UPDATE_WEEK_MS = 7 * DICTIONARY_AUTO_UPDATE_DAY_MS;
 
 afterEach(() => {
     vi.restoreAllMocks();
@@ -72,6 +74,11 @@ function createDictionarySummary(overrides = {}) {
         indexUrl: 'https://example.invalid/index.json',
         downloadUrl: 'https://example.invalid/dictionary.zip',
         importSuccess: true,
+        autoUpdate: {
+            schedule: 'manual',
+            lastUpdatedAt: 0,
+            nextUpdateAt: null,
+        },
         ...overrides,
     });
 }
@@ -178,6 +185,206 @@ describe('Backend dictionary auto-update helpers', () => {
         expect(setState).toHaveBeenCalledWith({
             'https://example.invalid/keep.json': {lastAttemptAt: 1},
         });
+    });
+
+    test('Backfills hourly schedule metadata for dictionaries already enabled in global auto-update settings', async () => {
+        let currentDictionaries = /** @type {import('dictionary-importer').Summary[]} */ ([
+            createDictionarySummary({
+                autoUpdate: void 0,
+                importDate: 500,
+            }),
+            createDictionarySummary({
+                title: 'Other Dictionary',
+                indexUrl: 'https://example.invalid/other.json',
+                autoUpdate: {
+                    schedule: 'daily',
+                    lastUpdatedAt: 250,
+                    nextUpdateAt: 250 + DICTIONARY_AUTO_UPDATE_DAY_MS,
+                },
+            }),
+        ]);
+        const updateDictionarySummaryByTitle = vi.fn(async (dictionaryTitle, summary) => {
+            currentDictionaries = currentDictionaries.map((dictionary) => (dictionary.title === dictionaryTitle ? summary : dictionary));
+            return summary;
+        });
+        const context = {
+            _options: {
+                global: {
+                    dictionaryAutoUpdates: ['https://example.invalid/index.json'],
+                },
+            },
+            _runWithDictionaryMutationLock: vi.fn(async (callback) => await callback()),
+            _ensureDictionaryDatabaseReady: async () => {},
+            _dictionaryDatabase: {
+                getDictionaryInfo: async () => currentDictionaries,
+                updateDictionarySummaryByTitle,
+            },
+            _setDictionarySummaryByTitle: getBackendMethod('_setDictionarySummaryByTitle'),
+        };
+
+        await getBackendMethod('_backfillDictionaryAutoUpdateSummarySchedules').call(context);
+
+        expect(updateDictionarySummaryByTitle).toHaveBeenCalledTimes(1);
+        expect(currentDictionaries[0].autoUpdate).toStrictEqual({
+            schedule: 'hourly',
+            lastUpdatedAt: 500,
+            nextUpdateAt: 500 + DICTIONARY_AUTO_UPDATE_INTERVAL_MS,
+        });
+        expect(currentDictionaries[1].autoUpdate).toStrictEqual({
+            schedule: 'daily',
+            lastUpdatedAt: 250,
+            nextUpdateAt: 250 + DICTIONARY_AUTO_UPDATE_DAY_MS,
+        });
+    });
+
+    test('Global hourly auto-update settings sync dictionary summary schedules between hourly and manual', async () => {
+        let currentDictionaries = /** @type {import('dictionary-importer').Summary[]} */ ([
+            createDictionarySummary({
+                autoUpdate: {
+                    schedule: 'manual',
+                    lastUpdatedAt: 10,
+                    nextUpdateAt: null,
+                },
+            }),
+            createDictionarySummary({
+                title: 'Daily Dictionary',
+                indexUrl: 'https://example.invalid/daily.json',
+                autoUpdate: {
+                    schedule: 'daily',
+                    lastUpdatedAt: 20,
+                    nextUpdateAt: 20 + DICTIONARY_AUTO_UPDATE_DAY_MS,
+                },
+            }),
+        ]);
+        const updateDictionarySummaryByTitle = vi.fn(async (dictionaryTitle, summary) => {
+            currentDictionaries = currentDictionaries.map((dictionary) => (dictionary.title === dictionaryTitle ? summary : dictionary));
+            return summary;
+        });
+        const context = {
+            _options: {
+                global: {
+                    dictionaryAutoUpdates: ['https://example.invalid/index.json'],
+                },
+            },
+            _runWithDictionaryMutationLock: vi.fn(async (callback) => await callback()),
+            _ensureDictionaryDatabaseReady: async () => {},
+            _dictionaryDatabase: {
+                getDictionaryInfo: async () => currentDictionaries,
+                updateDictionarySummaryByTitle,
+            },
+            _setDictionarySummaryByTitle: getBackendMethod('_setDictionarySummaryByTitle'),
+        };
+
+        await getBackendMethod('_syncDictionaryAutoUpdateSummarySchedulesWithGlobalSettings').call(context);
+
+        expect(updateDictionarySummaryByTitle).toHaveBeenCalledTimes(2);
+        expect(currentDictionaries[0].autoUpdate).toStrictEqual({
+            schedule: 'hourly',
+            lastUpdatedAt: 10,
+            nextUpdateAt: 10 + DICTIONARY_AUTO_UPDATE_INTERVAL_MS,
+        });
+        expect(currentDictionaries[1].autoUpdate).toStrictEqual({
+            schedule: 'manual',
+            lastUpdatedAt: 20,
+            nextUpdateAt: null,
+        });
+    });
+
+    test('setDictionaryUpdateSchedule persists schedules and syncs the hourly compatibility list', async () => {
+        let currentDictionary = createDictionarySummary({
+            importDate: 100,
+            autoUpdate: {
+                schedule: 'manual',
+                lastUpdatedAt: 100,
+                nextUpdateAt: null,
+            },
+        });
+        const saveOptions = vi.fn(async () => {});
+        const updateDictionarySummaryByTitle = vi.fn(async (_dictionaryTitle, summary) => {
+            currentDictionary = summary;
+            return summary;
+        });
+        const context = {
+            _options: {
+                global: {
+                    dictionaryAutoUpdates: [],
+                },
+            },
+            _runWithDictionaryMutationLock: vi.fn(async (callback) => await callback()),
+            _ensureDictionaryDatabaseReady: async () => {},
+            _dictionaryDatabase: {
+                getDictionaryInfo: async () => [currentDictionary],
+                updateDictionarySummaryByTitle,
+            },
+            _saveOptions: saveOptions,
+            _setDictionarySummaryByTitle: getBackendMethod('_setDictionarySummaryByTitle'),
+            _syncGlobalDictionaryAutoUpdateOptionsFromSummaries: getBackendMethod('_syncGlobalDictionaryAutoUpdateOptionsFromSummaries'),
+            _getSortedDictionaryAutoUpdateIndexUrls: getBackendMethod('_getSortedDictionaryAutoUpdateIndexUrls'),
+        };
+
+        const hourlySummary = /** @type {import('dictionary-importer').Summary} */ (
+            await getBackendMethod('_setDictionaryUpdateSchedule').call(context, 'Test Dictionary', 'hourly')
+        );
+        expect(hourlySummary.autoUpdate).toStrictEqual({
+            schedule: 'hourly',
+            lastUpdatedAt: 100,
+            nextUpdateAt: 100 + DICTIONARY_AUTO_UPDATE_INTERVAL_MS,
+        });
+        expect(context._options.global.dictionaryAutoUpdates).toStrictEqual(['https://example.invalid/index.json']);
+
+        const dailySummary = /** @type {import('dictionary-importer').Summary} */ (
+            await getBackendMethod('_setDictionaryUpdateSchedule').call(context, 'Test Dictionary', 'daily')
+        );
+        expect(dailySummary.autoUpdate).toStrictEqual({
+            schedule: 'daily',
+            lastUpdatedAt: 100,
+            nextUpdateAt: 100 + DICTIONARY_AUTO_UPDATE_DAY_MS,
+        });
+        expect(context._options.global.dictionaryAutoUpdates).toStrictEqual([]);
+
+        const weeklySummary = /** @type {import('dictionary-importer').Summary} */ (
+            await getBackendMethod('_setDictionaryUpdateSchedule').call(context, 'Test Dictionary', 'weekly')
+        );
+        expect(weeklySummary.autoUpdate).toStrictEqual({
+            schedule: 'weekly',
+            lastUpdatedAt: 100,
+            nextUpdateAt: 100 + DICTIONARY_AUTO_UPDATE_WEEK_MS,
+        });
+        expect(context._options.global.dictionaryAutoUpdates).toStrictEqual([]);
+        expect(updateDictionarySummaryByTitle).toHaveBeenCalledTimes(3);
+        expect(saveOptions).toHaveBeenCalledTimes(2);
+    });
+
+    test('setDictionaryUpdateSchedule rejects non-manual schedules for non-updatable dictionaries', async () => {
+        const dictionary = createDictionarySummary({
+            isUpdatable: false,
+            indexUrl: void 0,
+            downloadUrl: void 0,
+            autoUpdate: {
+                schedule: 'manual',
+                lastUpdatedAt: 50,
+                nextUpdateAt: null,
+            },
+        });
+        const context = {
+            _options: {
+                global: {
+                    dictionaryAutoUpdates: [],
+                },
+            },
+            _runWithDictionaryMutationLock: vi.fn(async (callback) => await callback()),
+            _ensureDictionaryDatabaseReady: async () => {},
+            _dictionaryDatabase: {
+                getDictionaryInfo: async () => [dictionary],
+                updateDictionarySummaryByTitle: vi.fn(async () => dictionary),
+            },
+            _saveOptions: vi.fn(async () => {}),
+            _setDictionarySummaryByTitle: getBackendMethod('_setDictionarySummaryByTitle'),
+            _syncGlobalDictionaryAutoUpdateOptionsFromSummaries: getBackendMethod('_syncGlobalDictionaryAutoUpdateOptionsFromSummaries'),
+            _getSortedDictionaryAutoUpdateIndexUrls: getBackendMethod('_getSortedDictionaryAutoUpdateIndexUrls'),
+        };
+
+        await expect(getBackendMethod('_setDictionaryUpdateSchedule').call(context, 'Test Dictionary', 'daily')).rejects.toThrow('Dictionary is not updatable');
     });
 
     test('HEAD 304 check updates validators without fetching the index body', async () => {
@@ -348,12 +555,22 @@ describe('Backend dictionary auto-update helpers', () => {
                 getDictionaryInfo: async () => [
                     createDictionarySummary({title: 'Recent', indexUrl: 'https://example.invalid/recent.json'}),
                     createDictionarySummary({title: 'Due', indexUrl: 'https://example.invalid/due.json'}),
+                    createDictionarySummary({
+                        title: 'Daily Metadata Only',
+                        indexUrl: 'https://example.invalid/daily.json',
+                        autoUpdate: {
+                            schedule: 'daily',
+                            lastUpdatedAt: 0,
+                            nextUpdateAt: DICTIONARY_AUTO_UPDATE_DAY_MS,
+                        },
+                    }),
                     createDictionarySummary({title: 'Static', isUpdatable: false, indexUrl: 'https://example.invalid/static.json'}),
                 ],
             },
             _getDictionaryAutoUpdateState: async () => ({
                 'https://example.invalid/due.json': {lastAttemptAt: 0},
                 'https://example.invalid/recent.json': {lastAttemptAt: (2 * DICTIONARY_AUTO_UPDATE_INTERVAL_MS) - 1},
+                'https://example.invalid/daily.json': {lastAttemptAt: 0},
             }),
             _checkDictionaryUpdates: checkDictionaryUpdates,
             _updateDictionaryByTitle: updateDictionaryByTitle,
@@ -489,6 +706,7 @@ describe('Backend dictionary auto-update helpers', () => {
             _captureDictionaryUpdateSettings: vi.fn(() => ({profilesDictionarySettings: {}, mainDictionaryProfileIds: new Set(), sortFrequencyDictionaryProfileIds: new Set()})),
             _dictionaryDatabase: {
                 deleteDictionary: vi.fn(async () => {}),
+                updateDictionarySummaryByTitle: vi.fn(async (_dictionaryTitle, summary) => summary),
             },
             _setDictionaryImportMode: vi.fn(async () => {}),
             _importDictionaryArchiveHeadless: vi.fn(async () => ({
@@ -498,6 +716,8 @@ describe('Backend dictionary auto-update helpers', () => {
                 }),
                 errors: [],
             })),
+            _setDictionarySummaryByTitle: getBackendMethod('_setDictionarySummaryByTitle'),
+            _createUpdatedDictionarySummaryAfterImport: getBackendMethod('_createUpdatedDictionarySummaryAfterImport'),
             _applyImportedDictionarySettings: vi.fn(async () => {}),
             _updateDictionaryAutoUpdateStateAfterSuccess: vi.fn(async () => {}),
             _setDictionaryAutoUpdateError: vi.fn(async () => {}),
@@ -530,6 +750,118 @@ describe('Backend dictionary auto-update helpers', () => {
             expect.any(Object),
         );
         expect(context._setDictionaryAutoUpdateError).not.toHaveBeenCalled();
+    });
+
+    test('Dictionary updates preserve stored schedule metadata and refresh lastUpdatedAt', async () => {
+        const dictionary = createDictionarySummary({
+            title: 'Custom Title',
+            importDate: 25,
+            autoUpdate: {
+                schedule: 'weekly',
+                lastUpdatedAt: 25,
+                nextUpdateAt: 25 + DICTIONARY_AUTO_UPDATE_WEEK_MS,
+            },
+        });
+        const archiveContent = new Uint8Array([1, 2, 3, 4]);
+        /** @type {import('dictionary-importer').Summary[]} */
+        const persistedSummaries = [];
+        const updateDictionarySummaryByTitle = vi.fn(async (_dictionaryTitle, summary) => {
+            persistedSummaries.push(summary);
+            return summary;
+        });
+        const context = {
+            _captureDictionaryUpdateSettings: vi.fn(() => ({profilesDictionarySettings: {}, mainDictionaryProfileIds: new Set(), sortFrequencyDictionaryProfileIds: new Set()})),
+            _dictionaryDatabase: {
+                deleteDictionary: vi.fn(async () => {}),
+                updateDictionarySummaryByTitle,
+            },
+            _createDictionaryImportDetails: vi.fn(() => ({prefixWildcardsSupported: false, yomitanVersion: '0.0.0.0'})),
+            _setDictionaryImportMode: vi.fn(async () => {}),
+            _importDictionaryArchiveHeadless: vi.fn(async () => ({
+                result: createDictionarySummary({
+                    title: 'Custom Title',
+                    revision: '2026.03',
+                    importDate: 500,
+                }),
+                errors: [],
+            })),
+            _setDictionarySummaryByTitle: getBackendMethod('_setDictionarySummaryByTitle'),
+            _createUpdatedDictionarySummaryAfterImport: getBackendMethod('_createUpdatedDictionarySummaryAfterImport'),
+            _applyImportedDictionarySettings: vi.fn(async () => {}),
+            _updateDictionaryAutoUpdateStateAfterSuccess: vi.fn(async () => {}),
+            _setDictionaryAutoUpdateError: vi.fn(async () => {}),
+            _handleDatabaseUpdated: vi.fn(async () => {}),
+            _pruneStaleProfileDictionaryOptions: vi.fn(async () => {}),
+            _pruneStaleDictionaryAutoUpdates: vi.fn(async () => {}),
+        };
+
+        const result = await getBackendMethod('_performDictionaryUpdate').call(context, dictionary, archiveContent, '2026.03');
+
+        expect(result).toStrictEqual({
+            dictionaryTitle: 'Custom Title',
+            status: 'updated',
+            latestRevision: '2026.03',
+            error: null,
+        });
+        expect(updateDictionarySummaryByTitle).toHaveBeenCalledTimes(1);
+        expect(persistedSummaries[0]?.autoUpdate).toStrictEqual({
+            schedule: 'weekly',
+            lastUpdatedAt: 500,
+            nextUpdateAt: 500 + DICTIONARY_AUTO_UPDATE_WEEK_MS,
+        });
+    });
+
+    test('Dictionary updates reset stored schedule metadata when the imported dictionary is no longer updatable', async () => {
+        const dictionary = createDictionarySummary({
+            title: 'Custom Title',
+            autoUpdate: {
+                schedule: 'hourly',
+                lastUpdatedAt: 75,
+                nextUpdateAt: 75 + DICTIONARY_AUTO_UPDATE_INTERVAL_MS,
+            },
+        });
+        const archiveContent = new Uint8Array([1, 2, 3, 4]);
+        /** @type {import('dictionary-importer').Summary[]} */
+        const persistedSummaries = [];
+        const context = {
+            _captureDictionaryUpdateSettings: vi.fn(() => ({profilesDictionarySettings: {}, mainDictionaryProfileIds: new Set(), sortFrequencyDictionaryProfileIds: new Set()})),
+            _dictionaryDatabase: {
+                deleteDictionary: vi.fn(async () => {}),
+                updateDictionarySummaryByTitle: vi.fn(async (_dictionaryTitle, summary) => {
+                    persistedSummaries.push(summary);
+                    return summary;
+                }),
+            },
+            _createDictionaryImportDetails: vi.fn(() => ({prefixWildcardsSupported: false, yomitanVersion: '0.0.0.0'})),
+            _setDictionaryImportMode: vi.fn(async () => {}),
+            _importDictionaryArchiveHeadless: vi.fn(async () => ({
+                result: createDictionarySummary({
+                    title: 'Custom Title',
+                    revision: '2026.03',
+                    importDate: 800,
+                    isUpdatable: false,
+                    indexUrl: void 0,
+                    downloadUrl: void 0,
+                }),
+                errors: [],
+            })),
+            _setDictionarySummaryByTitle: getBackendMethod('_setDictionarySummaryByTitle'),
+            _createUpdatedDictionarySummaryAfterImport: getBackendMethod('_createUpdatedDictionarySummaryAfterImport'),
+            _applyImportedDictionarySettings: vi.fn(async () => {}),
+            _updateDictionaryAutoUpdateStateAfterSuccess: vi.fn(async () => {}),
+            _setDictionaryAutoUpdateError: vi.fn(async () => {}),
+            _handleDatabaseUpdated: vi.fn(async () => {}),
+            _pruneStaleProfileDictionaryOptions: vi.fn(async () => {}),
+            _pruneStaleDictionaryAutoUpdates: vi.fn(async () => {}),
+        };
+
+        await getBackendMethod('_performDictionaryUpdate').call(context, dictionary, archiveContent, '2026.03');
+
+        expect(persistedSummaries[0]?.autoUpdate).toStrictEqual({
+            schedule: 'manual',
+            lastUpdatedAt: 800,
+            nextUpdateAt: null,
+        });
     });
 
     test('Imported dictionary settings migrate aliases, Anki fields, and auto-update preferences', async () => {
@@ -586,16 +918,32 @@ describe('Backend dictionary auto-update helpers', () => {
                 },
             },
             _saveOptions: saveOptions,
+            _ensureDictionaryDatabaseReady: async () => {},
+            _dictionaryDatabase: {
+                getDictionaryInfo: async () => [importedSummary],
+            },
+            _syncGlobalDictionaryAutoUpdateOptionsFromSummaries: getBackendMethod('_syncGlobalDictionaryAutoUpdateOptionsFromSummaries'),
+            _getSortedDictionaryAutoUpdateIndexUrls: getBackendMethod('_getSortedDictionaryAutoUpdateIndexUrls'),
         };
         const previousSummary = createDictionarySummary({
             title: 'Old Dictionary',
             indexUrl: 'https://example.invalid/old-index.json',
             styles: 'old-style',
+            autoUpdate: {
+                schedule: 'hourly',
+                lastUpdatedAt: 10,
+                nextUpdateAt: 10 + DICTIONARY_AUTO_UPDATE_INTERVAL_MS,
+            },
         });
         const importedSummary = createDictionarySummary({
             title: 'New Dictionary',
             indexUrl: 'https://example.invalid/new-index.json',
             styles: 'new-style',
+            autoUpdate: {
+                schedule: 'hourly',
+                lastUpdatedAt: 10,
+                nextUpdateAt: 10 + DICTIONARY_AUTO_UPDATE_INTERVAL_MS,
+            },
         });
         const updateContext = {
             profilesDictionarySettings: {
@@ -644,7 +992,7 @@ describe('Backend dictionary auto-update helpers', () => {
         expect(profile.options.general.sortFrequencyDictionary).toBe('New Dictionary');
         expect(profile.options.anki.cardFormats[0].fields.expression.value).toBe('new-dictionary-term new-dictionary-reading');
         expect(context._options.global.dictionaryAutoUpdates).toStrictEqual(['https://example.invalid/new-index.json']);
-        expect(saveOptions).toHaveBeenCalledTimes(1);
+        expect(saveOptions).toHaveBeenCalledTimes(2);
         expect(saveOptions).toHaveBeenCalledWith('background');
     });
 });

--- a/test/chromium/extension-two-dictionary-import.e2e.js
+++ b/test/chromium/extension-two-dictionary-import.e2e.js
@@ -2123,9 +2123,9 @@ async function closeDictionaryDetailsModal(page) {
     await page.waitForSelector('#dictionary-details-modal[hidden]', {timeout: 30000});
 }
 
-async function setDictionaryAutoUpdateEnabled(page, dictionaryName, enabled) {
+async function getDictionaryAutoUpdateUiState(page, dictionaryName) {
     await openDictionaryDetailsModal(page, dictionaryName);
-    const indexUrl = await page.evaluate((nextEnabled) => {
+    const uiState = await page.evaluate(() => {
         const modal = document.querySelector('#dictionary-details-modal');
         if (!(modal instanceof HTMLElement)) {
             throw new Error('Dictionary details modal missing');
@@ -2134,30 +2134,82 @@ async function setDictionaryAutoUpdateEnabled(page, dictionaryName, enabled) {
         if (!(setting instanceof HTMLElement) || setting.hidden) {
             throw new Error('Dictionary auto-update setting is hidden');
         }
-        const toggle = setting.querySelector('.dictionary-auto-update-toggle');
-        if (!(toggle instanceof HTMLInputElement)) {
-            throw new Error('Dictionary auto-update toggle missing');
+        const select = setting.querySelector('.dictionary-auto-update-select');
+        if (!(select instanceof HTMLSelectElement)) {
+            throw new Error('Dictionary auto-update select missing');
         }
-        const currentIndexUrl = String(toggle.dataset.indexUrl || '');
-        if (currentIndexUrl.length === 0) {
-            throw new Error('Dictionary auto-update toggle is missing data-index-url');
+        const description = setting.querySelector('.dictionary-auto-update-description');
+        if (!(description instanceof HTMLElement)) {
+            throw new Error('Dictionary auto-update description missing');
         }
-        if (toggle.checked !== nextEnabled) {
-            toggle.click();
+        /** @type {Record<string, string>} */
+        const details = {};
+        for (const row of modal.querySelectorAll('.dictionary-details-entry')) {
+            const labelNode = row.querySelector('.dictionary-details-entry-label');
+            const infoNode = row.querySelector('.dictionary-details-entry-info');
+            const label = String(labelNode?.textContent || '').replace(/:\s*$/, '').trim();
+            if (label.length === 0) { continue; }
+            details[label] = String(infoNode?.textContent || '').trim();
         }
-        return currentIndexUrl;
-    }, enabled);
+        return {
+            value: select.value,
+            dictionaryTitle: String(select.dataset.dictionaryTitle || ''),
+            currentSchedule: String(select.dataset.currentSchedule || ''),
+            description: String(description.textContent || '').trim(),
+            details,
+        };
+    });
+    await closeDictionaryDetailsModal(page);
+    return uiState;
+}
+
+async function setDictionaryAutoUpdateSchedule(page, dictionaryName, schedule) {
+    await openDictionaryDetailsModal(page, dictionaryName);
+    const dictionaryTitle = await page.evaluate((nextSchedule) => {
+        const modal = document.querySelector('#dictionary-details-modal');
+        if (!(modal instanceof HTMLElement)) {
+            throw new Error('Dictionary details modal missing');
+        }
+        const setting = modal.querySelector('.dictionary-auto-update-setting');
+        if (!(setting instanceof HTMLElement) || setting.hidden) {
+            throw new Error('Dictionary auto-update setting is hidden');
+        }
+        const select = setting.querySelector('.dictionary-auto-update-select');
+        if (!(select instanceof HTMLSelectElement)) {
+            throw new Error('Dictionary auto-update select missing');
+        }
+        const currentDictionaryTitle = String(select.dataset.dictionaryTitle || '');
+        if (currentDictionaryTitle.length === 0) {
+            throw new Error('Dictionary auto-update select is missing data-dictionary-title');
+        }
+        if (!['manual', 'hourly', 'daily', 'weekly'].includes(nextSchedule)) {
+            throw new Error(`Invalid dictionary auto-update schedule: ${String(nextSchedule)}`);
+        }
+        if (select.value !== nextSchedule) {
+            select.value = nextSchedule;
+            select.dispatchEvent(new Event('change', {bubbles: true}));
+        }
+        return currentDictionaryTitle;
+    }, schedule);
     const deadline = safePerformance.now() + 30_000;
+    let latestDictionary = null;
     while (safePerformance.now() < deadline) {
+        const dictionaryInfo = await getDictionaryInfoRuntime(page);
+        latestDictionary = Array.isArray(dictionaryInfo) ?
+            dictionaryInfo.find((dictionary) => String(dictionary?.title || '') === dictionaryTitle) :
+            null;
+        const savedSchedule = String(latestDictionary?.autoUpdate?.schedule || '');
         const optionsFull = await getOptionsFullRuntime(page);
         const enabledIndexUrls = Array.isArray(optionsFull?.global?.dictionaryAutoUpdates) ? optionsFull.global.dictionaryAutoUpdates.map(String) : [];
-        if (enabledIndexUrls.includes(indexUrl) === enabled) {
+        const indexUrl = String(latestDictionary?.indexUrl || '');
+        const isHourlyEnabled = indexUrl.length > 0 && enabledIndexUrls.includes(indexUrl);
+        if (savedSchedule === schedule && (schedule === 'hourly' ? isHourlyEnabled : !isHourlyEnabled)) {
             break;
         }
         await page.waitForTimeout(250);
     }
     await closeDictionaryDetailsModal(page);
-    return indexUrl;
+    return latestDictionary;
 }
 
 async function configureAutoUpdateDictionaryProfile(page, dictionaryName) {
@@ -2331,27 +2383,64 @@ async function runAutoUpdateScenario(page, extensionBaseUrl, localServer, report
             processSampler,
         );
 
-        const enableToggleStart = safePerformance.now();
-        const enableToggleProfile = await runPhaseProfile(cdpSession, async () => {
-            const enabledIndexUrl = await setDictionaryAutoUpdateEnabled(page, fixture.initialTitle, true);
+        const scheduleUiStart = safePerformance.now();
+        const scheduleUiProfile = await runPhaseProfile(cdpSession, async () => {
+            const initialUiState = await getDictionaryAutoUpdateUiState(page, fixture.initialTitle);
+            const dailyDictionary = await setDictionaryAutoUpdateSchedule(page, fixture.initialTitle, 'daily');
+            const dailyUiState = await getDictionaryAutoUpdateUiState(page, fixture.initialTitle);
+            const manualDictionary = await setDictionaryAutoUpdateSchedule(page, fixture.initialTitle, 'manual');
+            const manualUiState = await getDictionaryAutoUpdateUiState(page, fixture.initialTitle);
+            const hourlyDictionary = await setDictionaryAutoUpdateSchedule(page, fixture.initialTitle, 'hourly');
             await configureAutoUpdateDictionaryProfile(page, fixture.initialTitle);
             const optionsFull = await getOptionsFullRuntime(page);
-            return {enabledIndexUrl, optionsFull};
+            return {initialUiState, dailyDictionary, dailyUiState, manualDictionary, manualUiState, hourlyDictionary, optionsFull};
         });
-        const enableToggleEnd = safePerformance.now();
+        const scheduleUiEnd = safePerformance.now();
         ensureAutoUpdateRequest(
-            String(enableToggleProfile.result?.enabledIndexUrl || '') === fixture.oldIndexUrl,
-            'Auto-update toggle did not bind to the expected initial index URL',
-            enableToggleProfile.result,
+            scheduleUiProfile.result?.initialUiState?.value === 'manual' &&
+            scheduleUiProfile.result?.initialUiState?.currentSchedule === 'manual' &&
+            scheduleUiProfile.result?.initialUiState?.dictionaryTitle === fixture.initialTitle &&
+            scheduleUiProfile.result?.initialUiState?.description === 'Updates must be started manually.' &&
+            scheduleUiProfile.result?.initialUiState?.details?.['Update Schedule'] === 'Manual' &&
+            scheduleUiProfile.result?.initialUiState?.details?.['Next Scheduled Update'] === 'Not scheduled' &&
+            typeof scheduleUiProfile.result?.initialUiState?.details?.['Last Updated'] === 'string' &&
+            scheduleUiProfile.result.initialUiState.details['Last Updated'].length > 0,
+            'Initial manual auto-update UI state was not rendered as expected',
+            scheduleUiProfile.result,
+        );
+        ensureAutoUpdateRequest(
+            String(scheduleUiProfile.result?.dailyDictionary?.autoUpdate?.schedule || '') === 'daily' &&
+            String(scheduleUiProfile.result?.dailyUiState?.value || '') === 'daily' &&
+            String(scheduleUiProfile.result?.dailyUiState?.currentSchedule || '') === 'daily' &&
+            String(scheduleUiProfile.result?.dailyUiState?.description || '') === 'Checks for updates every day and installs them automatically.' &&
+            String(scheduleUiProfile.result?.dailyUiState?.details?.['Update Schedule'] || '') === 'Daily' &&
+            String(scheduleUiProfile.result?.dailyUiState?.details?.['Next Scheduled Update'] || '') !== 'Not scheduled',
+            'Daily auto-update schedule UI state was not rendered as expected',
+            scheduleUiProfile.result,
+        );
+        ensureAutoUpdateRequest(
+            String(scheduleUiProfile.result?.manualDictionary?.autoUpdate?.schedule || '') === 'manual' &&
+            String(scheduleUiProfile.result?.manualUiState?.value || '') === 'manual' &&
+            String(scheduleUiProfile.result?.manualUiState?.currentSchedule || '') === 'manual' &&
+            String(scheduleUiProfile.result?.manualUiState?.details?.['Update Schedule'] || '') === 'Manual' &&
+            String(scheduleUiProfile.result?.manualUiState?.details?.['Next Scheduled Update'] || '') === 'Not scheduled',
+            'Manual auto-update schedule did not persist after reopening the modal',
+            scheduleUiProfile.result,
+        );
+        ensureAutoUpdateRequest(
+            String(scheduleUiProfile.result?.hourlyDictionary?.indexUrl || '') === fixture.oldIndexUrl &&
+            String(scheduleUiProfile.result?.hourlyDictionary?.autoUpdate?.schedule || '') === 'hourly',
+            'Hourly auto-update schedule did not bind to the expected initial index URL',
+            scheduleUiProfile.result,
         );
         await addReportPhase(
             report,
             page,
-            'Enable hourly auto-updates',
-            `Enabled automatic hourly updates for ${fixture.initialTitle} using index URL ${fixture.oldIndexUrl}`,
-            enableToggleStart,
-            enableToggleEnd,
-            enableToggleProfile,
+            'Configure dictionary update schedules',
+            `Verified manual, daily, and hourly schedule UI states for ${fixture.initialTitle} using index URL ${fixture.oldIndexUrl}`,
+            scheduleUiStart,
+            scheduleUiEnd,
+            scheduleUiProfile,
             processSampler,
         );
 

--- a/test/data/database-test-cases.json
+++ b/test/data/database-test-cases.json
@@ -8,6 +8,11 @@
     "importDate": 0,
     "importSuccess": true,
     "prefixWildcardsSupported": true,
+    "autoUpdate": {
+      "schedule": "manual",
+      "lastUpdatedAt": 0,
+      "nextUpdateAt": null
+    },
     "counts": {
       "kanji": {
         "total": 2

--- a/test/database.test.js
+++ b/test/database.test.js
@@ -1273,6 +1273,9 @@ describe('Database', () => {
 
             if (importDictionaryResult) {
                 importDictionaryResult.importDate = fakeImportDate;
+                if (typeof importDictionaryResult.autoUpdate === 'object' && importDictionaryResult.autoUpdate !== null) {
+                    importDictionaryResult.autoUpdate.lastUpdatedAt = fakeImportDate;
+                }
             }
 
             expect.soft(importDictionaryErrors).toStrictEqual([]);
@@ -1281,7 +1284,12 @@ describe('Database', () => {
 
             // Get info summary
             const info = await dictionaryDatabase.getDictionaryInfo();
-            for (const item of info) { item.importDate = fakeImportDate; }
+            for (const item of info) {
+                item.importDate = fakeImportDate;
+                if (typeof item.autoUpdate === 'object' && item.autoUpdate !== null) {
+                    item.autoUpdate.lastUpdatedAt = fakeImportDate;
+                }
+            }
             expect.soft(info).toStrictEqual([testData.expectedSummary]);
 
             // Get counts
@@ -1372,6 +1380,68 @@ describe('Database', () => {
             }
 
             // Close
+            await dictionaryDatabase.close();
+        });
+
+        test('Normalizes legacy dictionary auto-update metadata on read and can persist metadata updates by title', async ({expect}) => {
+            const testDictionarySource = await createTestDictionaryArchiveData('valid-dictionary1');
+            const testDictionaryIndex = await getDictionaryArchiveIndex(testDictionarySource);
+            const dictionaryImporter = createDictionaryImporter(expect);
+            const dictionaryDatabase = new DictionaryDatabase();
+            await dictionaryDatabase.prepare();
+            await dictionaryImporter.importDictionary(
+                dictionaryDatabase,
+                testDictionarySource,
+                {prefixWildcardsSupported: true, yomitanVersion: '0.0.0.0'},
+            );
+
+            const db = dictionaryDatabase._requireDb();
+            const summaryRow = db.selectObject('SELECT summaryJson FROM dictionaries WHERE title = $title LIMIT 1', {$title: testDictionaryIndex.title});
+            expect.soft(typeof summaryRow).toBe('object');
+            if (typeof summaryRow === 'undefined') {
+                throw new Error('Imported dictionary summary row missing');
+            }
+            if (typeof summaryRow.summaryJson !== 'string') {
+                throw new Error('Imported dictionary summaryJson missing');
+            }
+            const summary = /** @type {import('dictionary-importer').Summary} */ (parseJson(summaryRow.summaryJson));
+            delete summary.autoUpdate;
+            db.exec({
+                sql: 'UPDATE dictionaries SET summaryJson = $summaryJson WHERE title = $title',
+                bind: {
+                    $summaryJson: JSON.stringify(summary),
+                    $title: testDictionaryIndex.title,
+                },
+            });
+
+            const [legacyInfo] = await dictionaryDatabase.getDictionaryInfo();
+            expect.soft(legacyInfo?.autoUpdate).toStrictEqual({
+                schedule: 'manual',
+                lastUpdatedAt: legacyInfo?.importDate ?? null,
+                nextUpdateAt: null,
+            });
+
+            const updatedSummary = await dictionaryDatabase.updateDictionarySummaryByTitle(testDictionaryIndex.title, {
+                ...legacyInfo,
+                autoUpdate: {
+                    schedule: 'manual',
+                    lastUpdatedAt: 1234,
+                    nextUpdateAt: null,
+                },
+            });
+            expect.soft(updatedSummary?.autoUpdate).toStrictEqual({
+                schedule: 'manual',
+                lastUpdatedAt: 1234,
+                nextUpdateAt: null,
+            });
+
+            const [persistedInfo] = await dictionaryDatabase.getDictionaryInfo();
+            expect.soft(persistedInfo?.autoUpdate).toStrictEqual({
+                schedule: 'manual',
+                lastUpdatedAt: 1234,
+                nextUpdateAt: null,
+            });
+
             await dictionaryDatabase.close();
         });
 

--- a/test/dictionary-auto-update-util.test.js
+++ b/test/dictionary-auto-update-util.test.js
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2026  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {describe, expect, test} from 'vitest';
+
+import {normalizeDictionarySummary, setDictionarySummaryAutoUpdate} from '../ext/js/dictionary/dictionary-auto-update-util.js';
+
+const HOUR_MS = 60 * 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+const WEEK_MS = 7 * DAY_MS;
+
+/**
+ * @param {Partial<import('dictionary-importer').Summary>} [overrides]
+ * @returns {import('dictionary-importer').Summary}
+ */
+function createDictionarySummary(overrides = {}) {
+    return /** @type {import('dictionary-importer').Summary} */ ({
+        title: 'Test Dictionary',
+        revision: '1',
+        sequenced: false,
+        version: 3,
+        importDate: 100,
+        prefixWildcardsSupported: false,
+        styles: '',
+        counts: {
+            terms: {total: 1},
+            termMeta: {total: 0},
+            kanji: {total: 0},
+            kanjiMeta: {total: 0},
+            tagMeta: {total: 0},
+            media: {total: 0},
+        },
+        isUpdatable: true,
+        indexUrl: 'https://example.invalid/index.json',
+        downloadUrl: 'https://example.invalid/dictionary.zip',
+        importSuccess: true,
+        autoUpdate: {
+            schedule: 'manual',
+            lastUpdatedAt: 100,
+            nextUpdateAt: null,
+        },
+        ...overrides,
+    });
+}
+
+describe('dictionary-auto-update-util', () => {
+    test('normalizeDictionarySummary preserves stored nextUpdateAt for scheduled dictionaries', () => {
+        const summary = createDictionarySummary({
+            autoUpdate: {
+                schedule: 'daily',
+                lastUpdatedAt: 250,
+                nextUpdateAt: 999,
+            },
+        });
+
+        const normalizedSummary = normalizeDictionarySummary(summary);
+
+        expect(normalizedSummary.autoUpdate).toStrictEqual({
+            schedule: 'daily',
+            lastUpdatedAt: 250,
+            nextUpdateAt: 999,
+        });
+    });
+
+    test('normalizeDictionarySummary synthesizes missing nextUpdateAt from lastUpdatedAt', () => {
+        const summary = createDictionarySummary();
+        summary.autoUpdate = /** @type {import('dictionary-importer').DictionaryAutoUpdateInfo} */ (/** @type {unknown} */ ({
+            schedule: 'daily',
+            lastUpdatedAt: 250,
+        }));
+
+        const normalizedSummary = normalizeDictionarySummary(summary);
+
+        expect(normalizedSummary.autoUpdate).toStrictEqual({
+            schedule: 'daily',
+            lastUpdatedAt: 250,
+            nextUpdateAt: 250 + DAY_MS,
+        });
+    });
+
+    test('normalizeDictionarySummary synthesizes invalid nextUpdateAt values from lastUpdatedAt', () => {
+        const summary = createDictionarySummary({
+            autoUpdate: /** @type {import('dictionary-importer').DictionaryAutoUpdateInfo} */ ({
+                schedule: 'weekly',
+                lastUpdatedAt: 300,
+                nextUpdateAt: Number.NaN,
+            }),
+        });
+
+        const normalizedSummary = normalizeDictionarySummary(summary);
+
+        expect(normalizedSummary.autoUpdate).toStrictEqual({
+            schedule: 'weekly',
+            lastUpdatedAt: 300,
+            nextUpdateAt: 300 + WEEK_MS,
+        });
+    });
+
+    test('normalizeDictionarySummary forces manual schedules to keep nextUpdateAt null', () => {
+        const summary = createDictionarySummary({
+            autoUpdate: {
+                schedule: 'manual',
+                lastUpdatedAt: 400,
+                nextUpdateAt: 400 + HOUR_MS,
+            },
+        });
+
+        const normalizedSummary = normalizeDictionarySummary(summary);
+
+        expect(normalizedSummary.autoUpdate).toStrictEqual({
+            schedule: 'manual',
+            lastUpdatedAt: 400,
+            nextUpdateAt: null,
+        });
+    });
+
+    test('setDictionarySummaryAutoUpdate preserves nextUpdateAt when schedule metadata is otherwise unchanged', () => {
+        const summary = createDictionarySummary({
+            autoUpdate: {
+                schedule: 'daily',
+                lastUpdatedAt: 500,
+                nextUpdateAt: 750,
+            },
+        });
+
+        const updatedSummary = setDictionarySummaryAutoUpdate(summary, {schedule: 'daily'});
+
+        expect(updatedSummary.autoUpdate).toStrictEqual({
+            schedule: 'daily',
+            lastUpdatedAt: 500,
+            nextUpdateAt: 750,
+        });
+    });
+
+    test('setDictionarySummaryAutoUpdate accepts explicit nextUpdateAt overrides', () => {
+        const summary = createDictionarySummary({
+            autoUpdate: {
+                schedule: 'daily',
+                lastUpdatedAt: 600,
+                nextUpdateAt: 600 + DAY_MS,
+            },
+        });
+
+        const updatedSummary = setDictionarySummaryAutoUpdate(summary, {
+            nextUpdateAt: 12345,
+        });
+
+        expect(updatedSummary.autoUpdate).toStrictEqual({
+            schedule: 'daily',
+            lastUpdatedAt: 600,
+            nextUpdateAt: 12345,
+        });
+    });
+});

--- a/test/firefox/extension-two-dictionary-import.e2e.js
+++ b/test/firefox/extension-two-dictionary-import.e2e.js
@@ -1816,9 +1816,9 @@ async function closeDictionaryDetailsModal(driver) {
     }, 30_000, 'Expected dictionary details modal to be hidden');
 }
 
-async function setDictionaryAutoUpdateEnabled(driver, dictionaryName, enabled) {
+async function getDictionaryAutoUpdateUiState(driver, dictionaryName) {
     await openDictionaryDetailsModal(driver, dictionaryName);
-    const indexUrl = String(await driver.executeScript(`
+    const uiState = await driver.executeScript(`
         const modal = document.querySelector('#dictionary-details-modal');
         if (!(modal instanceof HTMLElement)) {
             throw new Error('Dictionary details modal missing');
@@ -1827,30 +1827,82 @@ async function setDictionaryAutoUpdateEnabled(driver, dictionaryName, enabled) {
         if (!(setting instanceof HTMLElement) || setting.hidden) {
             throw new Error('Dictionary auto-update setting is hidden');
         }
-        const toggle = setting.querySelector('.dictionary-auto-update-toggle');
-        if (!(toggle instanceof HTMLInputElement)) {
-            throw new Error('Dictionary auto-update toggle missing');
+        const select = setting.querySelector('.dictionary-auto-update-select');
+        if (!(select instanceof HTMLSelectElement)) {
+            throw new Error('Dictionary auto-update select missing');
         }
-        const currentIndexUrl = String(toggle.dataset.indexUrl || '');
-        if (currentIndexUrl.length === 0) {
-            throw new Error('Dictionary auto-update toggle is missing data-index-url');
+        const description = setting.querySelector('.dictionary-auto-update-description');
+        if (!(description instanceof HTMLElement)) {
+            throw new Error('Dictionary auto-update description missing');
         }
-        if (toggle.checked !== arguments[0]) {
-            toggle.click();
+        /** @type {Record<string, string>} */
+        const details = {};
+        for (const row of modal.querySelectorAll('.dictionary-details-entry')) {
+            const labelNode = row.querySelector('.dictionary-details-entry-label');
+            const infoNode = row.querySelector('.dictionary-details-entry-info');
+            const label = String(labelNode?.textContent || '').replace(/:\\s*$/, '').trim();
+            if (label.length === 0) { continue; }
+            details[label] = String(infoNode?.textContent || '').trim();
         }
-        return currentIndexUrl;
-    `, enabled));
+        return {
+            value: select.value,
+            dictionaryTitle: String(select.dataset.dictionaryTitle || ''),
+            currentSchedule: String(select.dataset.currentSchedule || ''),
+            description: String(description.textContent || '').trim(),
+            details,
+        };
+    `);
+    await closeDictionaryDetailsModal(driver);
+    return uiState;
+}
+
+async function setDictionaryAutoUpdateSchedule(driver, dictionaryName, schedule) {
+    await openDictionaryDetailsModal(driver, dictionaryName);
+    const dictionaryTitle = String(await driver.executeScript(`
+        const modal = document.querySelector('#dictionary-details-modal');
+        if (!(modal instanceof HTMLElement)) {
+            throw new Error('Dictionary details modal missing');
+        }
+        const setting = modal.querySelector('.dictionary-auto-update-setting');
+        if (!(setting instanceof HTMLElement) || setting.hidden) {
+            throw new Error('Dictionary auto-update setting is hidden');
+        }
+        const select = setting.querySelector('.dictionary-auto-update-select');
+        if (!(select instanceof HTMLSelectElement)) {
+            throw new Error('Dictionary auto-update select missing');
+        }
+        const currentDictionaryTitle = String(select.dataset.dictionaryTitle || '');
+        if (currentDictionaryTitle.length === 0) {
+            throw new Error('Dictionary auto-update select is missing data-dictionary-title');
+        }
+        if (!['manual', 'hourly', 'daily', 'weekly'].includes(arguments[0])) {
+            throw new Error(\`Invalid dictionary auto-update schedule: \${String(arguments[0])}\`);
+        }
+        if (select.value !== arguments[0]) {
+            select.value = arguments[0];
+            select.dispatchEvent(new Event('change', {bubbles: true}));
+        }
+        return currentDictionaryTitle;
+    `, schedule));
     const deadline = safePerformance.now() + 30_000;
+    let latestDictionary = null;
     while (safePerformance.now() < deadline) {
+        const dictionaryInfo = await getDictionaryInfoRuntime(driver);
+        latestDictionary = Array.isArray(dictionaryInfo) ?
+            dictionaryInfo.find((dictionary) => String(dictionary?.title || '') === dictionaryTitle) :
+            null;
+        const savedSchedule = String(latestDictionary?.autoUpdate?.schedule || '');
         const optionsFull = await getOptionsFullRuntime(driver);
         const enabledIndexUrls = Array.isArray(optionsFull?.global?.dictionaryAutoUpdates) ? optionsFull.global.dictionaryAutoUpdates.map(String) : [];
-        if (enabledIndexUrls.includes(indexUrl) === enabled) {
+        const indexUrl = String(latestDictionary?.indexUrl || '');
+        const isHourlyEnabled = indexUrl.length > 0 && enabledIndexUrls.includes(indexUrl);
+        if (savedSchedule === schedule && (schedule === 'hourly' ? isHourlyEnabled : !isHourlyEnabled)) {
             break;
         }
         await driver.sleep(250);
     }
     await closeDictionaryDetailsModal(driver);
-    return indexUrl;
+    return latestDictionary;
 }
 
 async function configureAutoUpdateDictionaryProfile(driver, dictionaryName) {
@@ -1980,22 +2032,59 @@ async function runAutoUpdateScenario(driver, extensionBaseUrl, localServer, repo
             importEnd,
         );
 
-        const enableToggleStart = safePerformance.now();
-        const enabledIndexUrl = await setDictionaryAutoUpdateEnabled(driver, fixture.initialTitle, true);
+        const scheduleUiStart = safePerformance.now();
+        const initialUiState = await getDictionaryAutoUpdateUiState(driver, fixture.initialTitle);
+        const dailyDictionary = await setDictionaryAutoUpdateSchedule(driver, fixture.initialTitle, 'daily');
+        const dailyUiState = await getDictionaryAutoUpdateUiState(driver, fixture.initialTitle);
+        const manualDictionary = await setDictionaryAutoUpdateSchedule(driver, fixture.initialTitle, 'manual');
+        const manualUiState = await getDictionaryAutoUpdateUiState(driver, fixture.initialTitle);
+        const hourlyDictionary = await setDictionaryAutoUpdateSchedule(driver, fixture.initialTitle, 'hourly');
         await configureAutoUpdateDictionaryProfile(driver, fixture.initialTitle);
-        const enableToggleEnd = safePerformance.now();
+        const scheduleUiEnd = safePerformance.now();
         ensureAutoUpdateRequest(
-            enabledIndexUrl === fixture.oldIndexUrl,
-            'Auto-update toggle did not bind to the expected initial index URL',
-            enabledIndexUrl,
+            initialUiState?.value === 'manual' &&
+            initialUiState?.currentSchedule === 'manual' &&
+            initialUiState?.dictionaryTitle === fixture.initialTitle &&
+            initialUiState?.description === 'Updates must be started manually.' &&
+            initialUiState?.details?.['Update Schedule'] === 'Manual' &&
+            initialUiState?.details?.['Next Scheduled Update'] === 'Not scheduled' &&
+            typeof initialUiState?.details?.['Last Updated'] === 'string' &&
+            initialUiState.details['Last Updated'].length > 0,
+            'Initial manual auto-update UI state was not rendered as expected',
+            initialUiState,
+        );
+        ensureAutoUpdateRequest(
+            String(dailyDictionary?.autoUpdate?.schedule || '') === 'daily' &&
+            String(dailyUiState?.value || '') === 'daily' &&
+            String(dailyUiState?.currentSchedule || '') === 'daily' &&
+            String(dailyUiState?.description || '') === 'Checks for updates every day and installs them automatically.' &&
+            String(dailyUiState?.details?.['Update Schedule'] || '') === 'Daily' &&
+            String(dailyUiState?.details?.['Next Scheduled Update'] || '') !== 'Not scheduled',
+            'Daily auto-update schedule UI state was not rendered as expected',
+            dailyUiState,
+        );
+        ensureAutoUpdateRequest(
+            String(manualDictionary?.autoUpdate?.schedule || '') === 'manual' &&
+            String(manualUiState?.value || '') === 'manual' &&
+            String(manualUiState?.currentSchedule || '') === 'manual' &&
+            String(manualUiState?.details?.['Update Schedule'] || '') === 'Manual' &&
+            String(manualUiState?.details?.['Next Scheduled Update'] || '') === 'Not scheduled',
+            'Manual auto-update schedule did not persist after reopening the modal',
+            manualUiState,
+        );
+        ensureAutoUpdateRequest(
+            String(hourlyDictionary?.indexUrl || '') === fixture.oldIndexUrl &&
+            String(hourlyDictionary?.autoUpdate?.schedule || '') === 'hourly',
+            'Hourly auto-update schedule did not bind to the expected initial index URL',
+            hourlyDictionary,
         );
         await addReportPhase(
             report,
             driver,
-            'Enable hourly auto-updates',
-            `Enabled automatic hourly updates for ${fixture.initialTitle} using index URL ${fixture.oldIndexUrl}`,
-            enableToggleStart,
-            enableToggleEnd,
+            'Configure dictionary update schedules',
+            `Verified manual, daily, and hourly schedule UI states for ${fixture.initialTitle} using index URL ${fixture.oldIndexUrl}`,
+            scheduleUiStart,
+            scheduleUiEnd,
         );
 
         localServer.clearAutoUpdateRequests();

--- a/types/ext/api.d.ts
+++ b/types/ext/api.d.ts
@@ -317,6 +317,13 @@ type ApiSurface = {
         };
         return: Backend.DictionaryUpdateResult;
     };
+    setDictionaryUpdateSchedule: {
+        params: {
+            dictionaryTitle: string;
+            schedule: DictionaryImporter.DictionaryAutoUpdateSchedule;
+        };
+        return: DictionaryImporter.Summary;
+    };
     setDictionaryImportMode: {
         params: {
             active: boolean;

--- a/types/ext/dictionary-auto-update-util.d.ts
+++ b/types/ext/dictionary-auto-update-util.d.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2026  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import type * as DictionaryImporter from './dictionary-importer';
+
+export function isDictionaryAutoUpdateSchedule(value: unknown): value is DictionaryImporter.DictionaryAutoUpdateSchedule;
+
+export function getNextDictionaryAutoUpdateTime(
+    schedule: DictionaryImporter.DictionaryAutoUpdateSchedule,
+    referenceTimestamp: number | null | undefined,
+): number | null;
+
+export function createDictionaryAutoUpdate(
+    schedule: DictionaryImporter.DictionaryAutoUpdateSchedule,
+    lastUpdatedAt: number | null | undefined,
+): DictionaryImporter.DictionaryAutoUpdateInfo;
+
+export function normalizeDictionarySummary(summary: DictionaryImporter.Summary): DictionaryImporter.Summary;
+
+export function setDictionarySummaryAutoUpdate(
+    summary: DictionaryImporter.Summary,
+    details?: {
+        schedule?: DictionaryImporter.DictionaryAutoUpdateSchedule;
+        lastUpdatedAt?: number | null;
+    },
+): DictionaryImporter.Summary;

--- a/types/ext/dictionary-importer.d.ts
+++ b/types/ext/dictionary-importer.d.ts
@@ -65,6 +65,14 @@ export type ImportDetails = {
     termContentStorageMode?: 'baseline' | 'raw-bytes';
 };
 
+export type DictionaryAutoUpdateSchedule = 'manual' | 'hourly' | 'daily' | 'weekly';
+
+export type DictionaryAutoUpdateInfo = {
+    schedule: DictionaryAutoUpdateSchedule;
+    lastUpdatedAt: number | null;
+    nextUpdateAt: number | null;
+};
+
 export type Summary = {
     title: string;
     revision: string;
@@ -86,6 +94,7 @@ export type Summary = {
     targetLanguage?: string;
     frequencyMode?: 'occurrence-based' | 'rank-based';
     importSuccess?: boolean;
+    autoUpdate?: DictionaryAutoUpdateInfo;
 };
 
 export type SummaryDetails = {

--- a/types/ext/offscreen.d.ts
+++ b/types/ext/offscreen.d.ts
@@ -50,6 +50,13 @@ type ApiSurface = {
         params: void;
         return: DictionaryImporter.Summary[];
     };
+    updateDictionarySummaryByTitleOffscreen: {
+        params: {
+            dictionaryTitle: string;
+            summary: DictionaryImporter.Summary;
+        };
+        return: DictionaryImporter.Summary | null;
+    };
     getMaxHeadwordLengthOffscreen: {
         params: void;
         return: number;


### PR DESCRIPTION
## Summary
- make per-dictionary `autoUpdate` summary metadata the source of truth for automatic dictionary update scheduling
- add the dictionary details modal schedule selector and metadata rows for manual, hourly, daily, and weekly schedules
- keep `global.dictionaryAutoUpdates` as hourly-only compatibility state while expanding backend, database, unit, and browser-test coverage

## Notes
- no public API changes; existing `Summary.autoUpdate` and `setDictionaryUpdateSchedule(...)` remain the interface
- `daily` and `weekly` now execute automatically during the existing hourly background pass
- `nextUpdateAt` is scheduler-managed and may advance after successful automatic no-update checks
- browser e2e expectations were updated, but browser suites were not used as a local blocking gate for this shipping pass

## Testing
- `npm run test:unit -- --run test/backend-dictionary-auto-update.test.js test/dictionary-auto-update-util.test.js test/database.test.js`
- `npm run test:ts`
- `npm run test:html`
- `npm run test:build`
- `npx eslint ext/js/background/backend.js ext/js/dictionary/dictionary-auto-update-util.js ext/js/pages/settings/dictionary-controller.js ext/templates-modals.html test/backend-dictionary-auto-update.test.js test/chromium/extension-two-dictionary-import.e2e.js test/firefox/extension-two-dictionary-import.e2e.js test/dictionary-auto-update-util.test.js`
