### PR TITLE
Add popup appearance modes and glass presets

### DIFF
--- a/ext/css/display-pronunciation.css
+++ b/ext/css/display-pronunciation.css
@@ -22,6 +22,9 @@
 :root[data-theme=dark] {
     --pronunciation-annotation-color: #ffffff;
 }
+:root[data-theme-preset^=glass] {
+    --pronunciation-annotation-color: var(--reason-text-color);
+}
 
 .pronunciation-downstep-notation {
     display: inline;

--- a/ext/css/display.css
+++ b/ext/css/display.css
@@ -260,167 +260,67 @@
 :root[data-theme-preset=glass][data-theme=light] {
     color-scheme: light;
     --background-color: transparent;
-    --gloss-image-background-color: rgba(255, 255, 255, 0.16);
     --text-color: #202020;
     --reason-text-color: #535353;
     --headword-furigana-text-color: #535353;
     --headword-reading-text-color: #535353;
-    --light-border-color: rgba(255, 255, 255, 0.26);
-    --medium-border-color: rgba(255, 255, 255, 0.2);
-    --dark-border-color: rgba(104, 118, 138, 0.38);
-    --sidebar-background-color: rgba(255, 255, 255, 0.12);
-    --scrollbar-thumb-color: rgba(0, 0, 0, 0.28);
-    --scrollbar-track-color: rgba(255, 255, 255, 0.08);
-    --notification-text-color: #202020;
-    --notification-background-color: rgba(255, 255, 255, 0.2);
-    --notification-background-color-light: rgba(255, 255, 255, 0.26);
-    --notification-background-color-lighter: rgba(255, 255, 255, 0.32);
-    --notification-shadow-color: rgba(23, 32, 51, 0.15);
-    --background-color-light: rgba(255, 255, 255, 0.22);
-    --background-color-dark1: rgba(255, 255, 255, 0.08);
     --text-color-light2: #535353;
-    --text-color-light3: #60656f;
-    --text-color-light4: #737983;
-    --input-background-color: rgba(255, 255, 255, 0.18);
-    --input-background-color-dark: rgba(255, 255, 255, 0.24);
-    --input-background-color-darker: rgba(255, 255, 255, 0.3);
-    --glass-panel-background: rgba(255, 255, 255, 0.12);
-    --glass-panel-background-strong: rgba(255, 255, 255, 0.22);
-    --glass-panel-border-color: rgba(255, 255, 255, 0.24);
-    --glass-panel-shadow: 0 18px 40px rgba(28, 39, 59, 0.14);
-    --glass-page-background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.85), rgba(228, 237, 255, 0.5) 32%, rgba(201, 217, 242, 0.32) 65%, rgba(189, 203, 224, 0.14) 100%);
+    --glass-subtext-color: #535353;
+    --glass-panel-background: rgba(210, 210, 215, 0.85);
+    --glass-panel-background-strong: rgba(210, 210, 215, 0.85);
+    --glass-panel-border-color: rgba(0, 0, 0, 0.2);
 }
 :root[data-theme-preset=glass][data-theme=dark] {
     color-scheme: dark;
     --background-color: transparent;
-    --gloss-image-background-color: rgba(32, 37, 48, 0.52);
     --text-color: #dfdfdf;
     --reason-text-color: #acacac;
     --headword-furigana-text-color: #acacac;
     --headword-reading-text-color: #acacac;
-    --light-border-color: rgba(255, 255, 255, 0.12);
-    --medium-border-color: rgba(255, 255, 255, 0.16);
-    --dark-border-color: rgba(255, 255, 255, 0.24);
-    --sidebar-background-color: rgba(20, 24, 33, 0.3);
-    --scrollbar-thumb-color: rgba(255, 255, 255, 0.18);
-    --scrollbar-track-color: rgba(0, 0, 0, 0.08);
-    --notification-text-color: #dfdfdf;
-    --notification-background-color: rgba(27, 31, 43, 0.56);
-    --notification-background-color-light: rgba(37, 42, 58, 0.68);
-    --notification-background-color-lighter: rgba(46, 52, 72, 0.82);
-    --notification-shadow-color: rgba(0, 0, 0, 0.35);
-    --background-color-light: rgba(255, 255, 255, 0.08);
-    --background-color-dark1: rgba(255, 255, 255, 0.04);
     --text-color-light2: #acacac;
-    --text-color-light3: #9ba3ae;
-    --text-color-light4: #88909b;
-    --input-background-color: rgba(20, 24, 33, 0.32);
-    --input-background-color-dark: rgba(30, 35, 46, 0.44);
-    --input-background-color-darker: rgba(38, 44, 58, 0.56);
-    --glass-panel-background: rgba(18, 22, 31, 0.36);
-    --glass-panel-background-strong: rgba(24, 29, 40, 0.54);
-    --glass-panel-border-color: rgba(255, 255, 255, 0.12);
-    --glass-panel-shadow: 0 24px 48px rgba(0, 0, 0, 0.3);
-    --glass-page-background: radial-gradient(circle at top left, rgba(76, 95, 128, 0.46), rgba(29, 34, 48, 0.82) 38%, rgba(16, 18, 25, 0.96) 100%);
+    --glass-subtext-color: #acacac;
+    --glass-panel-background: rgba(45, 45, 50, 0.85);
+    --glass-panel-background-strong: rgba(45, 45, 50, 0.85);
+    --glass-panel-border-color: rgba(255, 255, 255, 0.2);
 }
 :root[data-theme-preset=glass-autumnal][data-theme=light] {
     color-scheme: light;
     --background-color: transparent;
-    --gloss-image-background-color: rgba(255, 243, 232, 0.26);
     --text-color: #3f2516;
     --reason-text-color: #7a5541;
-    --headword-furigana-text-color: #8a6047;
-    --headword-reading-text-color: #8a6047;
-    --light-border-color: rgba(255, 243, 232, 0.34);
-    --medium-border-color: rgba(224, 180, 145, 0.28);
-    --dark-border-color: rgba(168, 103, 60, 0.34);
-    --sidebar-background-color: rgba(255, 237, 221, 0.16);
-    --scrollbar-thumb-color: rgba(122, 85, 65, 0.34);
-    --scrollbar-track-color: rgba(255, 245, 236, 0.12);
-    --notification-text-color: #3f2516;
-    --notification-background-color: rgba(255, 241, 229, 0.2);
-    --notification-background-color-light: rgba(255, 241, 229, 0.26);
-    --notification-background-color-lighter: rgba(255, 241, 229, 0.34);
-    --notification-shadow-color: rgba(101, 59, 27, 0.16);
-    --background-color-light: rgba(255, 243, 232, 0.2);
-    --background-color-dark1: rgba(255, 226, 196, 0.14);
+    --headword-furigana-text-color: #7a5541;
+    --headword-reading-text-color: #7a5541;
     --text-color-light2: #7a5541;
-    --text-color-light3: #8a6047;
-    --text-color-light4: #9d7156;
-    --input-background-color: rgba(255, 240, 225, 0.22);
-    --input-background-color-dark: rgba(249, 220, 195, 0.3);
-    --input-background-color-darker: rgba(240, 198, 166, 0.4);
-    --glass-panel-background: rgba(255, 238, 222, 0.14);
-    --glass-panel-background-strong: rgba(255, 233, 214, 0.26);
-    --glass-panel-border-color: rgba(255, 244, 232, 0.3);
-    --glass-panel-shadow: 0 18px 40px rgba(114, 67, 33, 0.14);
-    --glass-page-background: radial-gradient(circle at top left, rgba(255, 235, 210, 0.92), rgba(236, 197, 160, 0.54) 34%, rgba(195, 132, 80, 0.24) 100%);
+    --glass-subtext-color: #7a5541;
+    --glass-panel-background: rgba(243, 219, 198, 0.85);
+    --glass-panel-background-strong: rgba(243, 219, 198, 0.85);
+    --glass-panel-border-color: rgba(116, 68, 39, 0.2);
 }
 :root[data-theme-preset=glass-autumnal][data-theme=dark] {
     color-scheme: dark;
     --background-color: transparent;
-    --gloss-image-background-color: rgba(59, 37, 24, 0.56);
     --text-color: #f6ddd0;
     --reason-text-color: #ddb6a0;
     --headword-furigana-text-color: #ddb6a0;
     --headword-reading-text-color: #ddb6a0;
-    --light-border-color: rgba(255, 209, 179, 0.12);
-    --medium-border-color: rgba(255, 209, 179, 0.18);
-    --dark-border-color: rgba(255, 209, 179, 0.28);
-    --sidebar-background-color: rgba(41, 24, 16, 0.32);
-    --scrollbar-thumb-color: rgba(255, 209, 179, 0.22);
-    --scrollbar-track-color: rgba(0, 0, 0, 0.08);
-    --notification-text-color: #f6ddd0;
-    --notification-background-color: rgba(66, 39, 27, 0.54);
-    --notification-background-color-light: rgba(82, 50, 36, 0.64);
-    --notification-background-color-lighter: rgba(100, 61, 43, 0.78);
-    --notification-shadow-color: rgba(0, 0, 0, 0.32);
-    --background-color-light: rgba(255, 209, 179, 0.08);
-    --background-color-dark1: rgba(255, 209, 179, 0.04);
     --text-color-light2: #ddb6a0;
-    --text-color-light3: #cca088;
-    --text-color-light4: #b98a72;
-    --input-background-color: rgba(54, 32, 22, 0.34);
-    --input-background-color-dark: rgba(71, 42, 29, 0.46);
-    --input-background-color-darker: rgba(88, 53, 37, 0.58);
-    --glass-panel-background: rgba(47, 28, 20, 0.38);
-    --glass-panel-background-strong: rgba(63, 37, 26, 0.56);
-    --glass-panel-border-color: rgba(255, 209, 179, 0.12);
-    --glass-panel-shadow: 0 24px 48px rgba(0, 0, 0, 0.32);
-    --glass-page-background: radial-gradient(circle at top left, rgba(146, 92, 57, 0.42), rgba(63, 37, 26, 0.82) 40%, rgba(23, 14, 10, 0.96) 100%);
+    --glass-subtext-color: #ddb6a0;
+    --glass-panel-background: rgba(63, 37, 26, 0.85);
+    --glass-panel-background-strong: rgba(63, 37, 26, 0.85);
+    --glass-panel-border-color: rgba(255, 221, 196, 0.2);
 }
 :root[data-theme-preset=glass-tokyo-night] {
     color-scheme: dark;
     --background-color: transparent;
-    --gloss-image-background-color: rgba(39, 46, 74, 0.54);
     --text-color: #c0caf5;
     --reason-text-color: #9aa5ce;
     --headword-furigana-text-color: #9aa5ce;
     --headword-reading-text-color: #9aa5ce;
-    --light-border-color: rgba(192, 202, 245, 0.12);
-    --medium-border-color: rgba(192, 202, 245, 0.18);
-    --dark-border-color: rgba(192, 202, 245, 0.26);
-    --sidebar-background-color: rgba(26, 27, 38, 0.32);
-    --scrollbar-thumb-color: rgba(192, 202, 245, 0.2);
-    --scrollbar-track-color: rgba(0, 0, 0, 0.08);
-    --notification-text-color: #c0caf5;
-    --notification-background-color: rgba(36, 40, 59, 0.56);
-    --notification-background-color-light: rgba(52, 58, 84, 0.68);
-    --notification-background-color-lighter: rgba(68, 76, 110, 0.8);
-    --notification-shadow-color: rgba(0, 0, 0, 0.34);
-    --background-color-light: rgba(192, 202, 245, 0.08);
-    --background-color-dark1: rgba(192, 202, 245, 0.04);
     --text-color-light2: #9aa5ce;
-    --text-color-light3: #7aa2f7;
-    --text-color-light4: #7dcfff;
-    --input-background-color: rgba(36, 40, 59, 0.36);
-    --input-background-color-dark: rgba(49, 54, 82, 0.48);
-    --input-background-color-darker: rgba(63, 70, 104, 0.62);
-    --glass-panel-background: rgba(26, 27, 38, 0.4);
-    --glass-panel-background-strong: rgba(36, 40, 59, 0.58);
-    --glass-panel-border-color: rgba(192, 202, 245, 0.12);
-    --glass-panel-shadow: 0 24px 48px rgba(0, 0, 0, 0.34);
-    --glass-page-background: radial-gradient(circle at top left, rgba(122, 162, 247, 0.28), rgba(26, 27, 38, 0.84) 42%, rgba(17, 19, 28, 0.98) 100%);
+    --glass-subtext-color: #9aa5ce;
+    --glass-panel-background: rgba(36, 40, 59, 0.85);
+    --glass-panel-background-strong: rgba(36, 40, 59, 0.85);
+    --glass-panel-border-color: rgba(192, 202, 245, 0.2);
 }
 
 
@@ -438,6 +338,10 @@
 }
 body {
     overflow: hidden;
+}
+:root[data-theme-preset^=glass] body {
+    background: transparent;
+    color: var(--text-color);
 }
 @supports (-moz-appearance: none) {
     :root[data-theme-preset^=glass] ruby>* {
@@ -620,41 +524,42 @@ a:has(rt) {
 :root[data-theme-preset^=glass] html::-webkit-scrollbar {
     display: none;
 }
-:root[data-theme-preset^=glass] .search-header-wrapper {
+:root[data-theme-preset^=glass] .headword-term,
+:root[data-theme-preset^=glass] .headword-term * {
+    color: var(--text-color);
+}
+:root[data-theme-preset^=glass] .headword-term>ruby>rt {
+    color: var(--glass-subtext-color);
+}
+:root:is([data-page-type=search], [data-page-type=popupPreview])[data-theme-preset^=glass] .search-header-wrapper {
     background-color: transparent;
 }
-:root[data-theme-preset^=glass] .search-header,
-:root[data-theme-preset^=glass] #query-parser-container,
-:root[data-theme-preset^=glass] .entry,
-:root[data-theme-preset^=glass] .content-sidebar,
-:root[data-theme-preset^=glass] .content-footer {
+:root:is([data-page-type=search], [data-page-type=popupPreview])[data-theme-preset^=glass] .search-header,
+:root:is([data-page-type=search], [data-page-type=popupPreview])[data-theme-preset^=glass] #query-parser-container,
+:root:is([data-page-type=search], [data-page-type=popupPreview])[data-theme-preset^=glass] .entry,
+:root:is([data-page-type=search], [data-page-type=popupPreview])[data-theme-preset^=glass] .content-sidebar,
+:root:is([data-page-type=search], [data-page-type=popupPreview])[data-theme-preset^=glass] .content-footer {
     background: var(--glass-panel-background);
     border: 1px solid var(--glass-panel-border-color);
-    box-shadow: var(--glass-panel-shadow);
-    backdrop-filter: blur(16px);
-    -webkit-backdrop-filter: blur(16px);
+    box-shadow: none;
+    backdrop-filter: blur(1px);
+    -webkit-backdrop-filter: blur(1px);
 }
-:root[data-theme-preset^=glass] .search-header,
-:root[data-theme-preset^=glass] .content-sidebar {
-    border-radius: 18px;
+:root:is([data-page-type=search], [data-page-type=popupPreview])[data-theme-preset^=glass] .search-header,
+:root:is([data-page-type=search], [data-page-type=popupPreview])[data-theme-preset^=glass] #query-parser-container,
+:root:is([data-page-type=search], [data-page-type=popupPreview])[data-theme-preset^=glass] .entry,
+:root:is([data-page-type=search], [data-page-type=popupPreview])[data-theme-preset^=glass] .content-sidebar,
+:root:is([data-page-type=search], [data-page-type=popupPreview])[data-theme-preset^=glass] .content-footer {
+    border-radius: 12px;
 }
-:root[data-theme-preset^=glass] #query-parser-container,
-:root[data-theme-preset^=glass] .entry,
-:root[data-theme-preset^=glass] .content-footer {
-    border-radius: 16px;
-}
-:root[data-theme-preset^=glass] .entry {
-    background: var(--glass-panel-background-strong);
-}
-:root[data-theme-preset^=glass] .entry+.entry {
+:root:is([data-page-type=search], [data-page-type=popupPreview])[data-theme-preset^=glass] .entry+.entry {
     margin-top: 0.75em;
     border-top: none;
 }
-:root[data-theme-preset^=glass] #query-parser-container {
+:root:is([data-page-type=search], [data-page-type=popupPreview])[data-theme-preset^=glass] #query-parser-container {
     margin-top: 0.5em;
-    border-bottom: 1px solid var(--glass-panel-border-color);
 }
-:root[data-theme-preset^=glass] .content-footer {
+:root:is([data-page-type=search], [data-page-type=popupPreview])[data-theme-preset^=glass] .content-footer {
     margin-bottom: 0.5em;
 }
 

--- a/ext/css/display.css
+++ b/ext/css/display.css
@@ -180,6 +180,12 @@
 
     --action-button-hover-color: #dddddd;
     --action-button-active-color: #c1c1c1;
+
+    --glass-panel-background: transparent;
+    --glass-panel-background-strong: transparent;
+    --glass-panel-border-color: transparent;
+    --glass-panel-shadow: none;
+    --glass-page-background: transparent;
 }
 :root[data-theme=dark] {
     /* Colors */
@@ -250,6 +256,173 @@
     --action-button-active-color: #444444;
 }
 
+/* Adapted from https://github.com/cakiya/yomitan-glass-theme */
+:root[data-theme-preset=glass][data-theme=light] {
+    color-scheme: light;
+    --background-color: transparent;
+    --gloss-image-background-color: rgba(255, 255, 255, 0.16);
+    --text-color: #202020;
+    --reason-text-color: #535353;
+    --headword-furigana-text-color: #535353;
+    --headword-reading-text-color: #535353;
+    --light-border-color: rgba(255, 255, 255, 0.26);
+    --medium-border-color: rgba(255, 255, 255, 0.2);
+    --dark-border-color: rgba(104, 118, 138, 0.38);
+    --sidebar-background-color: rgba(255, 255, 255, 0.12);
+    --scrollbar-thumb-color: rgba(0, 0, 0, 0.28);
+    --scrollbar-track-color: rgba(255, 255, 255, 0.08);
+    --notification-text-color: #202020;
+    --notification-background-color: rgba(255, 255, 255, 0.2);
+    --notification-background-color-light: rgba(255, 255, 255, 0.26);
+    --notification-background-color-lighter: rgba(255, 255, 255, 0.32);
+    --notification-shadow-color: rgba(23, 32, 51, 0.15);
+    --background-color-light: rgba(255, 255, 255, 0.22);
+    --background-color-dark1: rgba(255, 255, 255, 0.08);
+    --text-color-light2: #535353;
+    --text-color-light3: #60656f;
+    --text-color-light4: #737983;
+    --input-background-color: rgba(255, 255, 255, 0.18);
+    --input-background-color-dark: rgba(255, 255, 255, 0.24);
+    --input-background-color-darker: rgba(255, 255, 255, 0.3);
+    --glass-panel-background: rgba(255, 255, 255, 0.12);
+    --glass-panel-background-strong: rgba(255, 255, 255, 0.22);
+    --glass-panel-border-color: rgba(255, 255, 255, 0.24);
+    --glass-panel-shadow: 0 18px 40px rgba(28, 39, 59, 0.14);
+    --glass-page-background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.85), rgba(228, 237, 255, 0.5) 32%, rgba(201, 217, 242, 0.32) 65%, rgba(189, 203, 224, 0.14) 100%);
+}
+:root[data-theme-preset=glass][data-theme=dark] {
+    color-scheme: dark;
+    --background-color: transparent;
+    --gloss-image-background-color: rgba(32, 37, 48, 0.52);
+    --text-color: #dfdfdf;
+    --reason-text-color: #acacac;
+    --headword-furigana-text-color: #acacac;
+    --headword-reading-text-color: #acacac;
+    --light-border-color: rgba(255, 255, 255, 0.12);
+    --medium-border-color: rgba(255, 255, 255, 0.16);
+    --dark-border-color: rgba(255, 255, 255, 0.24);
+    --sidebar-background-color: rgba(20, 24, 33, 0.3);
+    --scrollbar-thumb-color: rgba(255, 255, 255, 0.18);
+    --scrollbar-track-color: rgba(0, 0, 0, 0.08);
+    --notification-text-color: #dfdfdf;
+    --notification-background-color: rgba(27, 31, 43, 0.56);
+    --notification-background-color-light: rgba(37, 42, 58, 0.68);
+    --notification-background-color-lighter: rgba(46, 52, 72, 0.82);
+    --notification-shadow-color: rgba(0, 0, 0, 0.35);
+    --background-color-light: rgba(255, 255, 255, 0.08);
+    --background-color-dark1: rgba(255, 255, 255, 0.04);
+    --text-color-light2: #acacac;
+    --text-color-light3: #9ba3ae;
+    --text-color-light4: #88909b;
+    --input-background-color: rgba(20, 24, 33, 0.32);
+    --input-background-color-dark: rgba(30, 35, 46, 0.44);
+    --input-background-color-darker: rgba(38, 44, 58, 0.56);
+    --glass-panel-background: rgba(18, 22, 31, 0.36);
+    --glass-panel-background-strong: rgba(24, 29, 40, 0.54);
+    --glass-panel-border-color: rgba(255, 255, 255, 0.12);
+    --glass-panel-shadow: 0 24px 48px rgba(0, 0, 0, 0.3);
+    --glass-page-background: radial-gradient(circle at top left, rgba(76, 95, 128, 0.46), rgba(29, 34, 48, 0.82) 38%, rgba(16, 18, 25, 0.96) 100%);
+}
+:root[data-theme-preset=glass-autumnal][data-theme=light] {
+    color-scheme: light;
+    --background-color: transparent;
+    --gloss-image-background-color: rgba(255, 243, 232, 0.26);
+    --text-color: #3f2516;
+    --reason-text-color: #7a5541;
+    --headword-furigana-text-color: #8a6047;
+    --headword-reading-text-color: #8a6047;
+    --light-border-color: rgba(255, 243, 232, 0.34);
+    --medium-border-color: rgba(224, 180, 145, 0.28);
+    --dark-border-color: rgba(168, 103, 60, 0.34);
+    --sidebar-background-color: rgba(255, 237, 221, 0.16);
+    --scrollbar-thumb-color: rgba(122, 85, 65, 0.34);
+    --scrollbar-track-color: rgba(255, 245, 236, 0.12);
+    --notification-text-color: #3f2516;
+    --notification-background-color: rgba(255, 241, 229, 0.2);
+    --notification-background-color-light: rgba(255, 241, 229, 0.26);
+    --notification-background-color-lighter: rgba(255, 241, 229, 0.34);
+    --notification-shadow-color: rgba(101, 59, 27, 0.16);
+    --background-color-light: rgba(255, 243, 232, 0.2);
+    --background-color-dark1: rgba(255, 226, 196, 0.14);
+    --text-color-light2: #7a5541;
+    --text-color-light3: #8a6047;
+    --text-color-light4: #9d7156;
+    --input-background-color: rgba(255, 240, 225, 0.22);
+    --input-background-color-dark: rgba(249, 220, 195, 0.3);
+    --input-background-color-darker: rgba(240, 198, 166, 0.4);
+    --glass-panel-background: rgba(255, 238, 222, 0.14);
+    --glass-panel-background-strong: rgba(255, 233, 214, 0.26);
+    --glass-panel-border-color: rgba(255, 244, 232, 0.3);
+    --glass-panel-shadow: 0 18px 40px rgba(114, 67, 33, 0.14);
+    --glass-page-background: radial-gradient(circle at top left, rgba(255, 235, 210, 0.92), rgba(236, 197, 160, 0.54) 34%, rgba(195, 132, 80, 0.24) 100%);
+}
+:root[data-theme-preset=glass-autumnal][data-theme=dark] {
+    color-scheme: dark;
+    --background-color: transparent;
+    --gloss-image-background-color: rgba(59, 37, 24, 0.56);
+    --text-color: #f6ddd0;
+    --reason-text-color: #ddb6a0;
+    --headword-furigana-text-color: #ddb6a0;
+    --headword-reading-text-color: #ddb6a0;
+    --light-border-color: rgba(255, 209, 179, 0.12);
+    --medium-border-color: rgba(255, 209, 179, 0.18);
+    --dark-border-color: rgba(255, 209, 179, 0.28);
+    --sidebar-background-color: rgba(41, 24, 16, 0.32);
+    --scrollbar-thumb-color: rgba(255, 209, 179, 0.22);
+    --scrollbar-track-color: rgba(0, 0, 0, 0.08);
+    --notification-text-color: #f6ddd0;
+    --notification-background-color: rgba(66, 39, 27, 0.54);
+    --notification-background-color-light: rgba(82, 50, 36, 0.64);
+    --notification-background-color-lighter: rgba(100, 61, 43, 0.78);
+    --notification-shadow-color: rgba(0, 0, 0, 0.32);
+    --background-color-light: rgba(255, 209, 179, 0.08);
+    --background-color-dark1: rgba(255, 209, 179, 0.04);
+    --text-color-light2: #ddb6a0;
+    --text-color-light3: #cca088;
+    --text-color-light4: #b98a72;
+    --input-background-color: rgba(54, 32, 22, 0.34);
+    --input-background-color-dark: rgba(71, 42, 29, 0.46);
+    --input-background-color-darker: rgba(88, 53, 37, 0.58);
+    --glass-panel-background: rgba(47, 28, 20, 0.38);
+    --glass-panel-background-strong: rgba(63, 37, 26, 0.56);
+    --glass-panel-border-color: rgba(255, 209, 179, 0.12);
+    --glass-panel-shadow: 0 24px 48px rgba(0, 0, 0, 0.32);
+    --glass-page-background: radial-gradient(circle at top left, rgba(146, 92, 57, 0.42), rgba(63, 37, 26, 0.82) 40%, rgba(23, 14, 10, 0.96) 100%);
+}
+:root[data-theme-preset=glass-tokyo-night] {
+    color-scheme: dark;
+    --background-color: transparent;
+    --gloss-image-background-color: rgba(39, 46, 74, 0.54);
+    --text-color: #c0caf5;
+    --reason-text-color: #9aa5ce;
+    --headword-furigana-text-color: #9aa5ce;
+    --headword-reading-text-color: #9aa5ce;
+    --light-border-color: rgba(192, 202, 245, 0.12);
+    --medium-border-color: rgba(192, 202, 245, 0.18);
+    --dark-border-color: rgba(192, 202, 245, 0.26);
+    --sidebar-background-color: rgba(26, 27, 38, 0.32);
+    --scrollbar-thumb-color: rgba(192, 202, 245, 0.2);
+    --scrollbar-track-color: rgba(0, 0, 0, 0.08);
+    --notification-text-color: #c0caf5;
+    --notification-background-color: rgba(36, 40, 59, 0.56);
+    --notification-background-color-light: rgba(52, 58, 84, 0.68);
+    --notification-background-color-lighter: rgba(68, 76, 110, 0.8);
+    --notification-shadow-color: rgba(0, 0, 0, 0.34);
+    --background-color-light: rgba(192, 202, 245, 0.08);
+    --background-color-dark1: rgba(192, 202, 245, 0.04);
+    --text-color-light2: #9aa5ce;
+    --text-color-light3: #7aa2f7;
+    --text-color-light4: #7dcfff;
+    --input-background-color: rgba(36, 40, 59, 0.36);
+    --input-background-color-dark: rgba(49, 54, 82, 0.48);
+    --input-background-color-darker: rgba(63, 70, 104, 0.62);
+    --glass-panel-background: rgba(26, 27, 38, 0.4);
+    --glass-panel-background-strong: rgba(36, 40, 59, 0.58);
+    --glass-panel-border-color: rgba(192, 202, 245, 0.12);
+    --glass-panel-shadow: 0 24px 48px rgba(0, 0, 0, 0.34);
+    --glass-page-background: radial-gradient(circle at top left, rgba(122, 162, 247, 0.28), rgba(26, 27, 38, 0.84) 42%, rgba(17, 19, 28, 0.98) 100%);
+}
+
 
 /* Fonts */
 @font-face {
@@ -265,6 +438,12 @@
 }
 body {
     overflow: hidden;
+}
+@supports (-moz-appearance: none) {
+    :root[data-theme-preset^=glass] ruby>* {
+        margin-top: -3px;
+        margin-bottom: -10px;
+    }
 }
 ol, ul {
     margin-top: 0;
@@ -425,6 +604,58 @@ a:has(rt) {
 }
 .contain-overscroll {
     overscroll-behavior: contain;
+}
+:root[data-theme-preset^=glass] .content-scroll,
+:root[data-theme-preset^=glass] .scrollbar,
+:root[data-theme-preset^=glass] .content-sidebar,
+:root[data-theme-preset^=glass] body,
+:root[data-theme-preset^=glass] html {
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+}
+:root[data-theme-preset^=glass] .content-scroll::-webkit-scrollbar,
+:root[data-theme-preset^=glass] .scrollbar::-webkit-scrollbar,
+:root[data-theme-preset^=glass] .content-sidebar::-webkit-scrollbar,
+:root[data-theme-preset^=glass] body::-webkit-scrollbar,
+:root[data-theme-preset^=glass] html::-webkit-scrollbar {
+    display: none;
+}
+:root[data-theme-preset^=glass] .search-header-wrapper {
+    background-color: transparent;
+}
+:root[data-theme-preset^=glass] .search-header,
+:root[data-theme-preset^=glass] #query-parser-container,
+:root[data-theme-preset^=glass] .entry,
+:root[data-theme-preset^=glass] .content-sidebar,
+:root[data-theme-preset^=glass] .content-footer {
+    background: var(--glass-panel-background);
+    border: 1px solid var(--glass-panel-border-color);
+    box-shadow: var(--glass-panel-shadow);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+}
+:root[data-theme-preset^=glass] .search-header,
+:root[data-theme-preset^=glass] .content-sidebar {
+    border-radius: 18px;
+}
+:root[data-theme-preset^=glass] #query-parser-container,
+:root[data-theme-preset^=glass] .entry,
+:root[data-theme-preset^=glass] .content-footer {
+    border-radius: 16px;
+}
+:root[data-theme-preset^=glass] .entry {
+    background: var(--glass-panel-background-strong);
+}
+:root[data-theme-preset^=glass] .entry+.entry {
+    margin-top: 0.75em;
+    border-top: none;
+}
+:root[data-theme-preset^=glass] #query-parser-container {
+    margin-top: 0.5em;
+    border-bottom: 1px solid var(--glass-panel-border-color);
+}
+:root[data-theme-preset^=glass] .content-footer {
+    margin-bottom: 0.5em;
 }
 
 

--- a/ext/css/popup-outer.css
+++ b/ext/css/popup-outer.css
@@ -40,18 +40,18 @@ iframe.yomitan-popup[data-theme-preset=glass][data-theme=dark] {
 }
 iframe.yomitan-popup[data-theme-preset=glass-autumnal][data-theme=light] {
     color-scheme: light;
-    --outer-bg: rgba(243, 219, 198, 0.84);
+    --outer-bg: rgba(243, 219, 198, 0.85);
     --outer-border: rgba(116, 68, 39, 0.2);
 }
 iframe.yomitan-popup[data-theme-preset=glass-autumnal][data-theme=dark] {
     color-scheme: dark;
-    --outer-bg: rgba(63, 37, 26, 0.86);
-    --outer-border: rgba(255, 221, 196, 0.18);
+    --outer-bg: rgba(63, 37, 26, 0.85);
+    --outer-border: rgba(255, 221, 196, 0.2);
 }
 iframe.yomitan-popup[data-theme-preset=glass-tokyo-night] {
     color-scheme: dark;
-    --outer-bg: rgba(36, 40, 59, 0.86);
-    --outer-border: rgba(192, 202, 245, 0.18);
+    --outer-bg: rgba(36, 40, 59, 0.85);
+    --outer-border: rgba(192, 202, 245, 0.2);
 }
 iframe.yomitan-popup[data-theme=dark] {
     background-color: #1e1e1e;

--- a/ext/css/popup-outer.css
+++ b/ext/css/popup-outer.css
@@ -28,14 +28,51 @@ iframe.yomitan-popup {
     z-index: 2147483647;
     box-sizing: border-box;
 }
+iframe.yomitan-popup[data-theme-preset=glass][data-theme=light] {
+    color-scheme: light;
+    --outer-bg: rgba(210, 210, 215, 0.85);
+    --outer-border: rgba(0, 0, 0, 0.2);
+}
+iframe.yomitan-popup[data-theme-preset=glass][data-theme=dark] {
+    color-scheme: dark;
+    --outer-bg: rgba(45, 45, 50, 0.85);
+    --outer-border: rgba(255, 255, 255, 0.2);
+}
+iframe.yomitan-popup[data-theme-preset=glass-autumnal][data-theme=light] {
+    color-scheme: light;
+    --outer-bg: rgba(243, 219, 198, 0.84);
+    --outer-border: rgba(116, 68, 39, 0.2);
+}
+iframe.yomitan-popup[data-theme-preset=glass-autumnal][data-theme=dark] {
+    color-scheme: dark;
+    --outer-bg: rgba(63, 37, 26, 0.86);
+    --outer-border: rgba(255, 221, 196, 0.18);
+}
+iframe.yomitan-popup[data-theme-preset=glass-tokyo-night] {
+    color-scheme: dark;
+    --outer-bg: rgba(36, 40, 59, 0.86);
+    --outer-border: rgba(192, 202, 245, 0.18);
+}
 iframe.yomitan-popup[data-theme=dark] {
     background-color: #1e1e1e;
     border-color: #666666;
+}
+iframe.yomitan-popup[data-theme-preset^=glass] {
+    background: var(--outer-bg);
+    backdrop-filter: blur(1px);
+    -webkit-backdrop-filter: blur(1px);
+    border-radius: 12px;
+    border: 1px solid var(--outer-border);
+    scrollbar-width: none;
+    -ms-overflow-style: none;
 }
 iframe.yomitan-popup[data-outer-theme=dark] {
     box-shadow: 0 0 10em rgba(255, 255, 255, 0.5);
 }
 iframe.yomitan-popup[data-outer-theme=none] {
+    box-shadow: none;
+}
+iframe.yomitan-popup[data-theme-preset^=glass][data-outer-theme=none] {
     box-shadow: none;
 }
 iframe.yomitan-popup[data-popup-display-mode=full-width] {

--- a/ext/css/popup-preview.css
+++ b/ext/css/popup-preview.css
@@ -26,6 +26,7 @@
     --animation-duration: 0s;
 
     --example-text-color: #333333;
+    --example-border-color: #dddddd;
     --background-color: rgba(0, 0, 0, 0);
 }
 :root[data-loaded=true] {
@@ -34,7 +35,33 @@
 
 :root[data-theme=dark] {
     --example-text-color: #d4d4d4;
+    --example-border-color: rgba(255, 255, 255, 0.2);
     --background-color: rgba(0, 0, 0, 0);
+}
+:root[data-theme-preset=glass][data-theme=light] {
+    --example-text-color: #202020;
+    --example-border-color: rgba(255, 255, 255, 0.3);
+    --background-color: radial-gradient(circle at top left, rgba(255, 255, 255, 0.82), rgba(224, 234, 252, 0.56) 40%, rgba(188, 203, 227, 0.18) 100%);
+}
+:root[data-theme-preset=glass][data-theme=dark] {
+    --example-text-color: #dfdfdf;
+    --example-border-color: rgba(255, 255, 255, 0.16);
+    --background-color: radial-gradient(circle at top left, rgba(76, 95, 128, 0.42), rgba(29, 34, 48, 0.82) 38%, rgba(16, 18, 25, 0.98) 100%);
+}
+:root[data-theme-preset=glass-autumnal][data-theme=light] {
+    --example-text-color: #3f2516;
+    --example-border-color: rgba(255, 244, 232, 0.34);
+    --background-color: radial-gradient(circle at top left, rgba(255, 235, 210, 0.94), rgba(236, 197, 160, 0.54) 36%, rgba(195, 132, 80, 0.2) 100%);
+}
+:root[data-theme-preset=glass-autumnal][data-theme=dark] {
+    --example-text-color: #f6ddd0;
+    --example-border-color: rgba(255, 209, 179, 0.16);
+    --background-color: radial-gradient(circle at top left, rgba(146, 92, 57, 0.42), rgba(63, 37, 26, 0.82) 40%, rgba(23, 14, 10, 0.98) 100%);
+}
+:root[data-theme-preset=glass-tokyo-night] {
+    --example-text-color: #c0caf5;
+    --example-border-color: rgba(192, 202, 245, 0.16);
+    --background-color: radial-gradient(circle at top left, rgba(122, 162, 247, 0.26), rgba(26, 27, 38, 0.84) 42%, rgba(17, 19, 28, 0.98) 100%);
 }
 
 
@@ -105,7 +132,7 @@ body {
 }
 .example-text:hover,
 .example-text-input {
-    border-color: #dddddd;
+    border-color: var(--example-border-color);
 }
 .example-text[hidden] {
     display: none;
@@ -129,6 +156,10 @@ body {
     border: 1px solid rgba(0, 0, 0, 0);
     flex-flow: column nowrap;
     justify-content: center;
+}
+:root[data-theme-preset^=glass] .content-body,
+:root[data-theme-preset^=glass] .popup-placeholder {
+    border-radius: 16px;
 }
 .placeholder-info {
     flex: 0 1 auto;

--- a/ext/css/popup-preview.css
+++ b/ext/css/popup-preview.css
@@ -40,28 +40,38 @@
 }
 :root[data-theme-preset=glass][data-theme=light] {
     --example-text-color: #202020;
-    --example-border-color: rgba(255, 255, 255, 0.3);
-    --background-color: radial-gradient(circle at top left, rgba(255, 255, 255, 0.82), rgba(224, 234, 252, 0.56) 40%, rgba(188, 203, 227, 0.18) 100%);
+    --example-border-color: rgba(0, 0, 0, 0.2);
+    --background-color: rgba(210, 210, 215, 0.2);
+    --preview-panel-background: rgba(210, 210, 215, 0.85);
+    --preview-panel-border: rgba(0, 0, 0, 0.2);
 }
 :root[data-theme-preset=glass][data-theme=dark] {
     --example-text-color: #dfdfdf;
-    --example-border-color: rgba(255, 255, 255, 0.16);
-    --background-color: radial-gradient(circle at top left, rgba(76, 95, 128, 0.42), rgba(29, 34, 48, 0.82) 38%, rgba(16, 18, 25, 0.98) 100%);
+    --example-border-color: rgba(255, 255, 255, 0.2);
+    --background-color: rgba(45, 45, 50, 0.2);
+    --preview-panel-background: rgba(45, 45, 50, 0.85);
+    --preview-panel-border: rgba(255, 255, 255, 0.2);
 }
 :root[data-theme-preset=glass-autumnal][data-theme=light] {
     --example-text-color: #3f2516;
-    --example-border-color: rgba(255, 244, 232, 0.34);
-    --background-color: radial-gradient(circle at top left, rgba(255, 235, 210, 0.94), rgba(236, 197, 160, 0.54) 36%, rgba(195, 132, 80, 0.2) 100%);
+    --example-border-color: rgba(116, 68, 39, 0.2);
+    --background-color: rgba(243, 219, 198, 0.2);
+    --preview-panel-background: rgba(243, 219, 198, 0.85);
+    --preview-panel-border: rgba(116, 68, 39, 0.2);
 }
 :root[data-theme-preset=glass-autumnal][data-theme=dark] {
     --example-text-color: #f6ddd0;
-    --example-border-color: rgba(255, 209, 179, 0.16);
-    --background-color: radial-gradient(circle at top left, rgba(146, 92, 57, 0.42), rgba(63, 37, 26, 0.82) 40%, rgba(23, 14, 10, 0.98) 100%);
+    --example-border-color: rgba(255, 221, 196, 0.2);
+    --background-color: rgba(63, 37, 26, 0.2);
+    --preview-panel-background: rgba(63, 37, 26, 0.85);
+    --preview-panel-border: rgba(255, 221, 196, 0.2);
 }
 :root[data-theme-preset=glass-tokyo-night] {
     --example-text-color: #c0caf5;
-    --example-border-color: rgba(192, 202, 245, 0.16);
-    --background-color: radial-gradient(circle at top left, rgba(122, 162, 247, 0.26), rgba(26, 27, 38, 0.84) 42%, rgba(17, 19, 28, 0.98) 100%);
+    --example-border-color: rgba(192, 202, 245, 0.2);
+    --background-color: rgba(36, 40, 59, 0.2);
+    --preview-panel-background: rgba(36, 40, 59, 0.85);
+    --preview-panel-border: rgba(192, 202, 245, 0.2);
 }
 
 
@@ -159,7 +169,11 @@ body {
 }
 :root[data-theme-preset^=glass] .content-body,
 :root[data-theme-preset^=glass] .popup-placeholder {
-    border-radius: 16px;
+    background: var(--preview-panel-background);
+    border: 1px solid var(--preview-panel-border);
+    border-radius: 12px;
+    backdrop-filter: blur(1px);
+    -webkit-backdrop-filter: blur(1px);
 }
 .placeholder-info {
     flex: 0 1 auto;

--- a/ext/css/search.css
+++ b/ext/css/search.css
@@ -58,7 +58,7 @@ body {
     overflow: hidden;
 }
 :root[data-theme-preset^=glass] body {
-    background: var(--glass-page-background);
+    background: transparent;
 }
 .search-header {
     padding-left: var(--search-scroll-container-horizontal-padding);
@@ -225,7 +225,11 @@ h1 {
 :root[data-theme-preset^=glass] #search-textbox,
 :root[data-theme-preset^=glass] .search-button,
 :root[data-theme-preset^=glass] .clear-button {
-    border-radius: 14px;
+    background: var(--glass-panel-background);
+    border: 1px solid var(--glass-panel-border-color);
+    border-radius: 12px;
+    backdrop-filter: blur(1px);
+    -webkit-backdrop-filter: blur(1px);
 }
 :root[data-theme-preset^=glass] .search-textbox-container {
     gap: 0.35em;

--- a/ext/css/search.css
+++ b/ext/css/search.css
@@ -40,6 +40,10 @@
 :root[data-theme=dark] {
     --separator-color1: #333333;
 }
+:root[data-theme-preset^=glass] {
+    --background-color: transparent;
+    --separator-color1: transparent;
+}
 
 /* Common styles */
 :root {
@@ -52,6 +56,9 @@ body {
     color: var(--text-color);
     height: 100%;
     overflow: hidden;
+}
+:root[data-theme-preset^=glass] body {
+    background: var(--glass-page-background);
 }
 .search-header {
     padding-left: var(--search-scroll-container-horizontal-padding);
@@ -214,6 +221,14 @@ h1 {
 }
 .search-option:not([hidden]) {
     display: flex;
+}
+:root[data-theme-preset^=glass] #search-textbox,
+:root[data-theme-preset^=glass] .search-button,
+:root[data-theme-preset^=glass] .clear-button {
+    border-radius: 14px;
+}
+:root[data-theme-preset^=glass] .search-textbox-container {
+    gap: 0.35em;
 }
 .search-option-label {
     padding-left: 0.5em;

--- a/ext/css/settings.css
+++ b/ext/css/settings.css
@@ -701,6 +701,24 @@ a.settings-item.settings-item-button {
 .settings-item-group.settings-item-group-wrap {
     flex-wrap: wrap;
 }
+.popup-appearance-right {
+    max-height: none;
+}
+.popup-appearance-group {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+    gap: 0.75em;
+}
+.popup-appearance-group .settings-item-group-item {
+    padding-right: 0;
+}
+.popup-appearance-group .settings-item-group-item-label {
+    margin-bottom: 0.25em;
+    white-space: nowrap;
+}
+.popup-appearance-group .appearance-select-width {
+    width: min(10.75em, var(--input-short-width));
+}
 .settings-item-group-item {
     flex: 0 1 auto;
     padding-right: var(--padding);
@@ -725,6 +743,11 @@ select.short-height {
     height: var(--input-short-height);
     margin-top: calc(var(--settings-group-right-max-height) - var(--input-short-height) - var(--font-size-small));
     line-height: var(--line-height);
+}
+@media (max-width: 820px) {
+    .popup-appearance-right {
+        width: 100%;
+    }
 }
 .settings-item-button-group-container {
     max-height: none;

--- a/ext/css/structured-content.css
+++ b/ext/css/structured-content.css
@@ -233,6 +233,11 @@
     padding: 0.25em;
     vertical-align: top;
 }
+:root[data-theme-preset^=glass] .gloss-sc-thead,
+:root[data-theme-preset^=glass] .gloss-sc-tfoot,
+:root[data-theme-preset^=glass] .gloss-sc-th {
+    background-color: transparent;
+}
 .gloss-sc-ol,
 .gloss-sc-ul {
     padding-left: var(--list-padding2);

--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -106,6 +106,7 @@
                                     "glossaryLayoutMode",
                                     "mainDictionary",
                                     "popupTheme",
+                                    "popupThemePreset",
                                     "popupOuterTheme",
                                     "customPopupCss",
                                     "customPopupOuterCss",
@@ -260,7 +261,12 @@
                                     "popupTheme": {
                                         "type": "string",
                                         "enum": ["light", "dark", "browser", "site"],
-                                        "default": "site"
+                                        "default": "browser"
+                                    },
+                                    "popupThemePreset": {
+                                        "type": "string",
+                                        "enum": ["default", "glass", "glass-autumnal", "glass-tokyo-night"],
+                                        "default": "default"
                                     },
                                     "popupOuterTheme": {
                                         "type": "string",

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -1105,6 +1105,7 @@ export class Popup extends EventDispatcher {
         const options = await this._application.api.optionsGet(optionsContext);
         const {general, scanning} = options;
         this._themeController.theme = general.popupTheme;
+        this._themeController.themePreset = general.popupThemePreset;
         this._themeController.outerTheme = general.popupOuterTheme;
         this._themeController.siteOverride = checkPopupPreviewURL(optionsContext.url);
         if (this._themeController.outerTheme === 'site' && this._themeController.siteOverride && ['dark', 'light'].includes(this._themeController.theme)) {

--- a/ext/js/app/theme-controller.js
+++ b/ext/js/app/theme-controller.js
@@ -28,7 +28,9 @@ export class ThemeController {
         /** @type {?HTMLElement} */
         this._element = element;
         /** @type {import("settings.js").PopupTheme} */
-        this._theme = 'site';
+        this._theme = 'browser';
+        /** @type {import("settings.js").PopupThemePreset} */
+        this._themePreset = 'default';
         /** @type {import("settings.js").PopupOuterTheme} */
         this._outerTheme = 'site';
         /** @type {?('dark'|'light')} */
@@ -69,6 +71,22 @@ export class ThemeController {
      */
     set theme(value) {
         this._theme = value;
+    }
+
+    /**
+     * Gets the visual preset for the content.
+     * @type {import("settings.js").PopupThemePreset}
+     */
+    get themePreset() {
+        return this._themePreset;
+    }
+
+    /**
+     * Sets the visual preset for the content.
+     * @param {import("settings.js").PopupThemePreset} value The preset value to assign.
+     */
+    set themePreset(value) {
+        this._themePreset = value;
     }
 
     /**
@@ -131,11 +149,12 @@ export class ThemeController {
         if (this._element === null) { return; }
         const computedSiteTheme = this._siteTheme !== null ? this._siteTheme : this.computeSiteTheme();
         const data = this._element.dataset;
-        data.theme = this._resolveThemeValue(this._theme, computedSiteTheme);
+        data.theme = this._resolveThemePresetValue(this._resolveThemeValue(this._theme, computedSiteTheme), this._themePreset);
         data.outerTheme = this._resolveThemeValue(this._outerTheme, computedSiteTheme);
         data.siteTheme = computedSiteTheme;
         data.browserTheme = this._browserTheme;
         data.themeRaw = this._theme;
+        data.themePreset = this._themePreset;
         data.outerThemeRaw = this._outerTheme;
     }
 
@@ -176,6 +195,21 @@ export class ThemeController {
             case 'site': return this.siteOverride ? this._browserTheme : computedSiteTheme;
             case 'browser': return this._browserTheme;
             default: return theme;
+        }
+    }
+
+    /**
+     * Resolves a theme preset to the actual base theme value which should be used.
+     * @param {string} theme The resolved base theme value.
+     * @param {import("settings.js").PopupThemePreset} themePreset The theme preset value.
+     * @returns {string} The resolved theme value after applying preset-specific constraints.
+     */
+    _resolveThemePresetValue(theme, themePreset) {
+        switch (themePreset) {
+            case 'glass-tokyo-night':
+                return 'dark';
+            default:
+                return theme;
         }
     }
 

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -314,6 +314,7 @@ export class OptionsUtil {
                 compactGlossaries: false,
                 mainDictionary: '',
                 popupTheme: 'default',
+                popupThemePreset: 'default',
                 popupOuterTheme: 'default',
                 customPopupCss: '',
                 customPopupOuterCss: '',
@@ -589,6 +590,7 @@ export class OptionsUtil {
             this._updateVersion75,
             this._updateVersion76,
             this._updateVersion77,
+            this._updateVersion78,
         ];
         /* eslint-enable @typescript-eslint/unbound-method */
         if (typeof targetVersion === 'number' && targetVersion < result.length) {
@@ -1872,6 +1874,21 @@ export class OptionsUtil {
             general.popupBlurByFrequencyThreshold = 10000;
             general.popupBlurByFrequencyOrder = 'descending';
             general.popupBlurByFrequencyUnblurDelay = 0;
+        }
+    }
+
+    /**
+     *  - Added general.popupThemePreset
+     *  - Migrated general.popupTheme='site' to 'browser'
+     *  @type {import('options-util').UpdateFunction}
+     */
+    async _updateVersion78(options) {
+        for (const profile of options.profiles) {
+            const {general} = profile.options;
+            general.popupThemePreset = 'default';
+            if (general.popupTheme === 'site') {
+                general.popupTheme = 'browser';
+            }
         }
     }
 

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -1278,7 +1278,7 @@ export class Display extends EventDispatcher {
      */
     _setTheme(options) {
         const {general} = options;
-        const {popupTheme, popupOuterTheme, fontFamily, fontSize, lineHeight} = general;
+        const {popupTheme, popupThemePreset, popupOuterTheme, fontFamily, fontSize, lineHeight} = general;
         /** @type {string} */
         let pageType = this._pageType;
         try {
@@ -1295,6 +1295,7 @@ export class Display extends EventDispatcher {
             log.error(e);
         }
         this._themeController.theme = popupTheme;
+        this._themeController.themePreset = popupThemePreset;
         this._themeController.outerTheme = popupOuterTheme;
         this._themeController.siteOverride = pageType === 'search' || pageType === 'popupPreview';
         this._themeController.updateTheme();

--- a/ext/js/pages/action-popup-main.js
+++ b/ext/js/pages/action-popup-main.js
@@ -243,6 +243,7 @@ class DisplayController {
         void this._updatePermissionsWarnings(options);
 
         this._themeController.theme = options.general.popupTheme;
+        this._themeController.themePreset = options.general.popupThemePreset;
         this._themeController.siteOverride = true;
         this._themeController.updateTheme();
     }

--- a/ext/js/pages/generic-page-main.js
+++ b/ext/js/pages/generic-page-main.js
@@ -33,6 +33,7 @@ await Application.main(true, async (application) => {
     const defaultProfile = (profileCurrent >= 0 && profileCurrent < profiles.length) ? profiles[profileCurrent] : null;
     if (defaultProfile !== null) {
         themeController.theme = defaultProfile.options.general.popupTheme;
+        themeController.themePreset = defaultProfile.options.general.popupThemePreset;
         themeController.siteOverride = true;
         themeController.updateTheme();
     }

--- a/ext/js/pages/info-main.js
+++ b/ext/js/pages/info-main.js
@@ -128,6 +128,7 @@ await Application.main(true, async (application) => {
     const defaultProfile = (profileCurrent >= 0 && profileCurrent < profiles.length) ? profiles[profileCurrent] : null;
     if (defaultProfile !== null) {
         themeController.theme = defaultProfile.options.general.popupTheme;
+        themeController.themePreset = defaultProfile.options.general.popupThemePreset;
         themeController.siteOverride = true;
         themeController.updateTheme();
     }

--- a/ext/js/pages/settings/backup-controller.js
+++ b/ext/js/pages/settings/backup-controller.js
@@ -669,6 +669,7 @@ export class BackupController {
 
         // Update display theme
         this._themeController.theme = optionsFull.profiles[optionsFull.profileCurrent].options.general.popupTheme;
+        this._themeController.themePreset = optionsFull.profiles[optionsFull.profileCurrent].options.general.popupThemePreset;
         this._themeController.prepare();
         this._themeController.siteOverride = true;
         this._themeController.updateTheme();

--- a/ext/js/pages/settings/popup-preview-controller.js
+++ b/ext/js/pages/settings/popup-preview-controller.js
@@ -105,6 +105,7 @@ export class PopupPreviewController {
      * @param {import('settings-controller').EventArgument<'optionsChanged'>} details
      */
     _onOptionsChanged({options}) {
+        this._onOptionsContextChange();
         this._invoke('setLanguageExampleText', {language: options.general.language});
     }
 

--- a/ext/js/pages/settings/popup-preview-frame.js
+++ b/ext/js/pages/settings/popup-preview-frame.js
@@ -143,6 +143,7 @@ export class PopupPreviewFrame {
         options.general.popupVerticalTextPosition = 'before';
         options.scanning.selectText = false;
         this._themeController.theme = options.general.popupTheme;
+        this._themeController.themePreset = options.general.popupThemePreset;
         this._themeController.siteOverride = true;
         this._themeController.updateTheme();
         return options;

--- a/ext/js/pages/settings/settings-display-controller.js
+++ b/ext/js/pages/settings/settings-display-controller.js
@@ -44,6 +44,8 @@ export class SettingsDisplayController {
         this._themeController = new ThemeController(document.documentElement);
         /** @type {HTMLSelectElement | null}*/
         this._themeDropdown = document.querySelector('[data-setting="general.popupTheme"]');
+        /** @type {HTMLSelectElement | null}*/
+        this._themePresetDropdown = document.querySelector('[data-setting="general.popupThemePreset"]');
     }
 
     /** */
@@ -94,16 +96,21 @@ export class SettingsDisplayController {
         if (this._themeDropdown) {
             this._themeDropdown.addEventListener('change', this._updateTheme.bind(this), false);
         }
+        if (this._themePresetDropdown) {
+            this._themePresetDropdown.addEventListener('change', this._updateTheme.bind(this), false);
+        }
     }
 
     /** */
     async _setTheme() {
         const preparedOptions = this._settingsController.getPreparedProfileOptions();
-        this._themeController.theme = (
+        const options = (
             preparedOptions !== null ?
-                preparedOptions.general.popupTheme :
-                (await this._settingsController.getOptions()).general.popupTheme
+                preparedOptions :
+                await this._settingsController.getOptions()
         );
+        this._themeController.theme = options.general.popupTheme;
+        this._themeController.themePreset = options.general.popupThemePreset;
         this._themeController.siteOverride = true;
         this._themeController.updateTheme();
     }
@@ -111,8 +118,12 @@ export class SettingsDisplayController {
     /** */
     async _updateTheme() {
         const theme = this._themeDropdown?.value;
-        if (theme === 'site' || theme === 'light' || theme === 'dark' || theme === 'browser') {
+        if (theme === 'light' || theme === 'dark' || theme === 'browser') {
             this._themeController.theme = theme;
+        }
+        const themePreset = this._themePresetDropdown?.value;
+        if (themePreset === 'default' || themePreset === 'glass' || themePreset === 'glass-autumnal' || themePreset === 'glass-tokyo-night') {
+            this._themeController.themePreset = themePreset;
         }
         this._themeController.siteOverride = true;
         this._themeController.updateTheme();

--- a/ext/js/pages/support-main.js
+++ b/ext/js/pages/support-main.js
@@ -31,6 +31,7 @@ await Application.main(true, async (application) => {
     const defaultProfile = (profileCurrent >= 0 && profileCurrent < profiles.length) ? profiles[profileCurrent] : null;
     if (defaultProfile !== null) {
         themeController.theme = defaultProfile.options.general.popupTheme;
+        themeController.themePreset = defaultProfile.options.general.popupThemePreset;
         themeController.siteOverride = true;
         themeController.updateTheme();
     }

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -875,18 +875,26 @@
     <div class="settings-group">
         <div class="settings-item"><div class="settings-item-inner settings-item-inner-wrappable">
             <div class="settings-item-left">
-                <div class="settings-item-label">Theme</div>
+                <div class="settings-item-label">Appearance</div>
                 <div class="settings-item-description">Adjust the style of Manabitan.</div>
             </div>
             <div class="settings-item-right">
                 <div class="settings-item-group">
                     <div class="settings-item-group-item">
-                        <div class="settings-item-group-item-label">Body</div>
+                        <div class="settings-item-group-item-label">Mode</div>
                         <select data-setting="general.popupTheme" class="short-width short-height">
-                            <option value="site">Auto</option>
+                            <option value="browser">System</option>
                             <option value="light">Light</option>
                             <option value="dark">Dark</option>
-                            <option value="browser">Browser</option>
+                        </select>
+                    </div>
+                    <div class="settings-item-group-item">
+                        <div class="settings-item-group-item-label">Theme</div>
+                        <select data-setting="general.popupThemePreset" class="short-width short-height">
+                            <option value="default">Default</option>
+                            <option value="glass">Glass</option>
+                            <option value="glass-autumnal">Autumnal (Glass)</option>
+                            <option value="glass-tokyo-night">Tokyo Night (Glass)</option>
                         </select>
                     </div>
                     <div class="settings-item-group-item">

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -876,13 +876,13 @@
         <div class="settings-item"><div class="settings-item-inner settings-item-inner-wrappable">
             <div class="settings-item-left">
                 <div class="settings-item-label">Appearance</div>
-                <div class="settings-item-description">Adjust the style of Manabitan.</div>
+                <div class="settings-item-description">Pick the popup mode, theme, and shadow.</div>
             </div>
-            <div class="settings-item-right">
-                <div class="settings-item-group">
+            <div class="settings-item-right popup-appearance-right">
+                <div class="settings-item-group popup-appearance-group">
                     <div class="settings-item-group-item">
                         <div class="settings-item-group-item-label">Mode</div>
-                        <select data-setting="general.popupTheme" class="short-width short-height">
+                        <select data-setting="general.popupTheme" class="short-height appearance-select-width">
                             <option value="browser">System</option>
                             <option value="light">Light</option>
                             <option value="dark">Dark</option>
@@ -890,7 +890,7 @@
                     </div>
                     <div class="settings-item-group-item">
                         <div class="settings-item-group-item-label">Theme</div>
-                        <select data-setting="general.popupThemePreset" class="short-width short-height">
+                        <select data-setting="general.popupThemePreset" class="short-height appearance-select-width">
                             <option value="default">Default</option>
                             <option value="glass">Glass</option>
                             <option value="glass-autumnal">Autumnal (Glass)</option>
@@ -899,7 +899,7 @@
                     </div>
                     <div class="settings-item-group-item">
                         <div class="settings-item-group-item-label">Shadow</div>
-                        <select data-setting="general.popupOuterTheme" class="short-width short-height">
+                        <select data-setting="general.popupOuterTheme" class="short-height appearance-select-width">
                             <option value="site">Auto</option>
                             <option value="light">Light</option>
                             <option value="dark">Dark</option>

--- a/ext/welcome.html
+++ b/ext/welcome.html
@@ -180,13 +180,13 @@
         <div class="settings-item"><div class="settings-item-inner settings-item-inner-wrappable">
             <div class="settings-item-left">
                 <div class="settings-item-label">Appearance</div>
-                <div class="settings-item-description">Adjust the style of Manabitan.</div>
+                <div class="settings-item-description">Pick the popup mode and theme.</div>
             </div>
-            <div class="settings-item-right">
-                <div class="settings-item-group">
+            <div class="settings-item-right popup-appearance-right">
+                <div class="settings-item-group popup-appearance-group">
                     <div class="settings-item-group-item">
                         <div class="settings-item-group-item-label">Mode</div>
-                        <select data-setting="general.popupTheme" class="short-width">
+                        <select data-setting="general.popupTheme" class="appearance-select-width">
                             <option value="browser">System</option>
                             <option value="light">Light</option>
                             <option value="dark">Dark</option>
@@ -194,7 +194,7 @@
                     </div>
                     <div class="settings-item-group-item">
                         <div class="settings-item-group-item-label">Theme</div>
-                        <select data-setting="general.popupThemePreset" class="short-width">
+                        <select data-setting="general.popupThemePreset" class="appearance-select-width">
                             <option value="default">Default</option>
                             <option value="glass">Glass</option>
                             <option value="glass-autumnal">Autumnal (Glass)</option>

--- a/ext/welcome.html
+++ b/ext/welcome.html
@@ -179,16 +179,29 @@
         </div></div>
         <div class="settings-item"><div class="settings-item-inner settings-item-inner-wrappable">
             <div class="settings-item-left">
-                <div class="settings-item-label">Theme</div>
+                <div class="settings-item-label">Appearance</div>
                 <div class="settings-item-description">Adjust the style of Manabitan.</div>
             </div>
             <div class="settings-item-right">
-                <select data-setting="general.popupTheme" class="short-width">
-                    <option value="site">Auto</option>
-                    <option value="light">Light</option>
-                    <option value="dark">Dark</option>
-                    <option value="browser">Browser</option>
-                </select>
+                <div class="settings-item-group">
+                    <div class="settings-item-group-item">
+                        <div class="settings-item-group-item-label">Mode</div>
+                        <select data-setting="general.popupTheme" class="short-width">
+                            <option value="browser">System</option>
+                            <option value="light">Light</option>
+                            <option value="dark">Dark</option>
+                        </select>
+                    </div>
+                    <div class="settings-item-group-item">
+                        <div class="settings-item-group-item-label">Theme</div>
+                        <select data-setting="general.popupThemePreset" class="short-width">
+                            <option value="default">Default</option>
+                            <option value="glass">Glass</option>
+                            <option value="glass-autumnal">Autumnal (Glass)</option>
+                            <option value="glass-tokyo-night">Tokyo Night (Glass)</option>
+                        </select>
+                    </div>
+                </div>
             </div>
         </div></div>
         <a href="/settings.html" rel="noopener" class="settings-item settings-item-button"><div class="settings-item-inner">

--- a/test/options-util.test.js
+++ b/test/options-util.test.js
@@ -294,6 +294,7 @@ function createProfileOptionsUpdatedTestData1() {
             glossaryLayoutMode: 'default',
             mainDictionary: '',
             popupTheme: 'light',
+            popupThemePreset: 'default',
             popupOuterTheme: 'light',
             customPopupCss: '',
             customPopupOuterCss: '',
@@ -711,7 +712,7 @@ function createOptionsUpdatedTestData1() {
             },
         ],
         profileCurrent: 0,
-        version: 77,
+        version: 78,
         global: {
             database: {
                 prefixWildcardsSupported: false,
@@ -778,35 +779,29 @@ describe('OptionsUtil', () => {
         delete options.global.database.maxHeadwordLength;
 
         const optionsUpdated = structuredClone(await optionsUtil.update(options));
-        expect(optionsUpdated.version).toBe(77);
+        expect(optionsUpdated.version).toBe(78);
         expect(optionsUpdated.global.dictionaryAutoUpdates).toStrictEqual([]);
         expect(optionsUpdated.global.database.maxHeadwordLength).toBe(0);
     });
 
-    test('PopupFrequencyBlurVersion77MigrationUsesDefaultsAndStaysDecoupled', async () => {
+    test('PopupFrequencyBlurAndThemePresetVersion78MigrationUsesDefaultsAndStaysDecoupled', async () => {
         const optionsUtil = new OptionsUtil();
         await optionsUtil.prepare();
 
         const options = /** @type {import('settings').Options} */ (structuredClone(createOptionsUpdatedTestData1()));
-        options.version = 76;
+        options.version = 77;
         const general = /** @type {import('core').SafeAny} */ (options.profiles[0].options.general);
         general.sortFrequencyDictionary = 'Sort Dictionary';
         general.sortFrequencyDictionaryOrder = 'ascending';
-        delete general.popupBlurByFrequencyEnabled;
-        delete general.popupBlurByFrequencyDictionary;
-        delete general.popupBlurByFrequencyThreshold;
-        delete general.popupBlurByFrequencyOrder;
-        delete general.popupBlurByFrequencyUnblurDelay;
+        general.popupTheme = 'site';
+        delete general.popupThemePreset;
 
         const optionsUpdated = structuredClone(await optionsUtil.update(options));
         const defaultGeneral = optionsUtil.getDefault().profiles[0].options.general;
-        expect(optionsUpdated.version).toBe(77);
+        expect(optionsUpdated.version).toBe(78);
         expect(optionsUpdated.profiles[0].options.general).toMatchObject({
-            popupBlurByFrequencyEnabled: defaultGeneral.popupBlurByFrequencyEnabled,
-            popupBlurByFrequencyDictionary: defaultGeneral.popupBlurByFrequencyDictionary,
-            popupBlurByFrequencyThreshold: defaultGeneral.popupBlurByFrequencyThreshold,
-            popupBlurByFrequencyOrder: defaultGeneral.popupBlurByFrequencyOrder,
-            popupBlurByFrequencyUnblurDelay: defaultGeneral.popupBlurByFrequencyUnblurDelay,
+            popupTheme: 'browser',
+            popupThemePreset: defaultGeneral.popupThemePreset,
             sortFrequencyDictionary: 'Sort Dictionary',
             sortFrequencyDictionaryOrder: 'ascending',
         });

--- a/test/settings-ui.test.js
+++ b/test/settings-ui.test.js
@@ -40,4 +40,28 @@ describe('Settings UI scan length exposure', () => {
             expect(hasScanLengthSetting).toBe(false);
         }
     });
+
+    test('settings page renders separate mode, theme, and shadow controls', () => {
+        const html = fs.readFileSync(path.join(dirname, '..', 'ext', 'settings.html'), {encoding: 'utf8'});
+
+        expect(html).toContain('data-setting="general.popupTheme"');
+        expect(html).toContain('data-setting="general.popupThemePreset"');
+        expect(html).toContain('data-setting="general.popupOuterTheme"');
+        expect(html).toContain('<option value="browser">System</option>');
+        expect(html).toContain('<option value="default">Default</option>');
+        expect(html).toContain('<option value="glass">Glass</option>');
+        expect(html).toContain('<option value="glass-autumnal">Autumnal (Glass)</option>');
+        expect(html).toContain('<option value="glass-tokyo-night">Tokyo Night (Glass)</option>');
+    });
+
+    test('welcome page renders separate mode and theme controls', () => {
+        const html = fs.readFileSync(path.join(dirname, '..', 'ext', 'welcome.html'), {encoding: 'utf8'});
+
+        expect(html).toContain('data-setting="general.popupTheme"');
+        expect(html).toContain('data-setting="general.popupThemePreset"');
+        expect(html).toContain('<div class="settings-item-group-item-label">Mode</div>');
+        expect(html).toContain('<div class="settings-item-group-item-label">Theme</div>');
+        expect(html).toContain('<option value="browser">System</option>');
+        expect(html).toContain('<option value="glass-tokyo-night">Tokyo Night (Glass)</option>');
+    });
 });

--- a/test/theme-controller.test.js
+++ b/test/theme-controller.test.js
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2026  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {afterAll, describe, expect, test} from 'vitest';
+import {ThemeController} from '../ext/js/app/theme-controller.js';
+import {setupDomTest} from './fixtures/dom-test.js';
+
+const {window, teardown} = await setupDomTest();
+const {document} = window;
+
+describe('ThemeController', () => {
+    afterAll(() => teardown(global));
+
+    test('system mode follows the browser preference and preserves the selected preset', () => {
+        const controller = new ThemeController(document.documentElement);
+        controller.theme = 'browser';
+        controller.themePreset = 'glass';
+        controller.siteTheme = 'light';
+
+        controller.updateTheme();
+        expect(document.documentElement.dataset.theme).toBe('light');
+        expect(document.documentElement.dataset.themeRaw).toBe('browser');
+        expect(document.documentElement.dataset.themePreset).toBe('glass');
+
+        controller._onPrefersColorSchemeDarkChange({matches: true});
+        expect(document.documentElement.dataset.theme).toBe('dark');
+        expect(document.documentElement.dataset.browserTheme).toBe('dark');
+    });
+
+    test('light and dark modes resolve directly', () => {
+        const controller = new ThemeController(document.documentElement);
+        controller.siteTheme = 'light';
+
+        controller.theme = 'light';
+        controller.updateTheme();
+        expect(document.documentElement.dataset.theme).toBe('light');
+
+        controller.theme = 'dark';
+        controller.updateTheme();
+        expect(document.documentElement.dataset.theme).toBe('dark');
+    });
+
+    test('tokyo night preset forces the resolved theme to dark', () => {
+        const controller = new ThemeController(document.documentElement);
+        controller.theme = 'light';
+        controller.themePreset = 'glass-tokyo-night';
+        controller.siteTheme = 'light';
+
+        controller.updateTheme();
+
+        expect(document.documentElement.dataset.theme).toBe('dark');
+        expect(document.documentElement.dataset.themeRaw).toBe('light');
+        expect(document.documentElement.dataset.themePreset).toBe('glass-tokyo-night');
+    });
+});

--- a/types/ext/settings.d.ts
+++ b/types/ext/settings.d.ts
@@ -135,6 +135,7 @@ export type GeneralOptions = {
     glossaryLayoutMode: GlossaryLayoutMode;
     mainDictionary: string;
     popupTheme: PopupTheme;
+    popupThemePreset: PopupThemePreset;
     popupOuterTheme: PopupOuterTheme;
     customPopupCss: string;
     customPopupOuterCss: string;
@@ -410,6 +411,8 @@ export type PopupVerticalTextPosition = 'default' | 'before' | 'after' | 'left' 
 export type GlossaryLayoutMode = 'default' | 'compact' | 'compact-popup-anki';
 
 export type PopupTheme = 'light' | 'dark' | 'browser' | 'site';
+
+export type PopupThemePreset = 'default' | 'glass' | 'glass-autumnal' | 'glass-tokyo-night';
 
 export type PopupOuterTheme = 'light' | 'dark' | 'browser' | 'site' | 'none';
 


### PR DESCRIPTION
## Summary
- split popup appearance into separate Mode and Theme controls in settings and welcome
- add built-in Glass, Autumnal (Glass), and Tokyo Night (Glass) presets with popup/search/preview styling
- add popup theme preset schema, migration, and controller coverage for the new mode/preset model

## Testing
- npx vitest run test/options-util.test.js test/settings-ui.test.js test/theme-controller.test.js
- npx html-validate ext/settings.html ext/welcome.html
- npx stylelint ext/css/display.css ext/css/display-pronunciation.css ext/css/structured-content.css ext/css/popup-outer.css ext/css/search.css ext/css/popup-preview.css

## Notes
- targeted ESLint could not be completed cleanly because the repo currently has unresolved vendored imports under ext/js/templates/* on this branch state (../../lib/handlebars.js and ../../lib/linkedom.js).