### PR TITLE
Fix real hover lookup latency across the hover, popup, and dictionary pipeline

### DIFF
--- a/benches/hover-lookup.bench.js
+++ b/benches/hover-lookup.bench.js
@@ -1,0 +1,264 @@
+/*
+ * Copyright (C) 2023-2025  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* eslint-disable no-underscore-dangle */
+
+import {fileURLToPath} from 'node:url';
+import path from 'path';
+import {afterAll, bench, describe} from 'vitest';
+import {Backend} from '../ext/js/background/backend.js';
+import {TextSourceRange} from '../ext/js/dom/text-source-range.js';
+import {TextSourceGenerator} from '../ext/js/dom/text-source-generator.js';
+import {TextScanner} from '../ext/js/language/text-scanner.js';
+import {setupDomTest} from '../test/fixtures/dom-test.js';
+import {createTranslatorContext} from '../test/fixtures/translator-test.js';
+import {setupStubs} from '../test/utilities/database.js';
+
+setupStubs();
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const dictionaryName = 'Test Dictionary 2';
+const {translator} = await createTranslatorContext(path.join(dirname, '..', 'test', 'data/dictionaries/valid-dictionary1'), dictionaryName);
+const {window, teardown} = await setupDomTest();
+
+afterAll(async () => {
+    await teardown(global);
+});
+
+const article = window.document.createElement('article');
+for (const [index, term] of ['打ち込む', '画像', '番号', '好き', '自重'].entries()) {
+    const element = window.document.createElement('span');
+    element.dataset.term = `${index + 1}`;
+    element.textContent = term;
+    article.appendChild(element);
+}
+window.document.body.replaceChildren(article);
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const backend = /** @type {Backend} */ (Object.create(Backend.prototype));
+backend._translatorProfileOptionsCache = /** @type {WeakMap<import('settings').ProfileOptions, object>} */ (new WeakMap());
+
+/** @type {import('settings').ProfileOptions} */
+const profileOptions = {
+    general: {
+        mainDictionary: dictionaryName,
+        sortFrequencyDictionary: null,
+        sortFrequencyDictionaryOrder: 'descending',
+        language: 'ja',
+    },
+    scanning: {
+        alphanumeric: false,
+    },
+    translation: {
+        searchResolution: 'letter',
+        textReplacements: {
+            searchOriginal: true,
+            groups: [[
+                {pattern: '\\(([^)]*)(?:\\))', ignoreCase: false, replacement: '$1'},
+            ]],
+        },
+    },
+    dictionaries: [{
+        name: dictionaryName,
+        enabled: true,
+        alias: dictionaryName,
+        allowSecondarySearches: false,
+        partsOfSpeechFilter: true,
+        useDeinflections: true,
+    }],
+};
+
+const searchContext = {
+    optionsContext: {url: 'https://example.com/article'},
+    detail: {documentTitle: 'Hover Lookup Bench'},
+};
+const benchOptions = {
+    time: 75,
+    iterations: 15,
+    warmupTime: 25,
+    warmupIterations: 5,
+};
+
+/**
+ * @param {import('settings').ProfileOptions} options
+ * @returns {Map<string, import('translation').FindTermDictionary>}
+ */
+function createLegacyEnabledDictionaryMap(options) {
+    const enabledDictionaryMap = new Map();
+    for (const dictionary of options.dictionaries) {
+        if (!dictionary.enabled) { continue; }
+        const {name, alias, allowSecondarySearches, partsOfSpeechFilter, useDeinflections} = dictionary;
+        enabledDictionaryMap.set(name, {
+            index: enabledDictionaryMap.size,
+            alias,
+            allowSecondarySearches,
+            partsOfSpeechFilter,
+            useDeinflections,
+        });
+    }
+    return enabledDictionaryMap;
+}
+
+/**
+ * @param {import('settings').TranslationTextReplacementOptions} textReplacementsOptions
+ * @returns {(?(import('translation').FindTermsTextReplacement[]))[]}
+ */
+function createLegacyTextReplacements(textReplacementsOptions) {
+    /** @type {(?(import('translation').FindTermsTextReplacement[]))[]} */
+    const textReplacements = [];
+    for (const group of textReplacementsOptions.groups) {
+        /** @type {import('translation').FindTermsTextReplacement[]} */
+        const textReplacementsEntries = [];
+        for (const {pattern, ignoreCase, replacement} of group) {
+            let patternRegExp;
+            try {
+                patternRegExp = ignoreCase ?
+                    new RegExp(pattern.replace(/['’]/g, "['’]"), 'gi') :
+                    new RegExp(pattern, 'g');
+            } catch (e) {
+                continue;
+            }
+            textReplacementsEntries.push({pattern: patternRegExp, replacement});
+        }
+        if (textReplacementsEntries.length > 0) {
+            textReplacements.push(textReplacementsEntries);
+        }
+    }
+    if (textReplacements.length === 0 || textReplacementsOptions.searchOriginal) {
+        textReplacements.unshift(null);
+    }
+    return textReplacements;
+}
+
+/**
+ * @param {import('api').FindTermsDetails} details
+ * @param {import('settings').ProfileOptions} options
+ * @returns {import('translation').FindTermsOptions}
+ */
+function createLegacyFindTermsOptions(details, options) {
+    let {matchType, deinflect, primaryReading} = details;
+    if (typeof matchType !== 'string') { matchType = /** @type {import('translation').FindTermsMatchType} */ ('exact'); }
+    if (typeof deinflect !== 'boolean') { deinflect = true; }
+    if (typeof primaryReading !== 'string') { primaryReading = ''; }
+    const enabledDictionaryMap = createLegacyEnabledDictionaryMap(options);
+    const {
+        general: {mainDictionary, sortFrequencyDictionary, sortFrequencyDictionaryOrder, language},
+        scanning: {alphanumeric},
+        translation: {
+            textReplacements: textReplacementsOptions,
+            searchResolution,
+        },
+    } = options;
+    return {
+        matchType,
+        deinflect,
+        primaryReading,
+        mainDictionary,
+        sortFrequencyDictionary,
+        sortFrequencyDictionaryOrder,
+        removeNonJapaneseCharacters: !alphanumeric,
+        searchResolution,
+        textReplacements: createLegacyTextReplacements(textReplacementsOptions),
+        enabledDictionaryMap,
+        excludeDictionaryDefinitions: null,
+        language,
+    };
+}
+
+const api = /** @type {import('../ext/js/comm/api.js').API} */ ({
+    async termsFind(text, details) {
+        const findTermsOptions = backend._getTranslatorFindTermsOptions('split', details, profileOptions);
+        return await translator.findTerms('split', text, findTermsOptions);
+    },
+    async kanjiFind(text) {
+        const findKanjiOptions = backend._getTranslatorFindKanjiOptions(profileOptions);
+        return await translator.findKanji(text, findKanjiOptions);
+    },
+    async isTextLookupWorthy() {
+        return true;
+    },
+});
+
+const textScanner = new TextScanner({
+    api,
+    node: window,
+    getSearchContext: () => searchContext,
+    searchTerms: true,
+    searchKanji: true,
+    textSourceGenerator: new TextSourceGenerator(),
+});
+textScanner.language = 'ja';
+textScanner.setOptions({
+    inputs: [],
+    deepContentScan: false,
+    normalizeCssZoom: true,
+    selectText: false,
+    delay: 0,
+    scanLength: 12,
+    layoutAwareScan: false,
+    preventMiddleMouseOnPage: false,
+    preventMiddleMouseOnTextHover: false,
+    preventBackForwardOnPage: false,
+    preventBackForwardOnTextHover: false,
+    sentenceParsingOptions: {
+        scanExtent: 24,
+        terminationCharacterMode: 'newlines',
+        terminationCharacters: [],
+    },
+    scanWithoutMousemove: true,
+    scanResolution: 'character',
+});
+
+const ranges = [...window.document.querySelectorAll('[data-term]')].map((element) => {
+    const node = /** @type {Text} */ (element.firstChild);
+    const range = window.document.createRange();
+    range.setStart(node, 0);
+    range.setEnd(node, 0);
+    return range;
+});
+const terms = [...window.document.querySelectorAll('[data-term]')].map((element) => element.textContent ?? '');
+
+describe('Hover lookup runtime', () => {
+    bench('Legacy Backend._getTranslatorFindTermsOptions', () => {
+        createLegacyFindTermsOptions({}, profileOptions);
+    }, benchOptions);
+
+    bench('Cached Backend._getTranslatorFindTermsOptions', () => {
+        backend._getTranslatorFindTermsOptions('split', {}, profileOptions);
+    }, benchOptions);
+
+    bench('Legacy translator lookup pipeline', async () => {
+        for (const term of terms) {
+            await translator.findTerms('split', term, createLegacyFindTermsOptions({}, profileOptions));
+        }
+    }, benchOptions);
+
+    bench('Cached translator lookup pipeline', async () => {
+        for (const term of terms) {
+            await translator.findTerms('split', term, backend._getTranslatorFindTermsOptions('split', {}, profileOptions));
+        }
+    }, benchOptions);
+
+    bench('TextScanner.search + translator lookup', async () => {
+        for (const range of ranges) {
+            textScanner.clearSelection();
+            await textScanner.search(TextSourceRange.createLazy(range.cloneRange()), null, false);
+        }
+    }, benchOptions);
+});
+
+/* eslint-enable no-underscore-dangle */

--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -17,6 +17,7 @@
  */
 
 import {createApiMap, invokeApiMapHandler} from '../core/api-map.js';
+import {publishDevTimingSnapshot} from '../core/dev-timing-diagnostics.js';
 import {EventListenerCollection} from '../core/event-listener-collection.js';
 import {log} from '../core/log.js';
 import {promiseAnimationFrame} from '../core/promise-animation-frame.js';
@@ -27,6 +28,9 @@ import {TextSourceElement} from '../dom/text-source-element.js';
 import {TextSourceGenerator} from '../dom/text-source-generator.js';
 import {TextSourceRange} from '../dom/text-source-range.js';
 import {TextScanner} from '../language/text-scanner.js';
+
+const HOVER_FRONTEND_DIAGNOSTICS_DATASET_KEY = 'manabitanDevHoverFrontendDiagnostics';
+const HOVER_FRONTEND_DIAGNOSTICS_EVENT = 'hover-frontend-phase-summary';
 
 /**
  * This is the main class responsible for scanning and handling webpage content.
@@ -388,14 +392,14 @@ export class Frontend {
     /**
      * @param {import('text-scanner').EventArgument<'searchSuccess'>} details
      */
-    _onSearchSuccess({type, dictionaryEntries, sentence, inputInfo: {eventType, detail: inputInfoDetail}, textSource, optionsContext, detail, pageTheme}) {
+    _onSearchSuccess({type, dictionaryEntries, dictionaryEntriesJson, dictionaryEntryCount, sentence, inputInfo: {eventType, detail: inputInfoDetail}, textSource, optionsContext, detail, pageTheme}) {
         this._stopClearSelectionDelayed();
         let focus = (eventType === 'mouseMove');
         if (typeof inputInfoDetail === 'object' && inputInfoDetail !== null) {
             const focus2 = inputInfoDetail.focus;
             if (typeof focus2 === 'boolean') { focus = focus2; }
         }
-        this._showContent(textSource, focus, dictionaryEntries, type, sentence, detail !== null ? detail.documentTitle : null, optionsContext, pageTheme);
+        this._showContent(textSource, focus, dictionaryEntries, dictionaryEntriesJson, dictionaryEntryCount, type, sentence, detail !== null ? detail.documentTitle : null, optionsContext, pageTheme);
     }
 
     /** */
@@ -767,13 +771,16 @@ export class Frontend {
      * @param {import('text-source').TextSource} textSource
      * @param {boolean} focus
      * @param {?import('dictionary').DictionaryEntry[]} dictionaryEntries
+     * @param {string|undefined} dictionaryEntriesJson
+     * @param {number|undefined} dictionaryEntryCount
      * @param {import('display').PageType} type
      * @param {?import('display').HistoryStateSentence} sentence
      * @param {?string} documentTitle
      * @param {import('settings').OptionsContext} optionsContext
      * @param {'dark' | 'light'} pageTheme
      */
-    _showContent(textSource, focus, dictionaryEntries, type, sentence, documentTitle, optionsContext, pageTheme) {
+    _showContent(textSource, focus, dictionaryEntries, dictionaryEntriesJson, dictionaryEntryCount, type, sentence, documentTitle, optionsContext, pageTheme) {
+        const buildDisplayDetailsStartedAt = safePerformance.now();
         const query = textSource.text();
         const {url} = optionsContext;
         /** @type {import('display').HistoryState} */
@@ -790,8 +797,14 @@ export class Frontend {
         const detailsContent = {
             contentOrigin: {tabId, frameId},
         };
-        if (dictionaryEntries !== null) {
+        if (dictionaryEntries !== null && (
+            dictionaryEntries.length > 0 ||
+            !(typeof dictionaryEntriesJson === 'string' && dictionaryEntriesJson.length > 0)
+        )) {
             detailsContent.dictionaryEntries = dictionaryEntries;
+        }
+        if (typeof dictionaryEntriesJson === 'string' && dictionaryEntriesJson.length > 0) {
+            detailsContent.dictionaryEntriesJson = dictionaryEntriesJson;
         }
         /** @type {import('display').ContentDetails} */
         const details = {
@@ -801,6 +814,7 @@ export class Frontend {
                 type,
                 query,
                 wildcards: 'off',
+                lookup: 'false',
             },
             state: detailsState,
             content: detailsContent,
@@ -809,20 +823,39 @@ export class Frontend {
             details.params.full = textSource.fullContent;
             details.params['full-visible'] = 'true';
         }
-        void this._showPopupContent(textSource, optionsContext, details);
+        void this._showPopupContent(textSource, optionsContext, details, {
+            focus,
+            type,
+            queryLength: query.length,
+            fullQueryLength: textSource instanceof TextSourceElement ? textSource.fullContent.length : query.length,
+            dictionaryEntryCount: (
+                typeof dictionaryEntryCount === 'number' &&
+                Number.isFinite(dictionaryEntryCount) &&
+                dictionaryEntryCount >= 0
+            ) ?
+                dictionaryEntryCount :
+                (Array.isArray(dictionaryEntries) ? dictionaryEntries.length : 0),
+            deferredSerializedDictionaryEntries: (typeof dictionaryEntriesJson === 'string' && dictionaryEntriesJson.length > 0),
+            buildDisplayDetailsElapsedMs: Math.max(0, safePerformance.now() - buildDisplayDetailsStartedAt),
+        });
     }
 
     /**
      * @param {import('text-source').TextSource} textSource
      * @param {?import('settings').OptionsContext} optionsContext
      * @param {?import('display').ContentDetails} details
+     * @param {Record<string, unknown>} [diagnosticsContext]
      * @returns {Promise<void>}
      */
-    _showPopupContent(textSource, optionsContext, details) {
+    _showPopupContent(textSource, optionsContext, details, diagnosticsContext = {}) {
+        const totalStartedAt = safePerformance.now();
+        const sourceRectsStartedAt = safePerformance.now();
         const sourceRects = [];
         for (const {left, top, right, bottom} of textSource.getRects()) {
             sourceRects.push({left, top, right, bottom});
         }
+        const sourceRectsElapsedMs = Math.max(0, safePerformance.now() - sourceRectsStartedAt);
+        const popupShowStartedAt = safePerformance.now();
         this._lastShowPromise = (
             this._popup !== null ?
             this._popup.showContent(
@@ -834,6 +867,33 @@ export class Frontend {
                 details,
             ) :
             Promise.resolve()
+        );
+        const popupShowDispatchElapsedMs = Math.max(0, safePerformance.now() - popupShowStartedAt);
+        /** @type {(status: string, errorMessage?: string|null) => void} */
+        const publishDiagnostics = (status, errorMessage = null) => {
+            publishDevTimingSnapshot(
+                HOVER_FRONTEND_DIAGNOSTICS_DATASET_KEY,
+                {
+                    ...diagnosticsContext,
+                    status,
+                    errorMessage,
+                    popupPresent: (this._popup !== null),
+                    sourceRectCount: sourceRects.length,
+                    sourceRectsElapsedMs,
+                    popupShowDispatchElapsedMs,
+                    popupShowCompletedElapsedMs: Math.max(0, safePerformance.now() - popupShowStartedAt),
+                    totalElapsedMs: Math.max(0, safePerformance.now() - totalStartedAt),
+                },
+                HOVER_FRONTEND_DIAGNOSTICS_EVENT,
+            );
+        };
+        this._lastShowPromise.then(
+            () => {
+                publishDiagnostics('success');
+            },
+            (error) => {
+                publishDiagnostics('error', error instanceof Error ? error.message : String(error));
+            },
         );
         this._lastShowPromise.catch((error) => {
             if (this._application.webExtension.unloaded) { return; }

--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -543,7 +543,16 @@ export class Frontend {
      */
     async _updateOptionsInternal() {
         const optionsContext = await this._getOptionsContext();
-        const options = await this._application.api.optionsGet(optionsContext);
+        const hoverPage = (this._pageType === 'web');
+        const effectiveHoverScanLengthPromise = (
+            hoverPage ?
+                this._application.api.getEffectiveHoverScanLength(optionsContext).catch(() => null) :
+                Promise.resolve(null)
+        );
+        const [options, effectiveHoverScanLengthRaw] = await Promise.all([
+            this._application.api.optionsGet(optionsContext),
+            effectiveHoverScanLengthPromise,
+        ]);
         const {scanning: scanningOptions, sentenceParsing: sentenceParsingOptions} = options;
         this._options = options;
 
@@ -555,6 +564,36 @@ export class Frontend {
         const preventMiddleMouseOnTextHover = scanningOptions.preventMiddleMouse.onTextHover;
         const preventBackForwardOnPage = this._getPreventSecondaryMouseValueForPageType(scanningOptions.preventBackForward);
         const preventBackForwardOnTextHover = scanningOptions.preventBackForward.onTextHover;
+        const configuredScanLength = (
+            typeof scanningOptions.length === 'number' &&
+            Number.isFinite(scanningOptions.length) &&
+            scanningOptions.length > 0
+        ) ?
+            Math.trunc(scanningOptions.length) :
+            1;
+        let scanLength = scanningOptions.length;
+        /** @type {?{
+         * configuredScanLength: number,
+         * automaticScanLength: number | null,
+         * effectiveScanLength: number,
+         * }} */
+        let hoverScanLengthDiagnostics = null;
+        if (hoverPage) {
+            const effectiveHoverScanLength = (
+                typeof effectiveHoverScanLengthRaw === 'number' &&
+                Number.isFinite(effectiveHoverScanLengthRaw) &&
+                effectiveHoverScanLengthRaw > 0
+            ) ?
+                Math.trunc(effectiveHoverScanLengthRaw) :
+                configuredScanLength;
+            scanLength = effectiveHoverScanLength;
+            hoverScanLengthDiagnostics = {
+                configuredScanLength,
+                automaticScanLength: (effectiveHoverScanLength < configuredScanLength ? effectiveHoverScanLength : null),
+                effectiveScanLength: effectiveHoverScanLength,
+            };
+        }
+
         this._textScanner.language = options.general.language;
         this._textScanner.setOptions({
             inputs: scanningOptions.inputs,
@@ -562,7 +601,8 @@ export class Frontend {
             normalizeCssZoom: scanningOptions.normalizeCssZoom,
             selectText: scanningOptions.selectText,
             delay: scanningOptions.delay,
-            scanLength: scanningOptions.length,
+            scanLength,
+            hoverScanLengthDiagnostics,
             layoutAwareScan: scanningOptions.layoutAwareScan,
             preventMiddleMouseOnPage,
             preventMiddleMouseOnTextHover,
@@ -641,7 +681,7 @@ export class Frontend {
         const optionsContext = await this._getOptionsContext();
         if (this._updatePopupToken !== token) { return; }
         if (popup !== null) {
-            await popup.setOptionsContext(optionsContext);
+            await popup.setOptionsContext(optionsContext, /** @type {import('settings').ProfileOptions} */ (this._options));
         }
         if (this._updatePopupToken !== token) { return; }
 

--- a/ext/js/app/popup-proxy.js
+++ b/ext/js/app/popup-proxy.js
@@ -137,9 +137,10 @@ export class PopupProxy extends EventDispatcher {
     /**
      * Sets the options context for the popup.
      * @param {import('settings').OptionsContext} optionsContext The options context object.
+     * @param {?import('settings').ProfileOptions} [_resolvedOptions=null]
      * @returns {Promise<void>}
      */
-    async setOptionsContext(optionsContext) {
+    async setOptionsContext(optionsContext, _resolvedOptions = null) {
         await this._invokeSafe('popupFactorySetOptionsContext', {id: this._id, optionsContext}, void 0);
     }
 

--- a/ext/js/app/popup-window.js
+++ b/ext/js/app/popup-window.js
@@ -122,9 +122,10 @@ export class PopupWindow extends EventDispatcher {
     /**
      * Sets the options context for the popup.
      * @param {import('settings').OptionsContext} optionsContext The options context object.
+     * @param {?import('settings').ProfileOptions} [_resolvedOptions=null]
      * @returns {Promise<void>}
      */
-    async setOptionsContext(optionsContext) {
+    async setOptionsContext(optionsContext, _resolvedOptions = null) {
         await this._invoke(false, 'displaySetOptionsContext', {optionsContext});
     }
 

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -70,6 +70,10 @@ export class Popup extends EventDispatcher {
         this._visibleValue = false;
         /** @type {?import('settings').OptionsContext} */
         this._optionsContext = null;
+        /** @type {?import('settings').ProfileOptions} */
+        this._options = null;
+        /** @type {boolean} */
+        this._displayResolvedOptionsPending = true;
         /** @type {number} */
         this._contentScale = 1;
         /** @type {string} */
@@ -227,9 +231,10 @@ export class Popup extends EventDispatcher {
     /**
      * Sets the options context for the popup.
      * @param {import('settings').OptionsContext} optionsContext The options context object.
+     * @param {?import('settings').ProfileOptions} [resolvedOptions=null]
      */
-    async setOptionsContext(optionsContext) {
-        await this._setOptionsContext(optionsContext);
+    async setOptionsContext(optionsContext, resolvedOptions = null) {
+        await this._setOptionsContext(optionsContext, resolvedOptions);
         if (this._frameConnected) {
             await this._invokeSafe('displaySetOptionsContext', {optionsContext});
         }
@@ -361,6 +366,7 @@ export class Popup extends EventDispatcher {
         let serializeDisplayDetailsElapsedMs = 0;
         let serializedDictionaryEntries = false;
         let serializedDictionaryEntriesLength = 0;
+        const includeResolvedOptions = (this._displayResolvedOptionsPending && this._options !== null);
         if (displayDetails !== null) {
             const content = Reflect.get(displayDetails, 'content');
             const dictionaryEntriesJson = (
@@ -428,6 +434,8 @@ export class Popup extends EventDispatcher {
                     serializeDisplayDetailsElapsedMs,
                     serializedDictionaryEntries,
                     serializedDictionaryEntriesLength,
+                    includedResolvedOptions: includeResolvedOptions,
+                    includedResolvedOptionsDictionaryCount: includeResolvedOptions ? this._options?.dictionaries.length ?? 0 : 0,
                     displaySetContentCompletedElapsedMs,
                     totalElapsedMs: Math.max(0, safePerformance.now() - totalStartedAt),
                     ...showTimingDiagnostics,
@@ -439,8 +447,14 @@ export class Popup extends EventDispatcher {
         if (displayDetails !== null) {
             safePerformance.mark('invokeDisplaySetContent:start');
             const displaySetContentStartedAt = safePerformance.now();
-            void this._invokeSafe('displaySetContent', {details: /** @type {import('display').ContentDetails} */ (displayDetailsMessage)}).then(
+            void this._invokeSafe('displaySetContent', {
+                details: /** @type {import('display').ContentDetails} */ (displayDetailsMessage),
+                resolvedOptions: includeResolvedOptions ? this._options ?? void 0 : void 0,
+            }).then(
                 () => {
+                    if (includeResolvedOptions) {
+                        this._displayResolvedOptionsPending = false;
+                    }
                     publishDiagnostics('success', null, Math.max(0, safePerformance.now() - displaySetContentStartedAt));
                 },
                 (error) => {
@@ -673,6 +687,7 @@ export class Popup extends EventDispatcher {
         this._frameClient = frameClient;
         await frameClient.connect(this._frame, this._targetOrigin, this._frameId, setupFrame);
         this._frameConnected = true;
+        this._displayResolvedOptionsPending = true;
 
         // Reattach mouse event listeners after frame injection
         const boundMouseOver = this._onFrameMouseOver.bind(this);
@@ -716,6 +731,7 @@ export class Popup extends EventDispatcher {
         this._frameConnected = false;
         this._injectPromise = null;
         this._injectPromiseComplete = false;
+        this._displayResolvedOptionsPending = true;
     }
 
     /**
@@ -1218,10 +1234,19 @@ export class Popup extends EventDispatcher {
 
     /**
      * @param {import('settings').OptionsContext} optionsContext
+     * @param {?import('settings').ProfileOptions} [resolvedOptions=null]
      */
-    async _setOptionsContext(optionsContext) {
+    async _setOptionsContext(optionsContext, resolvedOptions = null) {
         this._optionsContext = optionsContext;
-        const options = await this._application.api.optionsGet(optionsContext);
+        const options = (
+            typeof resolvedOptions === 'object' &&
+            resolvedOptions !== null &&
+            !Array.isArray(resolvedOptions)
+        ) ?
+            /** @type {import('settings').ProfileOptions} */ (resolvedOptions) :
+            await this._application.api.optionsGet(optionsContext);
+        this._options = options;
+        this._displayResolvedOptionsPending = true;
         const {general, scanning} = options;
         this._themeController.theme = general.popupTheme;
         this._themeController.themePreset = general.popupThemePreset;

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -17,6 +17,7 @@
  */
 
 import {FrameClient} from '../comm/frame-client.js';
+import {publishDevTimingSnapshot} from '../core/dev-timing-diagnostics.js';
 import {DynamicProperty} from '../core/dynamic-property.js';
 import {EventDispatcher} from '../core/event-dispatcher.js';
 import {EventListenerCollection} from '../core/event-listener-collection.js';
@@ -27,6 +28,9 @@ import {addFullscreenChangeEventListener, computeZoomScale, convertRectZoomCoord
 import {loadStyle} from '../dom/style-util.js';
 import {checkPopupPreviewURL} from '../pages/settings/popup-preview-controller.js';
 import {ThemeController} from './theme-controller.js';
+
+const POPUP_DIAGNOSTICS_DATASET_KEY = 'manabitanDevPopupDiagnostics';
+const POPUP_DIAGNOSTICS_EVENT = 'popup-show-phase-summary';
 
 /**
  * This class is the container which hosts the display of search results.
@@ -333,19 +337,122 @@ export class Popup extends EventDispatcher {
     async showContent(details, displayDetails) {
         if (this._optionsContext === null) { throw new Error('Options not assigned'); }
 
+        const totalStartedAt = safePerformance.now();
         const {optionsContext, sourceRects, writingMode} = details;
+        const frameConnectedBeforeShow = this._frameConnected;
+        const visibleBeforeShow = this.isVisibleSync();
+        let setOptionsContextElapsedMs = 0;
         if (optionsContext !== null) {
+            const setOptionsContextStartedAt = safePerformance.now();
             await this._setOptionsContextIfDifferent(optionsContext);
+            setOptionsContextElapsedMs = Math.max(0, safePerformance.now() - setOptionsContextStartedAt);
         }
 
         // If there's already a timer running on the same popup from a previous lookup, reset it
         this.stopHideDelayed();
 
-        await this._show(sourceRects, writingMode);
+        /** @type {Record<string, unknown>} */
+        const showTimingDiagnostics = {};
+        const showStartedAt = safePerformance.now();
+        await this._show(sourceRects, writingMode, showTimingDiagnostics);
+        const showElapsedMs = Math.max(0, safePerformance.now() - showStartedAt);
+
+        let displayDetailsMessage = displayDetails;
+        let serializeDisplayDetailsElapsedMs = 0;
+        let serializedDictionaryEntries = false;
+        let serializedDictionaryEntriesLength = 0;
+        if (displayDetails !== null) {
+            const content = Reflect.get(displayDetails, 'content');
+            const dictionaryEntriesJson = (
+                typeof content === 'object' &&
+                content !== null &&
+                !Array.isArray(content) &&
+                typeof Reflect.get(content, 'dictionaryEntriesJson') === 'string'
+            ) ?
+                /** @type {string} */ (Reflect.get(content, 'dictionaryEntriesJson')) :
+                null;
+            if (dictionaryEntriesJson !== null && dictionaryEntriesJson.length > 0) {
+                serializedDictionaryEntries = true;
+                serializedDictionaryEntriesLength = dictionaryEntriesJson.length;
+                displayDetailsMessage = {
+                    ...displayDetails,
+                    content: {
+                        .../** @type {Record<string, unknown>} */ (content),
+                        dictionaryEntries: void 0,
+                        dictionaryEntriesJson,
+                    },
+                };
+            }
+            const dictionaryEntries = (
+                typeof content === 'object' &&
+                content !== null &&
+                !Array.isArray(content) &&
+                Array.isArray(Reflect.get(content, 'dictionaryEntries'))
+            ) ?
+                /** @type {import('dictionary').DictionaryEntry[]} */ (Reflect.get(content, 'dictionaryEntries')) :
+                null;
+            if (dictionaryEntries !== null && dictionaryEntriesJson === null) {
+                const serializeDisplayDetailsStartedAt = safePerformance.now();
+                try {
+                    const dictionaryEntriesJsonNew = JSON.stringify(dictionaryEntries);
+                    serializeDisplayDetailsElapsedMs = Math.max(0, safePerformance.now() - serializeDisplayDetailsStartedAt);
+                    serializedDictionaryEntries = true;
+                    serializedDictionaryEntriesLength = dictionaryEntriesJsonNew.length;
+                    displayDetailsMessage = {
+                        ...displayDetails,
+                        content: {
+                            .../** @type {Record<string, unknown>} */ (content),
+                            dictionaryEntries: void 0,
+                            dictionaryEntriesJson: dictionaryEntriesJsonNew,
+                        },
+                    };
+                } catch (_) {
+                    serializeDisplayDetailsElapsedMs = Math.max(0, safePerformance.now() - serializeDisplayDetailsStartedAt);
+                }
+            }
+        }
+
+        /** @type {(status: string, errorMessage?: string|null, displaySetContentCompletedElapsedMs?: number|null) => void} */
+        const publishDiagnostics = (status, errorMessage = null, displaySetContentCompletedElapsedMs = null) => {
+            publishDevTimingSnapshot(
+                POPUP_DIAGNOSTICS_DATASET_KEY,
+                {
+                    status,
+                    errorMessage,
+                    frameConnectedBeforeShow,
+                    visibleBeforeShow,
+                    displayDetailsProvided: (displayDetails !== null),
+                    sourceRectCount: sourceRects.length,
+                    setOptionsContextElapsedMs,
+                    showElapsedMs,
+                    serializeDisplayDetailsElapsedMs,
+                    serializedDictionaryEntries,
+                    serializedDictionaryEntriesLength,
+                    displaySetContentCompletedElapsedMs,
+                    totalElapsedMs: Math.max(0, safePerformance.now() - totalStartedAt),
+                    ...showTimingDiagnostics,
+                },
+                POPUP_DIAGNOSTICS_EVENT,
+            );
+        };
 
         if (displayDetails !== null) {
             safePerformance.mark('invokeDisplaySetContent:start');
-            void this._invokeSafe('displaySetContent', {details: displayDetails});
+            const displaySetContentStartedAt = safePerformance.now();
+            void this._invokeSafe('displaySetContent', {details: /** @type {import('display').ContentDetails} */ (displayDetailsMessage)}).then(
+                () => {
+                    publishDiagnostics('success', null, Math.max(0, safePerformance.now() - displaySetContentStartedAt));
+                },
+                (error) => {
+                    publishDiagnostics(
+                        'error',
+                        error instanceof Error ? error.message : String(error),
+                        Math.max(0, safePerformance.now() - displaySetContentStartedAt),
+                    );
+                },
+            );
+        } else {
+            publishDiagnostics('success');
         }
     }
 
@@ -699,13 +806,25 @@ export class Popup extends EventDispatcher {
     /**
      * @param {import('popup').Rect[]} sourceRects
      * @param {import('document-util').NormalizedWritingMode} writingMode
+     * @param {?Record<string, unknown>} [showTimingDiagnostics]
      */
-    async _show(sourceRects, writingMode) {
+    async _show(sourceRects, writingMode, showTimingDiagnostics = null) {
+        const injectStartedAt = safePerformance.now();
         const injected = await this._inject();
+        if (showTimingDiagnostics !== null) {
+            showTimingDiagnostics.injectElapsedMs = Math.max(0, safePerformance.now() - injectStartedAt);
+            showTimingDiagnostics.injected = injected;
+        }
         if (!injected) { return; }
 
+        const positionStartedAt = safePerformance.now();
         const viewport = this._getViewport(this._scaleRelativeToVisualViewport);
         let {left, top, width, height, after, below} = this._getPosition(sourceRects, writingMode, viewport);
+        if (showTimingDiagnostics !== null) {
+            showTimingDiagnostics.positionElapsedMs = Math.max(0, safePerformance.now() - positionStartedAt);
+            showTimingDiagnostics.popupWidth = width;
+            showTimingDiagnostics.popupHeight = height;
+        }
 
         if (this._displayModeIsFullWidth) {
             left = viewport.left;

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -252,6 +252,8 @@ export class Backend {
         this._permissions = null;
         /** @type {Map<string, (() => void)[]>} */
         this._applicationReadyHandlers = new Map();
+        /** @type {WeakMap<import('settings').ProfileOptions, object>} */
+        this._translatorProfileOptionsCache = new WeakMap();
 
         /* eslint-disable @stylistic/no-multi-spaces */
         /** @type {import('api').ApiMap} */
@@ -2224,6 +2226,7 @@ export class Backend {
     _applyOptions(source) {
         const options = this._getProfileOptions({current: true}, false);
         this._updateBadge();
+        this._clearTranslatorProfileOptionsCache();
 
         const enabled = options.general.enable;
 
@@ -2505,6 +2508,13 @@ export class Backend {
      */
     _clearProfileConditionsSchemaCache() {
         this._profileConditionsSchemaCache = [];
+    }
+
+    /**
+     * @returns {void}
+     */
+    _clearTranslatorProfileOptionsCache() {
+        this._translatorProfileOptionsCache = new WeakMap();
     }
 
     /**
@@ -5038,27 +5048,35 @@ export class Backend {
         if (typeof matchType !== 'string') { matchType = /** @type {import('translation').FindTermsMatchType} */ ('exact'); }
         if (typeof deinflect !== 'boolean') { deinflect = true; }
         if (typeof primaryReading !== 'string') { primaryReading = ''; }
-        const enabledDictionaryMap = this._getTranslatorEnabledDictionaryMap(options);
-        const {
-            general: {mainDictionary, sortFrequencyDictionary, sortFrequencyDictionaryOrder, language},
-            scanning: {alphanumeric},
-            translation: {
-                textReplacements: textReplacementsOptions,
-                searchResolution,
-            },
-        } = options;
-        const textReplacements = this._getTranslatorTextReplacements(textReplacementsOptions);
+        const cachedOptions = this._getTranslatorProfileOptionsCache(options);
+        let {
+            enabledDictionaryMap,
+            mainDictionary,
+            sortFrequencyDictionary,
+            sortFrequencyDictionaryOrder,
+            removeNonJapaneseCharacters,
+            searchResolution,
+            textReplacements,
+            language,
+        } = cachedOptions;
         let excludeDictionaryDefinitions = null;
         if (mode === 'merge' && !enabledDictionaryMap.has(mainDictionary)) {
-            enabledDictionaryMap.set(mainDictionary, {
-                index: enabledDictionaryMap.size,
-                alias: mainDictionary,
-                allowSecondarySearches: false,
-                partsOfSpeechFilter: true,
-                useDeinflections: true,
-            });
-            excludeDictionaryDefinitions = new Set();
-            excludeDictionaryDefinitions.add(mainDictionary);
+            let {mergeEnabledDictionaryMap, mergeExcludeDictionaryDefinitions} = cachedOptions;
+            if (typeof mergeEnabledDictionaryMap === 'undefined') {
+                mergeEnabledDictionaryMap = new Map(enabledDictionaryMap);
+                mergeEnabledDictionaryMap.set(mainDictionary, {
+                    index: mergeEnabledDictionaryMap.size,
+                    alias: mainDictionary,
+                    allowSecondarySearches: false,
+                    partsOfSpeechFilter: true,
+                    useDeinflections: true,
+                });
+                mergeExcludeDictionaryDefinitions = new Set([mainDictionary]);
+                cachedOptions.mergeEnabledDictionaryMap = mergeEnabledDictionaryMap;
+                cachedOptions.mergeExcludeDictionaryDefinitions = mergeExcludeDictionaryDefinitions;
+            }
+            enabledDictionaryMap = mergeEnabledDictionaryMap;
+            excludeDictionaryDefinitions = mergeExcludeDictionaryDefinitions ?? null;
         }
         return {
             matchType,
@@ -5067,7 +5085,7 @@ export class Backend {
             mainDictionary,
             sortFrequencyDictionary,
             sortFrequencyDictionaryOrder,
-            removeNonJapaneseCharacters: !alphanumeric,
+            removeNonJapaneseCharacters,
             searchResolution,
             textReplacements,
             enabledDictionaryMap,
@@ -5082,11 +5100,55 @@ export class Backend {
      * @returns {import('translation').FindKanjiOptions} An options object.
      */
     _getTranslatorFindKanjiOptions(options) {
-        const enabledDictionaryMap = this._getTranslatorEnabledDictionaryMap(options);
+        const {enabledDictionaryMap, removeNonJapaneseCharacters} = this._getTranslatorProfileOptionsCache(options);
         return {
             enabledDictionaryMap,
-            removeNonJapaneseCharacters: !options.scanning.alphanumeric,
+            removeNonJapaneseCharacters,
         };
+    }
+
+    /**
+     * @param {import('settings').ProfileOptions} options
+     * @returns {{
+     *     enabledDictionaryMap: Map<string, import('translation').FindTermDictionary>,
+     *     mergeEnabledDictionaryMap?: Map<string, import('translation').FindTermDictionary>,
+     *     mergeExcludeDictionaryDefinitions?: Set<string>,
+     *     mainDictionary: string,
+     *     sortFrequencyDictionary: string | null,
+     *     sortFrequencyDictionaryOrder: import('settings').SortFrequencyDictionaryOrder,
+     *     removeNonJapaneseCharacters: boolean,
+     *     searchResolution: import('settings').SearchResolution,
+     *     textReplacements: (?(import('translation').FindTermsTextReplacement[]))[],
+     *     language: string,
+     * }}
+     */
+    _getTranslatorProfileOptionsCache(options) {
+        let cache = this._translatorProfileOptionsCache.get(options);
+        if (typeof cache !== 'undefined') {
+            return cache;
+        }
+
+        const {
+            general: {mainDictionary, sortFrequencyDictionary, sortFrequencyDictionaryOrder, language},
+            scanning: {alphanumeric},
+            translation: {
+                textReplacements: textReplacementsOptions,
+                searchResolution,
+            },
+        } = options;
+
+        cache = {
+            enabledDictionaryMap: this._getTranslatorEnabledDictionaryMap(options),
+            mainDictionary,
+            sortFrequencyDictionary,
+            sortFrequencyDictionaryOrder,
+            removeNonJapaneseCharacters: !alphanumeric,
+            searchResolution,
+            textReplacements: this._getTranslatorTextReplacements(textReplacementsOptions),
+            language,
+        };
+        this._translatorProfileOptionsCache.set(options, cache);
+        return cache;
     }
 
     /**

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -252,7 +252,16 @@ export class Backend {
         this._permissions = null;
         /** @type {Map<string, (() => void)[]>} */
         this._applicationReadyHandlers = new Map();
-        /** @type {WeakMap<import('settings').ProfileOptions, object>} */
+        /** @type {WeakMap<import('settings').ProfileOptions, {
+         *     enabledDictionaryMap: Map<string, import('translation').FindTermDictionary>,
+         *     mainDictionary: string,
+         *     sortFrequencyDictionary: string|null,
+         *     sortFrequencyDictionaryOrder: import('settings').SortFrequencyDictionaryOrder,
+         *     removeNonJapaneseCharacters: boolean,
+         *     searchResolution: import('settings').SearchResolution,
+         *     textReplacements: (?(import('translation').FindTermsTextReplacement[]))[],
+         *     language: string,
+         * }>} */
         this._translatorProfileOptionsCache = new WeakMap();
 
         /* eslint-disable @stylistic/no-multi-spaces */
@@ -288,6 +297,7 @@ export class Backend {
             ['deleteDictionaryByTitle',      this._onApiDeleteDictionaryByTitle.bind(this)],
             ['updateDictionaryMetadata',     this._onApiUpdateDictionaryMetadata.bind(this)],
             ['getDictionaryCounts',          this._onApiGetDictionaryCounts.bind(this)],
+            ['clearDatabaseCaches',         this._onApiClearDatabaseCaches.bind(this)],
             ['checkDictionaryUpdates',       this._onApiCheckDictionaryUpdates.bind(this)],
             ['updateDictionaryByTitle',      this._onApiUpdateDictionaryByTitle.bind(this)],
             ['setDictionaryUpdateSchedule',  this._onApiSetDictionaryUpdateSchedule.bind(this)],
@@ -850,13 +860,84 @@ export class Backend {
         if (this._dictionaryImportModeActive) {
             return {dictionaryEntries: [], originalTextLength: 0};
         }
+        const includeTimingDiagnostics = (details?.includeTimingDiagnostics === true);
+        const serializeDictionaryEntries = (details?.serializeDictionaryEntries === true);
+        const totalStartedAt = safePerformance.now();
+        const ensureDatabaseStartedAt = safePerformance.now();
         await this._ensureDictionaryDatabaseReady();
+        const ensureDatabaseElapsedMs = Math.max(0, safePerformance.now() - ensureDatabaseStartedAt);
+        const getProfileOptionsStartedAt = safePerformance.now();
         const options = this._getProfileOptions(optionsContext, false);
+        const getProfileOptionsElapsedMs = Math.max(0, safePerformance.now() - getProfileOptionsStartedAt);
         const {general: {resultOutputMode: mode, maxResults}} = options;
+        const createFindTermsOptionsStartedAt = safePerformance.now();
         const findTermsOptions = this._getTranslatorFindTermsOptions(mode, details, options);
-        const {dictionaryEntries, originalTextLength} = await this._translator.findTerms(mode, text, findTermsOptions);
+        const createFindTermsOptionsElapsedMs = Math.max(0, safePerformance.now() - createFindTermsOptionsStartedAt);
+        const translatorFindTermsStartedAt = safePerformance.now();
+        const {
+            dictionaryEntries,
+            originalTextLength,
+            timingDiagnostics: translatorTimingDiagnosticsRaw = null,
+        } = this._translator instanceof TranslatorProxy ?
+            await this._translator.findTerms(mode, text, findTermsOptions, maxResults, includeTimingDiagnostics) :
+            await this._translator.findTerms(mode, text, findTermsOptions, includeTimingDiagnostics);
+        const translatorFindTermsElapsedMs = Math.max(0, safePerformance.now() - translatorFindTermsStartedAt);
+        const spliceResultsStartedAt = safePerformance.now();
         dictionaryEntries.splice(maxResults);
-        return {dictionaryEntries, originalTextLength};
+        const spliceResultsElapsedMs = Math.max(0, safePerformance.now() - spliceResultsStartedAt);
+        const dictionaryEntryCount = dictionaryEntries.length;
+        let dictionaryEntriesResult = dictionaryEntries;
+        let dictionaryEntriesJson;
+        let serializeDictionaryEntriesElapsedMs = 0;
+        let serializedDictionaryEntries = false;
+        let serializedDictionaryEntriesLength = 0;
+        let serializeDictionaryEntriesErrorMessage = null;
+        if (serializeDictionaryEntries && dictionaryEntries.length > 0) {
+            const serializeDictionaryEntriesStartedAt = safePerformance.now();
+            try {
+                dictionaryEntriesJson = JSON.stringify(dictionaryEntries);
+                serializeDictionaryEntriesElapsedMs = Math.max(0, safePerformance.now() - serializeDictionaryEntriesStartedAt);
+                serializedDictionaryEntries = true;
+                serializedDictionaryEntriesLength = dictionaryEntriesJson.length;
+                dictionaryEntriesResult = [];
+            } catch (error) {
+                serializeDictionaryEntriesElapsedMs = Math.max(0, safePerformance.now() - serializeDictionaryEntriesStartedAt);
+                serializeDictionaryEntriesErrorMessage = error instanceof Error ? error.message : String(error);
+            }
+        }
+        /** @type {Record<string, unknown>} */
+        const timingDiagnostics = {
+            backend: {
+                transport: this._translator instanceof TranslatorProxy ? 'offscreen-proxy' : 'direct',
+                ensureDatabaseElapsedMs,
+                getProfileOptionsElapsedMs,
+                createFindTermsOptionsElapsedMs,
+                translatorFindTermsElapsedMs,
+                spliceResultsElapsedMs,
+                serializeDictionaryEntriesRequested: serializeDictionaryEntries,
+                serializeDictionaryEntriesElapsedMs,
+                serializedDictionaryEntries,
+                serializedDictionaryEntriesLength,
+                serializeDictionaryEntriesErrorMessage,
+                totalElapsedMs: Math.max(0, safePerformance.now() - totalStartedAt),
+                textLength: text.length,
+                maxResults,
+            },
+        };
+        if (isObjectNotArray(translatorTimingDiagnosticsRaw)) {
+            Object.assign(timingDiagnostics, translatorTimingDiagnosticsRaw);
+        }
+        if (!includeTimingDiagnostics) {
+            if (isObjectNotArray(timingDiagnostics.backend)) {
+                reportDiagnostics('hover-terms-find-summary', {
+                    ...timingDiagnostics.backend,
+                    dictionaryEntryCount,
+                    originalTextLength,
+                });
+            }
+            return {dictionaryEntries: dictionaryEntriesResult, dictionaryEntriesJson, dictionaryEntryCount, originalTextLength};
+        }
+        return {dictionaryEntries: dictionaryEntriesResult, dictionaryEntriesJson, dictionaryEntryCount, originalTextLength, timingDiagnostics};
     }
 
     /** @type {import('api').ApiHandler<'parseText'>} */
@@ -1596,6 +1677,11 @@ export class Backend {
     async _onApiGetDictionaryCounts({dictionaryNames, getTotal}) {
         await this._ensureDictionaryDatabaseReady();
         return await this._dictionaryDatabase.getDictionaryCounts(dictionaryNames, getTotal);
+    }
+
+    /** @type {import('api').ApiHandler<'clearDatabaseCaches'>} */
+    async _onApiClearDatabaseCaches() {
+        await Promise.resolve(this._translator.clearDatabaseCaches());
     }
 
     /** @type {import('api').ApiHandler<'checkDictionaryUpdates'>} */

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -263,6 +263,8 @@ export class Backend {
          *     language: string,
          * }>} */
         this._translatorProfileOptionsCache = new WeakMap();
+        /** @type {Map<string, number>} */
+        this._effectiveScanLengthMaxHeadwordLengthCache = new Map();
 
         /* eslint-disable @stylistic/no-multi-spaces */
         /** @type {import('api').ApiMap} */
@@ -271,6 +273,7 @@ export class Backend {
             ['requestBackendReadySignal',    this._onApiRequestBackendReadySignal.bind(this)],
             ['optionsGet',                   this._onApiOptionsGet.bind(this)],
             ['optionsGetFull',               this._onApiOptionsGetFull.bind(this)],
+            ['getEffectiveHoverScanLength',  this._onApiGetEffectiveHoverScanLength.bind(this)],
             ['kanjiFind',                    this._onApiKanjiFind.bind(this)],
             ['termsFind',                    this._onApiTermsFind.bind(this)],
             ['parseText',                    this._onApiParseText.bind(this)],
@@ -833,12 +836,23 @@ export class Backend {
 
     /** @type {import('api').ApiHandler<'optionsGet'>} */
     async _onApiOptionsGet({optionsContext}) {
-        return await this._createEffectiveProfileOptions(optionsContext);
+        return clone(this._getProfileOptions(optionsContext, false));
     }
 
     /** @type {import('api').ApiHandler<'optionsGetFull'>} */
     _onApiOptionsGetFull() {
         return this._getOptionsFull(false);
+    }
+
+    /** @type {import('api').ApiHandler<'getEffectiveHoverScanLength'>} */
+    async _onApiGetEffectiveHoverScanLength({optionsContext}) {
+        const options = this._getProfileOptions(optionsContext, false);
+        try {
+            await this._ensureDictionaryDatabaseReady();
+        } catch (_) {
+            return options.scanning.length;
+        }
+        return await this._getEffectiveHoverScanLength(options.scanning.length, options);
     }
 
     /** @type {import('api').ApiHandler<'kanjiFind'>} */
@@ -2407,9 +2421,33 @@ export class Backend {
      * @returns {Promise<import('settings').ProfileOptions>}
      */
     async _createEffectiveProfileOptions(optionsContext) {
-        const options = clone(this._getProfileOptions(optionsContext, false));
-        options.scanning.length = await this._getEffectiveScanLength(options.scanning.length);
-        return options;
+        return clone(this._getProfileOptions(optionsContext, false));
+    }
+
+    /**
+     * @param {import('settings').ProfileOptions} options
+     * @returns {string[]}
+     */
+    _getEnabledDictionaryNames(options) {
+        const names = [];
+        const seen = new Set();
+        for (const dictionary of options.dictionaries) {
+            if (dictionary.enabled !== true) { continue; }
+            const name = String(dictionary.name || '').trim();
+            if (name.length === 0 || seen.has(name)) { continue; }
+            seen.add(name);
+            names.push(name);
+        }
+        names.sort();
+        return names;
+    }
+
+    /**
+     * @param {string[]} dictionaryNames
+     * @returns {string}
+     */
+    _getDictionarySetCacheKey(dictionaryNames) {
+        return dictionaryNames.join('\u001f');
     }
 
     /**
@@ -2443,9 +2481,10 @@ export class Backend {
     /**
      * @param {object} [root0]
      * @param {boolean} [root0.allowDuringMutation=false]
+     * @param {string[]|null} [root0.dictionaryNames=null]
      * @returns {Promise<number|null>}
      */
-    async _computeMaxHeadwordLengthFromDatabase({allowDuringMutation = false} = {}) {
+    async _computeMaxHeadwordLengthFromDatabase({allowDuringMutation = false, dictionaryNames = null} = {}) {
         if (this._dictionaryImportModeActive) {
             return null;
         }
@@ -2461,7 +2500,7 @@ export class Backend {
         }
 
         try {
-            const value = await /** @type {() => Promise<number>} */ (getMaxHeadwordLength).call(this._dictionaryDatabase);
+            const value = await /** @type {(dictionaryNames?: string[]|null) => Promise<number>} */ (getMaxHeadwordLength).call(this._dictionaryDatabase, dictionaryNames);
             if (!(typeof value === 'number' && Number.isFinite(value))) {
                 return 0;
             }
@@ -2473,21 +2512,49 @@ export class Backend {
 
     /**
      * @param {number} legacyScanLength
+     * @param {import('settings').ProfileOptions} options
      * @returns {Promise<number>}
      */
-    async _getEffectiveScanLength(legacyScanLength) {
-        const cached = this._getStoredGlobalMaxHeadwordLength();
-        if (cached > 0) {
-            return cached + SCAN_LENGTH_INFLECTION_BUFFER;
+    async _getEffectiveScanLength(legacyScanLength, options) {
+        return await this._getEffectiveHoverScanLength(legacyScanLength, options);
+    }
+
+    /**
+     * @param {number} legacyScanLength
+     * @param {import('settings').ProfileOptions} options
+     * @returns {Promise<number>}
+     */
+    async _getEffectiveHoverScanLength(legacyScanLength, options) {
+        const enabledDictionaryNames = this._getEnabledDictionaryNames(options);
+        if (enabledDictionaryNames.length === 0) {
+            return legacyScanLength;
         }
 
-        const computed = await this._computeMaxHeadwordLengthFromDatabase();
+        const allInstalledDictionariesEnabled = (enabledDictionaryNames.length === options.dictionaries.length);
+        const cachedGlobal = (allInstalledDictionariesEnabled ? this._getStoredGlobalMaxHeadwordLength() : 0);
+        if (cachedGlobal > 0) {
+            const effectiveCachedGlobal = cachedGlobal + SCAN_LENGTH_INFLECTION_BUFFER;
+            return Math.max(1, Math.min(legacyScanLength, effectiveCachedGlobal));
+        }
+
+        const cacheKey = this._getDictionarySetCacheKey(enabledDictionaryNames);
+        const cached = this._effectiveScanLengthMaxHeadwordLengthCache.get(cacheKey);
+        if (typeof cached === 'number') {
+            const effectiveCached = cached + SCAN_LENGTH_INFLECTION_BUFFER;
+            return Math.max(1, Math.min(legacyScanLength, effectiveCached));
+        }
+
+        const computed = await this._computeMaxHeadwordLengthFromDatabase({dictionaryNames: enabledDictionaryNames});
         if (computed === null || computed <= 0) {
             return legacyScanLength;
         }
 
-        await this._setGlobalMaxHeadwordLength(computed, 'background');
-        return computed + SCAN_LENGTH_INFLECTION_BUFFER;
+        this._effectiveScanLengthMaxHeadwordLengthCache.set(cacheKey, computed);
+        if (allInstalledDictionariesEnabled) {
+            await this._setGlobalMaxHeadwordLength(computed, 'background');
+        }
+        const effectiveComputed = computed + SCAN_LENGTH_INFLECTION_BUFFER;
+        return Math.max(1, Math.min(legacyScanLength, effectiveComputed));
     }
 
     /**
@@ -2512,6 +2579,7 @@ export class Backend {
      */
     async _handleDatabaseUpdated(type, cause) {
         if (type === 'dictionary') {
+            this._effectiveScanLengthMaxHeadwordLengthCache.clear();
             await this._refreshCachedMaxHeadwordLength('background', {allowDuringMutation: this._dictionaryMutationActive});
         }
         this._triggerDatabaseUpdated(type, cause);

--- a/ext/js/background/offscreen-dictionary-worker.js
+++ b/ext/js/background/offscreen-dictionary-worker.js
@@ -155,7 +155,9 @@ class OffscreenDictionaryWorkerHandler {
             case 'getMaxHeadwordLengthOffscreen':
                 this._assertDatabaseAvailable(action);
                 await this._ensureDatabasePrepared();
-                return await this._dictionaryDatabase.getMaxHeadwordLength();
+                return await this._dictionaryDatabase.getMaxHeadwordLength(
+                    Array.isArray(params.dictionaryNames) ? /** @type {string[]} */ (params.dictionaryNames) : null,
+                );
             case 'deleteDictionaryOffscreen':
                 this._assertDatabaseAvailable(action);
                 await this._ensureDatabasePrepared();

--- a/ext/js/background/offscreen-dictionary-worker.js
+++ b/ext/js/background/offscreen-dictionary-worker.js
@@ -18,6 +18,7 @@
 
 import {ExtensionError} from '../core/extension-error.js';
 import {log} from '../core/log.js';
+import {safePerformance} from '../core/safe-performance.js';
 import {arrayBufferToBase64, base64ToArrayBuffer} from '../data/array-buffer-util.js';
 import {DictionaryDatabase} from '../dictionary/dictionary-database.js';
 import {getSqlite3} from '../dictionary/sqlite-wasm.js';
@@ -222,10 +223,13 @@ class OffscreenDictionaryWorkerHandler {
             }
             case 'findTermsOffscreen': {
                 this._assertDatabaseAvailable(action);
+                const totalStartedAt = safePerformance.now();
                 await this._ensureDatabasePrepared();
                 const mode = /** @type {import('translator').FindTermsMode} */ (params.mode);
                 const text = /** @type {string} */ (params.text ?? '');
                 const options = /** @type {import('offscreen').FindTermsOptionsOffscreen} */ (params.options);
+                const includeTimingDiagnostics = (options.includeTimingDiagnostics === true);
+                const hydrateOptionsStartedAt = safePerformance.now();
                 const enabledDictionaryMap = new Map(options.enabledDictionaryMap);
                 const excludeDictionaryDefinitions = (
                     options.excludeDictionaryDefinitions !== null ?
@@ -247,7 +251,45 @@ class OffscreenDictionaryWorkerHandler {
                     excludeDictionaryDefinitions,
                     textReplacements,
                 };
-                return await this._translator.findTerms(mode, text, modifiedOptions);
+                const maxResults = (
+                    Number.isFinite(options.maxResults) &&
+                    /** @type {number} */ (options.maxResults) >= 0
+                ) ? Math.trunc(/** @type {number} */ (options.maxResults)) : -1;
+                const hydrateOptionsElapsedMs = Math.max(0, safePerformance.now() - hydrateOptionsStartedAt);
+                const translatorFindTermsStartedAt = safePerformance.now();
+                const result = await this._translator.findTerms(mode, text, modifiedOptions, includeTimingDiagnostics);
+                const translatorFindTermsElapsedMs = Math.max(0, safePerformance.now() - translatorFindTermsStartedAt);
+                if (maxResults >= 0 && Array.isArray(result?.dictionaryEntries)) {
+                    result.dictionaryEntries.splice(maxResults);
+                }
+                if (!includeTimingDiagnostics) {
+                    return result;
+                }
+                const timingDiagnostics = (
+                    typeof result === 'object' &&
+                    result !== null &&
+                    !Array.isArray(result) &&
+                    typeof Reflect.get(result, 'timingDiagnostics') === 'object' &&
+                    Reflect.get(result, 'timingDiagnostics') !== null &&
+                    !Array.isArray(Reflect.get(result, 'timingDiagnostics'))
+                ) ?
+                    /** @type {Record<string, unknown>} */ (Reflect.get(result, 'timingDiagnostics')) :
+                    {};
+                return {
+                    ...result,
+                    timingDiagnostics: {
+                        ...timingDiagnostics,
+                        offscreenWorker: {
+                            hydrateOptionsElapsedMs,
+                            translatorFindTermsElapsedMs,
+                            totalElapsedMs: Math.max(0, safePerformance.now() - totalStartedAt),
+                            enabledDictionaryCount: enabledDictionaryMap.size,
+                            excludeDictionaryDefinitionCount: excludeDictionaryDefinitions?.size ?? 0,
+                            textReplacementGroupCount: textReplacements.length,
+                            textLength: text.length,
+                        },
+                    },
+                };
             }
             case 'getTermFrequenciesOffscreen':
                 this._assertDatabaseAvailable(action);

--- a/ext/js/background/offscreen-proxy.js
+++ b/ext/js/background/offscreen-proxy.js
@@ -20,6 +20,15 @@ import {ExtensionError} from '../core/extension-error.js';
 import {isObjectNotArray} from '../core/object-utilities.js';
 import {arrayBufferToBase64, base64ToArrayBuffer} from '../data/array-buffer-util.js';
 
+/** @type {WeakMap<object, [string, import('translation').FindKanjiDictionary][]>} */
+const KANJI_ENABLED_DICTIONARY_MAP_LIST_CACHE = new WeakMap();
+/** @type {WeakMap<object, [string, import('translation').FindTermDictionary][]>} */
+const TERM_ENABLED_DICTIONARY_MAP_LIST_CACHE = new WeakMap();
+/** @type {WeakMap<object, string[]>} */
+const EXCLUDE_DICTIONARY_DEFINITIONS_LIST_CACHE = new WeakMap();
+/** @type {WeakMap<object, (import('offscreen').FindTermsTextReplacementOffscreen[] | null)[]>} */
+const TEXT_REPLACEMENTS_SERIALIZED_CACHE = new WeakMap();
+
 /**
  * This class is responsible for creating and communicating with an offscreen document.
  * This offscreen document is used to solve three issues:
@@ -331,7 +340,7 @@ export class TranslatorProxy {
      * @returns {Promise<import('dictionary').KanjiDictionaryEntry[]>}
      */
     async findKanji(text, options) {
-        const enabledDictionaryMapList = [...options.enabledDictionaryMap];
+        const enabledDictionaryMapList = this._getKanjiEnabledDictionaryMapList(options.enabledDictionaryMap);
         /** @type {import('offscreen').FindKanjiOptionsOffscreen} */
         const modifiedOptions = {
             ...options,
@@ -348,11 +357,9 @@ export class TranslatorProxy {
      */
     async findTerms(mode, text, options) {
         const {enabledDictionaryMap, excludeDictionaryDefinitions, textReplacements} = options;
-        const enabledDictionaryMapList = [...enabledDictionaryMap];
-        const excludeDictionaryDefinitionsList = excludeDictionaryDefinitions ? [...excludeDictionaryDefinitions] : null;
-        const textReplacementsSerialized = textReplacements.map((group) => {
-            return group !== null ? group.map((opt) => ({...opt, pattern: opt.pattern.toString()})) : null;
-        });
+        const enabledDictionaryMapList = this._getTermEnabledDictionaryMapList(enabledDictionaryMap);
+        const excludeDictionaryDefinitionsList = this._getExcludeDictionaryDefinitionsList(excludeDictionaryDefinitions);
+        const textReplacementsSerialized = this._getTextReplacementsSerialized(textReplacements);
         /** @type {import('offscreen').FindTermsOptionsOffscreen} */
         const modifiedOptions = {
             ...options,
@@ -375,6 +382,64 @@ export class TranslatorProxy {
     /** */
     async clearDatabaseCaches() {
         await this._offscreen.sendMessagePromise({action: 'clearDatabaseCachesOffscreen'});
+    }
+
+    /**
+     * @param {Map<string, import('translation').FindKanjiDictionary>} enabledDictionaryMap
+     * @returns {[string, import('translation').FindKanjiDictionary][]}
+     */
+    _getKanjiEnabledDictionaryMapList(enabledDictionaryMap) {
+        let cached = KANJI_ENABLED_DICTIONARY_MAP_LIST_CACHE.get(enabledDictionaryMap);
+        if (typeof cached === 'undefined') {
+            cached = [...enabledDictionaryMap];
+            KANJI_ENABLED_DICTIONARY_MAP_LIST_CACHE.set(enabledDictionaryMap, cached);
+        }
+        return cached;
+    }
+
+    /**
+     * @param {Map<string, import('translation').FindTermDictionary>} enabledDictionaryMap
+     * @returns {[string, import('translation').FindTermDictionary][]}
+     */
+    _getTermEnabledDictionaryMapList(enabledDictionaryMap) {
+        let cached = TERM_ENABLED_DICTIONARY_MAP_LIST_CACHE.get(enabledDictionaryMap);
+        if (typeof cached === 'undefined') {
+            cached = [...enabledDictionaryMap];
+            TERM_ENABLED_DICTIONARY_MAP_LIST_CACHE.set(enabledDictionaryMap, cached);
+        }
+        return cached;
+    }
+
+    /**
+     * @param {?Set<string>} excludeDictionaryDefinitions
+     * @returns {?string[]}
+     */
+    _getExcludeDictionaryDefinitionsList(excludeDictionaryDefinitions) {
+        if (excludeDictionaryDefinitions === null) {
+            return null;
+        }
+
+        let cached = EXCLUDE_DICTIONARY_DEFINITIONS_LIST_CACHE.get(excludeDictionaryDefinitions);
+        if (typeof cached === 'undefined') {
+            cached = [...excludeDictionaryDefinitions];
+            EXCLUDE_DICTIONARY_DEFINITIONS_LIST_CACHE.set(excludeDictionaryDefinitions, cached);
+        }
+        return cached;
+    }
+
+    /**
+     * @param {(import('translation').FindTermsTextReplacement[]|null)[]} textReplacements
+     * @returns {(import('offscreen').FindTermsTextReplacementOffscreen[] | null)[]}
+     */
+    _getTextReplacementsSerialized(textReplacements) {
+        let cached = TEXT_REPLACEMENTS_SERIALIZED_CACHE.get(textReplacements);
+        if (typeof cached === 'undefined') {
+            cached = textReplacements.map((group) => {
+                return group !== null ? group.map((opt) => ({...opt, pattern: opt.pattern.toString()})) : null;
+            });
+            TEXT_REPLACEMENTS_SERIALIZED_CACHE.set(textReplacements, cached);
+        }
+        return cached;
     }
 }
 

--- a/ext/js/background/offscreen-proxy.js
+++ b/ext/js/background/offscreen-proxy.js
@@ -259,10 +259,11 @@ export class DictionaryDatabaseProxy {
     }
 
     /**
+     * @param {string[]|null} [dictionaryNames=null]
      * @returns {Promise<number>}
      */
-    async getMaxHeadwordLength() {
-        return await this._offscreen.sendMessagePromise({action: 'getMaxHeadwordLengthOffscreen'});
+    async getMaxHeadwordLength(dictionaryNames = null) {
+        return await this._offscreen.sendMessagePromise({action: 'getMaxHeadwordLengthOffscreen', params: {dictionaryNames}});
     }
 
     /**

--- a/ext/js/background/offscreen-proxy.js
+++ b/ext/js/background/offscreen-proxy.js
@@ -18,6 +18,7 @@
 
 import {ExtensionError} from '../core/extension-error.js';
 import {isObjectNotArray} from '../core/object-utilities.js';
+import {safePerformance} from '../core/safe-performance.js';
 import {arrayBufferToBase64, base64ToArrayBuffer} from '../data/array-buffer-util.js';
 
 /** @type {WeakMap<object, [string, import('translation').FindKanjiDictionary][]>} */
@@ -195,6 +196,7 @@ export class OffscreenProxy {
             void this.sendMessagePromise({action: 'createAndRegisterPortOffscreen'});
         }
     }
+
 }
 
 export class DictionaryDatabaseProxy {
@@ -204,6 +206,15 @@ export class DictionaryDatabaseProxy {
     constructor(offscreen) {
         /** @type {OffscreenProxy} */
         this._offscreen = offscreen;
+        /** @type {boolean} */
+        this._prepared = false;
+    }
+
+    /**
+     * @returns {boolean}
+     */
+    isPrepared() {
+        return this._prepared;
     }
 
     /**
@@ -211,6 +222,7 @@ export class DictionaryDatabaseProxy {
      */
     async prepare() {
         await this._offscreen.sendMessagePromise({action: 'databasePrepareOffscreen'});
+        this._prepared = true;
     }
 
     /**
@@ -218,6 +230,7 @@ export class DictionaryDatabaseProxy {
      */
     async refreshConnection() {
         await this._offscreen.sendMessagePromise({action: 'databaseRefreshOffscreen'});
+        this._prepared = true;
     }
 
     /**
@@ -226,6 +239,7 @@ export class DictionaryDatabaseProxy {
      */
     async setSuspended(suspended) {
         await this._offscreen.sendMessagePromise({action: 'databaseSetSuspendedOffscreen', params: {suspended}});
+        this._prepared = !suspended;
     }
 
     /**
@@ -353,21 +367,59 @@ export class TranslatorProxy {
      * @param {import('translator').FindTermsMode} mode
      * @param {string} text
      * @param {import('translation').FindTermsOptions} options
+     * @param {number} [maxResults]
      * @returns {Promise<import('translator').FindTermsResult>}
      */
-    async findTerms(mode, text, options) {
+    async findTerms(mode, text, options, maxResults, includeTimingDiagnostics = false) {
+        const totalStartedAt = safePerformance.now();
         const {enabledDictionaryMap, excludeDictionaryDefinitions, textReplacements} = options;
+        const serializeEnabledDictionaryMapStartedAt = safePerformance.now();
         const enabledDictionaryMapList = this._getTermEnabledDictionaryMapList(enabledDictionaryMap);
+        const serializeEnabledDictionaryMapElapsedMs = Math.max(0, safePerformance.now() - serializeEnabledDictionaryMapStartedAt);
+        const serializeExcludeDictionaryDefinitionsStartedAt = safePerformance.now();
         const excludeDictionaryDefinitionsList = this._getExcludeDictionaryDefinitionsList(excludeDictionaryDefinitions);
+        const serializeExcludeDictionaryDefinitionsElapsedMs = Math.max(0, safePerformance.now() - serializeExcludeDictionaryDefinitionsStartedAt);
+        const serializeTextReplacementsStartedAt = safePerformance.now();
         const textReplacementsSerialized = this._getTextReplacementsSerialized(textReplacements);
+        const serializeTextReplacementsElapsedMs = Math.max(0, safePerformance.now() - serializeTextReplacementsStartedAt);
         /** @type {import('offscreen').FindTermsOptionsOffscreen} */
         const modifiedOptions = {
             ...options,
             enabledDictionaryMap: enabledDictionaryMapList,
             excludeDictionaryDefinitions: excludeDictionaryDefinitionsList,
             textReplacements: textReplacementsSerialized,
+            maxResults: typeof maxResults === 'number' ? maxResults : void 0,
+            includeTimingDiagnostics,
         };
-        return this._offscreen.sendMessagePromise({action: 'findTermsOffscreen', params: {mode, text, options: modifiedOptions}});
+        const sendMessageStartedAt = safePerformance.now();
+        const result = await this._offscreen.sendMessagePromise({action: 'findTermsOffscreen', params: {mode, text, options: modifiedOptions}});
+        const sendMessageElapsedMs = Math.max(0, safePerformance.now() - sendMessageStartedAt);
+        if (!includeTimingDiagnostics) {
+            return result;
+        }
+        const timingDiagnostics = (
+            isObjectNotArray(result) &&
+            isObjectNotArray(Reflect.get(result, 'timingDiagnostics'))
+        ) ?
+            /** @type {Record<string, unknown>} */ (Reflect.get(result, 'timingDiagnostics')) :
+            {};
+        return {
+            ...result,
+            timingDiagnostics: {
+                ...timingDiagnostics,
+                translatorProxy: {
+                    serializeEnabledDictionaryMapElapsedMs,
+                    serializeExcludeDictionaryDefinitionsElapsedMs,
+                    serializeTextReplacementsElapsedMs,
+                    sendMessageElapsedMs,
+                    totalElapsedMs: Math.max(0, safePerformance.now() - totalStartedAt),
+                    transport: 'runtime-message',
+                    enabledDictionaryCount: enabledDictionaryMap.size,
+                    excludeDictionaryDefinitionCount: excludeDictionaryDefinitions?.size ?? 0,
+                    textReplacementGroupCount: textReplacements.length,
+                },
+            },
+        };
     }
 
     /**

--- a/ext/js/comm/api.js
+++ b/ext/js/comm/api.js
@@ -58,6 +58,14 @@ export class API {
     }
 
     /**
+     * @param {import('api').ApiParam<'getEffectiveHoverScanLength', 'optionsContext'>} optionsContext
+     * @returns {Promise<import('api').ApiReturn<'getEffectiveHoverScanLength'>>}
+     */
+    getEffectiveHoverScanLength(optionsContext) {
+        return this._invoke('getEffectiveHoverScanLength', {optionsContext});
+    }
+
+    /**
      * @param {import('api').ApiParam<'termsFind', 'text'>} text
      * @param {import('api').ApiParam<'termsFind', 'details'>} details
      * @param {import('api').ApiParam<'termsFind', 'optionsContext'>} optionsContext

--- a/ext/js/comm/api.js
+++ b/ext/js/comm/api.js
@@ -18,6 +18,11 @@
 
 import {ExtensionError} from '../core/extension-error.js';
 import {log} from '../core/log.js';
+import {safePerformance} from '../core/safe-performance.js';
+import {publishDevTimingSnapshot} from '../core/dev-timing-diagnostics.js';
+
+const API_INVOKE_DIAGNOSTICS_DATASET_KEY = 'manabitanDevApiInvokeDiagnostics';
+const API_INVOKE_DIAGNOSTICS_EVENT = 'api-invoke-summary';
 
 export class API {
     /**
@@ -34,6 +39,7 @@ export class API {
 
         /** @type {MessagePort?} */
         this._backendPort = backendPort;
+
     }
 
     /**
@@ -417,6 +423,13 @@ export class API {
     }
 
     /**
+     * @returns {Promise<import('api').ApiReturn<'clearDatabaseCaches'>>}
+     */
+    clearDatabaseCaches() {
+        return this._invoke('clearDatabaseCaches', void 0);
+    }
+
+    /**
      * @returns {Promise<import('api').ApiReturn<'testMecab'>>}
      */
     testMecab() {
@@ -523,27 +536,103 @@ export class API {
     _invoke(action, params) {
         /** @type {import('api').ApiMessage<TAction>} */
         const data = {action, params};
+        const startedAt = safePerformance.now();
+        /**
+         * @param {string} status
+         * @param {Record<string, unknown>} [details]
+         * @returns {void}
+         */
+        const publishDiagnostics = (status, details = {}) => {
+            const elapsedMs = Math.max(0, safePerformance.now() - startedAt);
+            if (!(action === 'termsFind' || action === 'kanjiFind' || status !== 'success' || elapsedMs >= 200)) { return; }
+            publishDevTimingSnapshot(
+                API_INVOKE_DIAGNOSTICS_DATASET_KEY,
+                {
+                    action,
+                    status,
+                    elapsedMs,
+                    ...details,
+                },
+                API_INVOKE_DIAGNOSTICS_EVENT,
+            );
+        };
         return new Promise((resolve, reject) => {
+            /** @param {unknown} response */
+            const handleResponseViaRuntimeMessage = (response) => {
+                this._handleInvokeResponse(data, response, publishDiagnostics, /** @type {(result: unknown) => void} */ (resolve), reject);
+            };
             try {
-                this._webExtension.sendMessage(data, (response) => {
-                    this._webExtension.getLastError();
-                    if (response !== null && typeof response === 'object') {
-                        const {error} = /** @type {import('core').UnknownObject} */ (response);
-                        if (typeof error !== 'undefined') {
-                            reject(ExtensionError.deserialize(/** @type {import('core').SerializedError} */(error)));
-                        } else {
-                            const {result} = /** @type {import('core').UnknownObject} */ (response);
-                            resolve(/** @type {import('api').ApiReturn<TAction>} */(result));
-                        }
-                    } else {
-                        const message = response === null ? 'Unexpected null response. You may need to refresh the page.' : `Unexpected response of type ${typeof response}. You may need to refresh the page.`;
-                        reject(new Error(`${message} (${JSON.stringify(data)})`));
-                    }
-                });
+                this._webExtension.sendMessage(data, handleResponseViaRuntimeMessage);
             } catch (e) {
+                publishDiagnostics('send-error', {
+                    transport: 'runtime-message',
+                    errorMessage: e instanceof Error ? e.message : String(e),
+                });
                 reject(e);
             }
         });
+    }
+
+    /**
+     * @template {import('api').ApiNames} TAction
+     * @param {import('api').ApiMessage<TAction>} data
+     * @param {unknown} response
+     * @param {(status: string, details?: Record<string, unknown>) => void} publishDiagnostics
+     * @param {(result: unknown) => void} resolve
+     * @param {(error: unknown) => void} reject
+     * @returns {void}
+     */
+    _handleInvokeResponse(data, response, publishDiagnostics, resolve, reject) {
+        const lastError = this._webExtension.getLastError();
+        if (lastError !== null) {
+            publishDiagnostics('runtime-error', {
+                transport: 'runtime-message',
+                errorMessage: lastError.message,
+                responseType: response === null ? 'null' : typeof response,
+            });
+            reject(lastError);
+            return;
+        }
+        if (response !== null && typeof response === 'object') {
+            const {error} = /** @type {import('core').UnknownObject} */ (response);
+            if (typeof error !== 'undefined') {
+                publishDiagnostics('extension-error', {transport: 'runtime-message'});
+                reject(ExtensionError.deserialize(/** @type {import('core').SerializedError} */(error)));
+            } else {
+                const {result} = /** @type {import('core').UnknownObject} */ (response);
+                const resultObject = (
+                    typeof result === 'object' &&
+                    result !== null &&
+                    !Array.isArray(result)
+                ) ?
+                    /** @type {import('core').UnknownObject} */ (result) :
+                    null;
+                const dictionaryEntries = resultObject?.dictionaryEntries;
+                const dictionaryEntriesJson = resultObject?.dictionaryEntriesJson;
+                const dictionaryEntryCount = resultObject?.dictionaryEntryCount;
+                publishDiagnostics('success', {
+                    transport: 'runtime-message',
+                    responseType: typeof result,
+                    dictionaryEntryCount: (
+                        typeof dictionaryEntryCount === 'number' &&
+                        Number.isFinite(dictionaryEntryCount) &&
+                        dictionaryEntryCount >= 0
+                    ) ?
+                        dictionaryEntryCount :
+                        (Array.isArray(dictionaryEntries) ? dictionaryEntries.length : null),
+                    serializedDictionaryEntries: (typeof dictionaryEntriesJson === 'string' && dictionaryEntriesJson.length > 0),
+                    serializedDictionaryEntriesLength: typeof dictionaryEntriesJson === 'string' ? dictionaryEntriesJson.length : 0,
+                });
+                resolve(result);
+            }
+        } else {
+            const message = response === null ? 'Unexpected null response. You may need to refresh the page.' : `Unexpected response of type ${typeof response}. You may need to refresh the page.`;
+            publishDiagnostics('invalid-response', {
+                transport: 'runtime-message',
+                responseType: response === null ? 'null' : typeof response,
+            });
+            reject(new Error(`${message} (${JSON.stringify(data)})`));
+        }
     }
 
     /**

--- a/ext/js/core/dev-timing-diagnostics.js
+++ b/ext/js/core/dev-timing-diagnostics.js
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2026  Manabitan authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {reportDiagnostics} from './diagnostics-reporter.js';
+
+/**
+ * @returns {HTMLElement|null}
+ */
+function getDocumentElement() {
+    const documentValue = Reflect.get(globalThis, 'document');
+    const documentElement = /** @type {{documentElement?: unknown}|undefined} */ (documentValue)?.documentElement;
+    return documentElement instanceof HTMLElement ? documentElement : null;
+}
+
+/**
+ * @param {unknown} value
+ * @returns {string|null}
+ */
+function serializeValue(value) {
+    try {
+        return JSON.stringify(value);
+    } catch (_) {
+        return null;
+    }
+}
+
+/**
+ * @returns {boolean}
+ */
+function isDevBuild() {
+    try {
+        const manifest = chrome.runtime?.getManifest?.();
+        return typeof manifest?.name === 'string' && manifest.name.includes('(dev)');
+    } catch (_) {
+        return false;
+    }
+}
+
+/**
+ * @returns {boolean}
+ */
+function shouldReportDevTimingSnapshot() {
+    const globalFlag = Reflect.get(globalThis, 'manabitanDevReportTimingDiagnostics');
+    if (globalFlag === true) {
+        return true;
+    }
+    const documentElement = getDocumentElement();
+    return documentElement?.dataset.manabitanDevReportTimingDiagnostics === 'true';
+}
+
+/**
+ * @param {string} datasetKey
+ * @param {unknown} payload
+ * @param {string|null} [diagnosticsEvent]
+ * @returns {void}
+ */
+export function publishDevTimingSnapshot(datasetKey, payload, diagnosticsEvent = null) {
+    const documentElement = getDocumentElement();
+    const serialized = serializeValue(payload);
+    if (documentElement !== null) {
+        if (serialized !== null) {
+            Reflect.set(documentElement.dataset, datasetKey, serialized);
+        } else {
+            Reflect.deleteProperty(documentElement.dataset, datasetKey);
+        }
+    }
+
+    if (diagnosticsEvent !== null && isDevBuild() && shouldReportDevTimingSnapshot()) {
+        const diagnosticsPayload = (
+            typeof payload === 'object' &&
+            payload !== null &&
+            !Array.isArray(payload)
+        ) ?
+            /** @type {Record<string, unknown>} */ (payload) :
+            {value: payload};
+        reportDiagnostics(diagnosticsEvent, diagnosticsPayload);
+    }
+}
+
+/**
+ * @param {string[]} datasetKeys
+ * @returns {void}
+ */
+export function clearDevTimingSnapshots(datasetKeys) {
+    const documentElement = getDocumentElement();
+    if (documentElement === null) { return; }
+    for (const datasetKey of datasetKeys) {
+        Reflect.deleteProperty(documentElement.dataset, datasetKey);
+    }
+}

--- a/ext/js/dictionary/dictionary-database.js
+++ b/ext/js/dictionary/dictionary-database.js
@@ -64,6 +64,8 @@ const HIGH_MEMORY_TERM_BULK_ADD_STAGING_MAX_ROWS = 10240;
 const TERM_CONTENT_STORAGE_MODE_BASELINE = 'baseline';
 const TERM_CONTENT_STORAGE_MODE_RAW_BYTES = 'raw-bytes';
 const DEFAULT_RAW_TERM_CONTENT_PACK_TARGET_BYTES = 4 * 1024 * 1024;
+const DIRECT_TERM_PREFIX_BUCKET_MAX_LENGTH = 2;
+const TERM_CONTENT_READ_PAGE_SIZE_BYTES_DIAGNOSTIC = 64 * 1024;
 
 /**
  * @param {string} value
@@ -122,6 +124,34 @@ function packContentChunksIntoSlabs(chunks, targetBytes) {
         startIndex = endIndex;
     }
     return {packedChunks, sourceChunkIndices, sourceChunkLocalOffsets};
+}
+
+/**
+ * @param {string} value
+ * @returns {string}
+ */
+function getTermPrefixBucketKey(value) {
+    let prefix = '';
+    let count = 0;
+    for (const char of value) {
+        prefix += char;
+        ++count;
+        if (count >= DIRECT_TERM_PREFIX_BUCKET_MAX_LENGTH) {
+            break;
+        }
+    }
+    return prefix;
+}
+
+/**
+ * @param {{dictionary?: string, expression?: string, reading?: string}} row
+ * @returns {string}
+ */
+function getTermContentLocalityKey(row) {
+    const dictionary = typeof row.dictionary === 'string' ? row.dictionary : '';
+    const expression = typeof row.expression === 'string' ? row.expression : '';
+    const reading = typeof row.reading === 'string' ? row.reading : '';
+    return `${dictionary}\u001f${getTermPrefixBucketKey(expression)}\u001f${expression}\u001f${getTermPrefixBucketKey(reading)}\u001f${reading}`;
 }
 
 
@@ -193,9 +223,13 @@ export class DictionaryDatabase {
         this._termExactPresenceCacheMaxEntries = this._computeTermExactPresenceCacheMaxEntries();
         /** @type {Map<string, boolean>} */
         this._termPrefixNegativeCache = new Map();
+        /** @type {?boolean} */
+        this._termMetaTableHasRows = null;
         /** @type {number|null} */
         this._maxHeadwordLengthCache = null;
-        /** @type {Map<string, {expression: Map<string, number[]>, reading: Map<string, number[]>, expressionReverse: Map<string, number[]>, readingReverse: Map<string, number[]>, pair: Map<string, number[]>, sequence: Map<number, number[]>}>} */
+        /** @type {Map<string, Map<string, import('dictionary-database').Tag>>} */
+        this._tagMetaIndexByDictionary = new Map();
+        /** @type {Map<string, {expression: Map<string, number[]>, reading: Map<string, number[]>, expressionReverse: Map<string, number[]>, readingReverse: Map<string, number[]>, expressionPrefixes: Map<string, string[]>, readingPrefixes: Map<string, string[]>, expressionReversePrefixes: Map<string, string[]>, readingReversePrefixes: Map<string, string[]>, pair: Map<string, number[]>, sequence: Map<number, number[]>}>} */
         this._directTermIndexByDictionary = new Map();
         /** @type {import('@sqlite.org/sqlite-wasm').sqlite3_module|null} */
         this._termsVtabModule = null;
@@ -313,7 +347,9 @@ export class DictionaryDatabase {
         this._termEntryContentIdByHash.clear();
         this._termExactPresenceCache.clear();
         this._termPrefixNegativeCache.clear();
+        this._invalidateTermMetaTableHasRowsCache();
         this._invalidateMaxHeadwordLengthCache();
+        this._tagMetaIndexByDictionary.clear();
         this._directTermIndexByDictionary.clear();
         this._clearTermsVtabCursorState();
         this._termsVtabModuleRegistered = false;
@@ -327,6 +363,11 @@ export class DictionaryDatabase {
      */
     isPrepared() {
         return this._db !== null;
+    }
+
+    /** */
+    clearTagCaches() {
+        this._tagMetaIndexByDictionary.clear();
     }
 
     /**
@@ -1055,6 +1096,8 @@ export class DictionaryDatabase {
         this._clearTermEntryContentMetaCaches();
         this._termExactPresenceCache.clear();
         this._termPrefixNegativeCache.clear();
+        this._invalidateTermMetaTableHasRowsCache();
+        this._tagMetaIndexByDictionary.clear();
         this._directTermIndexByDictionary.clear();
     }
 
@@ -1131,6 +1174,8 @@ export class DictionaryDatabase {
         this._clearTermEntryContentMetaCaches();
         this._termExactPresenceCache.clear();
         this._termPrefixNegativeCache.clear();
+        this._invalidateTermMetaTableHasRowsCache();
+        this._tagMetaIndexByDictionary.clear();
         this._directTermIndexByDictionary.clear();
     }
 
@@ -1178,12 +1223,67 @@ export class DictionaryDatabase {
         this._clearTermEntryContentMetaCaches();
         this._termExactPresenceCache.clear();
         this._termPrefixNegativeCache.clear();
+        this._invalidateTermMetaTableHasRowsCache();
+        this._tagMetaIndexByDictionary.clear();
         this._directTermIndexByDictionary.clear();
     }
 
     /** */
     _invalidateMaxHeadwordLengthCache() {
         this._maxHeadwordLengthCache = null;
+    }
+
+    /** */
+    _invalidateTermMetaTableHasRowsCache() {
+        this._termMetaTableHasRows = null;
+    }
+
+    /**
+     * @returns {boolean}
+     */
+    _hasTermMetaTableRows() {
+        const cached = this._termMetaTableHasRows;
+        if (typeof cached === 'boolean') {
+            return cached;
+        }
+        const db = this._requireDb();
+        const hasRows = this._asNumber(db.selectValue('SELECT 1 FROM termMeta LIMIT 1'), 0) === 1;
+        this._termMetaTableHasRows = hasRows;
+        return hasRows;
+    }
+
+    /**
+     * @param {string} dictionaryName
+     * @returns {Map<string, import('dictionary-database').Tag>}
+     */
+    _ensureTagMetaIndex(dictionaryName, timingDiagnostics = null) {
+        const existing = this._tagMetaIndexByDictionary.get(dictionaryName);
+        if (typeof existing !== 'undefined') {
+            if (timingDiagnostics !== null) {
+                ++timingDiagnostics.cacheHitDictionaryCount;
+            }
+            return existing;
+        }
+        const buildStartedAt = safePerformance.now();
+        const stmt = this._getCachedStatement(
+            'SELECT name, category, ord as "order", notes, score, dictionary FROM tagMeta WHERE dictionary = $dictionary',
+        );
+        stmt.reset(true);
+        stmt.bind({$dictionary: dictionaryName});
+        /** @type {Map<string, import('dictionary-database').Tag>} */
+        const index = new Map();
+        while (stmt.step()) {
+            const row = /** @type {import('core').SafeAny} */ (stmt.get({}));
+            const tag = this._deserializeTagRow(row);
+            index.set(tag.name, tag);
+        }
+        if (timingDiagnostics !== null) {
+            ++timingDiagnostics.cacheMissDictionaryCount;
+            timingDiagnostics.loadedTagCount += index.size;
+            timingDiagnostics.indexBuildElapsedMs += Math.max(0, safePerformance.now() - buildStartedAt);
+        }
+        this._tagMetaIndexByDictionary.set(dictionaryName, index);
+        return index;
     }
 
     /**
@@ -1270,7 +1370,7 @@ export class DictionaryDatabase {
 
     /**
      * @param {string} dictionaryName
-     * @returns {{expression: Map<string, number[]>, reading: Map<string, number[]>, expressionReverse: Map<string, number[]>, readingReverse: Map<string, number[]>, pair: Map<string, number[]>, sequence: Map<number, number[]>}}
+     * @returns {{expression: Map<string, number[]>, reading: Map<string, number[]>, expressionReverse: Map<string, number[]>, readingReverse: Map<string, number[]>, expressionPrefixes: Map<string, string[]>, readingPrefixes: Map<string, string[]>, expressionReversePrefixes: Map<string, string[]>, readingReversePrefixes: Map<string, string[]>, pair: Map<string, number[]>, sequence: Map<number, number[]>}}
      */
     _ensureDirectTermIndex(dictionaryName) {
         const existing = this._directTermIndexByDictionary.get(dictionaryName);
@@ -1323,6 +1423,7 @@ export class DictionaryDatabase {
         if (termList.length === 0 || dictionaries.size === 0) {
             return [];
         }
+        const totalStartedAt = safePerformance.now();
         const visited = new Set();
         /** @type {import('dictionary-database').TermEntry[]} */
         const results = [];
@@ -1332,6 +1433,7 @@ export class DictionaryDatabase {
         const columns = (matchType === 'suffix') ? ['expressionReverse', 'readingReverse'] : ['expression', 'reading'];
 
         if (matchType === 'exact') {
+            const buildMatchesStartedAt = safePerformance.now();
             /** @type {Map<string, number[]>} */
             const termIndexMap = new Map();
             /** @type {Map<number, {matchSource: import('dictionary-database').MatchSource, itemIndex: number}[]>} */
@@ -1403,7 +1505,11 @@ export class DictionaryDatabase {
                 return [];
             }
 
-            const rowsById = await this._fetchTermRowsByIds(idMatches.keys());
+            const buildMatchesElapsedMs = Math.max(0, safePerformance.now() - buildMatchesStartedAt);
+            const fetchTermRowsStartedAt = safePerformance.now();
+            const {rowsById, timingDiagnostics: fetchTermRowsDiagnostics = null} = await this._fetchTermRowsByIds(idMatches.keys());
+            const fetchTermRowsElapsedMs = Math.max(0, safePerformance.now() - fetchTermRowsStartedAt);
+            const createTermsStartedAt = safePerformance.now();
             for (const [id, matches] of idMatches) {
                 const row = rowsById.get(id);
                 if (typeof row === 'undefined') { continue; }
@@ -1411,19 +1517,41 @@ export class DictionaryDatabase {
                     results.push(this._createTerm(matchSource, 'exact', row, itemIndex));
                 }
             }
+            const createTermsElapsedMs = Math.max(0, safePerformance.now() - createTermsStartedAt);
+            Object.defineProperty(results, 'timingDiagnostics', {
+                value: {
+                    path: 'exact',
+                    buildMatchesElapsedMs,
+                    fetchTermRowsElapsedMs,
+                    createTermsElapsedMs,
+                    totalElapsedMs: Math.max(0, safePerformance.now() - totalStartedAt),
+                    requestedTermCount: termList.length,
+                    uniqueTermCount: termIndexMap.size,
+                    matchedIdCount: idMatches.size,
+                    resultCount: results.length,
+                    fetchTermRows: fetchTermRowsDiagnostics,
+                },
+                configurable: true,
+            });
             return results;
         }
 
+        const buildMatchesStartedAt = safePerformance.now();
         /** @type {Map<number, {matchSource: import('dictionary-database').MatchSource, matchType: import('dictionary-database').MatchType, itemIndex: number}>} */
         const idMatches = new Map();
-        /** @type {Map<string, {term: string, query: string, itemIndex: number}>} */
+        /** @type {Map<string, {term: string, query: string, prefixBucketKey: string, itemIndex: number}>} */
         const uniqueQueryMap = new Map();
         for (let itemIndex = 0; itemIndex < termList.length; ++itemIndex) {
             const term = termList[itemIndex];
             const query = matchType === 'suffix' ? stringReverse(term) : term;
             if (query.length === 0) { continue; }
             if (!uniqueQueryMap.has(query)) {
-                uniqueQueryMap.set(query, {term, query, itemIndex});
+                uniqueQueryMap.set(query, {
+                    term,
+                    query,
+                    prefixBucketKey: getTermPrefixBucketKey(query),
+                    itemIndex,
+                });
             }
         }
         const dictionaryCacheKey = this._getDictionaryCacheKey(dictionaryNames);
@@ -1431,33 +1559,54 @@ export class DictionaryDatabase {
         const queriesToCheck = [...uniqueQueryMap.values()].filter(({query}) => !this._termPrefixNegativeCache.has(`${negativeCachePrefix}${query}`));
         /** @type {Set<string>} */
         const foundQueries = new Set();
+        const directTermLookups = dictionaryNames.map((dictionaryName) => this._ensureDirectTermIndex(dictionaryName));
+        let prefixBucketHitCount = 0;
+        let prefixBucketMissCount = 0;
+        let prefixBucketCandidateValueCount = 0;
+        let scannedValueCount = 0;
 
         for (let indexIndex = 0; indexIndex < columns.length; ++indexIndex) {
             const column = columns[indexIndex];
-            /** @type {Map<string, number[]>|null} */
-            let lookup = null;
             for (const queryData of queriesToCheck) {
-                for (const dictionaryName of dictionaryNames) {
-                    const index = this._ensureDirectTermIndex(dictionaryName);
+                for (const index of directTermLookups) {
+                    /** @type {Map<string, number[]>|null} */
+                    let lookup = null;
+                    /** @type {Map<string, string[]>|null} */
+                    let prefixes = null;
                     switch (column) {
                         case 'expression':
                             lookup = index.expression;
+                            prefixes = index.expressionPrefixes;
                             break;
                         case 'reading':
                             lookup = index.reading;
+                            prefixes = index.readingPrefixes;
                             break;
                         case 'expressionReverse':
                             lookup = index.expressionReverse;
+                            prefixes = index.expressionReversePrefixes;
                             break;
                         case 'readingReverse':
                             lookup = index.readingReverse;
+                            prefixes = index.readingReversePrefixes;
                             break;
                         default:
                             lookup = null;
+                            prefixes = null;
                             break;
                     }
-                    if (lookup === null) { continue; }
-                    for (const [value, ids] of lookup.entries()) {
+                    if (lookup === null || prefixes === null) { continue; }
+                    const candidateValues = prefixes.get(queryData.prefixBucketKey);
+                    if (typeof candidateValues === 'undefined') {
+                        ++prefixBucketMissCount;
+                        continue;
+                    }
+                    ++prefixBucketHitCount;
+                    prefixBucketCandidateValueCount += candidateValues.length;
+                    for (const value of candidateValues) {
+                        ++scannedValueCount;
+                        const ids = lookup.get(value);
+                        if (typeof ids === 'undefined') { continue; }
                         if (!value.startsWith(queryData.query)) { continue; }
                         foundQueries.add(queryData.query);
                         for (const id of ids) {
@@ -1483,12 +1632,37 @@ export class DictionaryDatabase {
             this._termPrefixNegativeCache.clear();
         }
 
-        const rowsById = await this._fetchTermRowsByIds(idMatches.keys());
+        const buildMatchesElapsedMs = Math.max(0, safePerformance.now() - buildMatchesStartedAt);
+        const fetchTermRowsStartedAt = safePerformance.now();
+        const {rowsById, timingDiagnostics: fetchTermRowsDiagnostics = null} = await this._fetchTermRowsByIds(idMatches.keys());
+        const fetchTermRowsElapsedMs = Math.max(0, safePerformance.now() - fetchTermRowsStartedAt);
+        const createTermsStartedAt = safePerformance.now();
         for (const [id, {matchSource, matchType: matchType2, itemIndex}] of idMatches) {
             const row = rowsById.get(id);
             if (typeof row === 'undefined') { continue; }
             results.push(this._createTerm(matchSource, matchType2, row, itemIndex));
         }
+        const createTermsElapsedMs = Math.max(0, safePerformance.now() - createTermsStartedAt);
+        Object.defineProperty(results, 'timingDiagnostics', {
+            value: {
+                path: matchType,
+                buildMatchesElapsedMs,
+                fetchTermRowsElapsedMs,
+                createTermsElapsedMs,
+                totalElapsedMs: Math.max(0, safePerformance.now() - totalStartedAt),
+                requestedTermCount: termList.length,
+                uniqueQueryCount: uniqueQueryMap.size,
+                matchedIdCount: idMatches.size,
+                resultCount: results.length,
+                prefixBucketKeyMaxLength: DIRECT_TERM_PREFIX_BUCKET_MAX_LENGTH,
+                prefixBucketHitCount,
+                prefixBucketMissCount,
+                prefixBucketCandidateValueCount,
+                scannedValueCount,
+                fetchTermRows: fetchTermRowsDiagnostics,
+            },
+            configurable: true,
+        });
         return results;
     }
 
@@ -1628,6 +1802,9 @@ export class DictionaryDatabase {
         if (termList.length === 0 || dictionaries.size === 0) {
             return [];
         }
+        if (!this._hasTermMetaTableRows()) {
+            return [];
+        }
         /** @type {import('dictionary-database').TermMeta[]} */
         const results = [];
         const termIndexMap = this._buildTermIndexMap(termList);
@@ -1724,49 +1901,53 @@ export class DictionaryDatabase {
         if (items.length === 0) {
             return [];
         }
+        const totalStartedAt = safePerformance.now();
         const results = new Array(items.length);
-        /** @type {Map<string, number[]>} */
-        const requestIndexes = new Map();
+        /** @type {Map<string, Map<string, number[]>>} */
+        const requestIndexesByDictionary = new Map();
         for (let i = 0; i < items.length; ++i) {
             const item = items[i];
-            const key = `${item.dictionary}\u001f${this._asString(item.query)}`;
-            const itemIndexes = requestIndexes.get(key);
+            const dictionary = item.dictionary;
+            const query = this._asString(item.query);
+            let requestIndexes = requestIndexesByDictionary.get(dictionary);
+            if (typeof requestIndexes === 'undefined') {
+                requestIndexes = new Map();
+                requestIndexesByDictionary.set(dictionary, requestIndexes);
+            }
+            const itemIndexes = requestIndexes.get(query);
             if (typeof itemIndexes === 'undefined') {
-                requestIndexes.set(key, [i]);
+                requestIndexes.set(query, [i]);
             } else {
                 itemIndexes.push(i);
             }
         }
-
-        const uniqueRequests = [...requestIndexes.keys()];
-        for (const requestChunk of this._chunkValues(uniqueRequests, 256)) {
-            /** @type {Record<string, string>} */
-            const bind = {};
-            const conditions = [];
-            for (let i = 0; i < requestChunk.length; ++i) {
-                const [dictionary, query] = requestChunk[i].split('\u001f');
-                const dictionaryKey = `$dictionary${i}`;
-                const queryKey = `$query${i}`;
-                bind[dictionaryKey] = dictionary;
-                bind[queryKey] = query;
-                conditions.push(`(dictionary = ${dictionaryKey} AND name = ${queryKey})`);
-            }
-            const sql = `SELECT name, category, ord as "order", notes, score, dictionary FROM tagMeta WHERE ${conditions.join(' OR ')}`;
-            const stmt = this._getCachedStatement(sql);
-            stmt.reset(true);
-            stmt.bind(bind);
-            while (stmt.step()) {
-                const row = /** @type {import('core').SafeAny} */ (stmt.get({}));
-                const tag = this._deserializeTagRow(row);
-                const itemIndexes = requestIndexes.get(`${tag.dictionary}\u001f${tag.name}`);
-                if (typeof itemIndexes === 'undefined') { continue; }
+        const timingDiagnostics = {
+            requestedItemCount: items.length,
+            uniqueDictionaryCount: requestIndexesByDictionary.size,
+            uniqueQueryCount: 0,
+            cacheHitDictionaryCount: 0,
+            cacheMissDictionaryCount: 0,
+            loadedTagCount: 0,
+            indexBuildElapsedMs: 0,
+        };
+        for (const [dictionary, requestIndexes] of requestIndexesByDictionary) {
+            timingDiagnostics.uniqueQueryCount += requestIndexes.size;
+            const tagIndex = this._ensureTagMetaIndex(dictionary, timingDiagnostics);
+            for (const [query, itemIndexes] of requestIndexes) {
+                const tag = tagIndex.get(query);
+                if (typeof tag === 'undefined') { continue; }
                 for (const itemIndex of itemIndexes) {
-                    if (typeof results[itemIndex] === 'undefined') {
-                        results[itemIndex] = tag;
-                    }
+                    results[itemIndex] = tag;
                 }
             }
         }
+        Object.defineProperty(results, 'timingDiagnostics', {
+            value: {
+                ...timingDiagnostics,
+                totalElapsedMs: Math.max(0, safePerformance.now() - totalStartedAt),
+            },
+            configurable: true,
+        });
 
         return results;
     }
@@ -1777,12 +1958,8 @@ export class DictionaryDatabase {
      * @returns {Promise<?import('dictionary-database').Tag>}
      */
     async findTagForTitle(name, dictionary) {
-        const db = this._requireDb();
-        const row = db.selectObject(
-            'SELECT name, category, ord as "order", notes, score, dictionary FROM tagMeta WHERE name = $name AND dictionary = $dictionary LIMIT 1',
-            {$name: name, $dictionary: dictionary},
-        );
-        return typeof row === 'undefined' ? null : this._deserializeTagRow(row);
+        const tag = this._ensureTagMetaIndex(dictionary).get(name);
+        return typeof tag === 'undefined' ? null : tag;
     }
 
     /**
@@ -2299,6 +2476,7 @@ export class DictionaryDatabase {
         this._clearTermEntryContentMetaCaches();
         this._termExactPresenceCache.clear();
         this._termPrefixNegativeCache.clear();
+        this._tagMetaIndexByDictionary.clear();
         this._directTermIndexByDictionary.clear();
         this._sharedGlossaryArtifactMetaByDictionary.clear();
         this._sharedGlossaryArtifactInflatedByDictionary.clear();
@@ -2331,6 +2509,8 @@ export class DictionaryDatabase {
             this._termExactPresenceCache.clear();
             this._termPrefixNegativeCache.clear();
             this._directTermIndexByDictionary.clear();
+        } else if (objectStoreName === 'termMeta') {
+            this._invalidateTermMetaTableHasRowsCache();
         }
 
         if (objectStoreName === 'terms') {
@@ -2450,7 +2630,23 @@ export class DictionaryDatabase {
             contentDictName,
             uncompressedLength: Math.max(0, uncompressedLength),
         });
-        this._sharedGlossaryArtifactInflatedByDictionary.delete(dictionary);
+        let inflatedBytes = null;
+        if (contentDictName === RAW_TERM_CONTENT_SHARED_GLOSSARY_DICT_NAME) {
+            inflatedBytes = bytes;
+        } else if (contentDictName === RAW_TERM_CONTENT_COMPRESSED_SHARED_GLOSSARY_DICT_NAME) {
+            try {
+                const defaultHeapSize = uncompressedLength > 0 ? uncompressedLength : (bytes.byteLength * 16);
+                inflatedBytes = zstdDecompress(bytes, {defaultHeapSize});
+            } catch (e) {
+                logTermContentZstdError(e);
+                inflatedBytes = null;
+            }
+        }
+        if (inflatedBytes instanceof Uint8Array) {
+            this._sharedGlossaryArtifactInflatedByDictionary.set(dictionary, inflatedBytes);
+        } else {
+            this._sharedGlossaryArtifactInflatedByDictionary.delete(dictionary);
+        }
         return span;
     }
 
@@ -2698,6 +2894,10 @@ export class DictionaryDatabase {
         let pendingContentHash2s = [];
         /** @type {Uint8Array[]} */
         let pendingContentBytes = [];
+        /** @type {(string|null)[]} */
+        let pendingContentDictNameOverrides = [];
+        /** @type {string[]} */
+        let pendingContentLocalityKeys = [];
         /** @type {Map<string, number>|null} */
         let pendingContentRowIndexByHash = shouldDedupWithinBatch ? new Map() : null;
         /** @type {Map<number, Map<number, number>>|null} */
@@ -2717,6 +2917,8 @@ export class DictionaryDatabase {
                     pendingContentHash1s = [];
                     pendingContentHash2s = [];
                     pendingContentBytes = [];
+                    pendingContentDictNameOverrides = [];
+                    pendingContentLocalityKeys = [];
                     if (pendingContentRowIndexByHash !== null) {
                         pendingContentRowIndexByHash.clear();
                     }
@@ -2728,14 +2930,39 @@ export class DictionaryDatabase {
 
                 if (pendingContentBytes.length > 0) {
                     totalPendingContentUniqueCount += pendingContentBytes.length;
+                    if (pendingContentLocalityKeys.length > 1) {
+                        const sortedPendingIndexes = pendingContentLocalityKeys
+                            .map((_, index) => index)
+                            .sort((a, b) => {
+                                const keyA = pendingContentLocalityKeys[a];
+                                const keyB = pendingContentLocalityKeys[b];
+                                if (keyA < keyB) { return -1; }
+                                if (keyA > keyB) { return 1; }
+                                return a - b;
+                            });
+                        /** @type {number[]} */
+                        const pendingIndexRemap = new Array(sortedPendingIndexes.length);
+                        pendingContentHashes = sortedPendingIndexes.map((index, nextIndex) => {
+                            pendingIndexRemap[index] = nextIndex;
+                            return pendingContentHashes[index];
+                        });
+                        pendingContentHash1s = sortedPendingIndexes.map((index) => pendingContentHash1s[index]);
+                        pendingContentHash2s = sortedPendingIndexes.map((index) => pendingContentHash2s[index]);
+                        pendingContentBytes = sortedPendingIndexes.map((index) => pendingContentBytes[index]);
+                        pendingContentDictNameOverrides = sortedPendingIndexes.map((index) => pendingContentDictNameOverrides[index]);
+                        pendingContentLocalityKeys = sortedPendingIndexes.map((index) => pendingContentLocalityKeys[index]);
+                        for (let i = 0, ii = stagedPendingContentIndexes.length; i < ii; ++i) {
+                            const pendingIndex = stagedPendingContentIndexes[i];
+                            if (pendingIndex >= 0) {
+                                stagedPendingContentIndexes[i] = pendingIndexRemap[pendingIndex];
+                            }
+                        }
+                    }
                     const tCompressStart = safePerformance.now();
                     const storageChunks = this._createTermContentStorageChunks(
                         pendingContentBytes,
                         compressionDictName,
-                        stagedRows.map((row, index) => {
-                            const pendingIndex = stagedPendingContentIndexes[index];
-                            return pendingIndex >= 0 ? (row.termEntryContentDictName ?? null) : null;
-                        }),
+                        pendingContentDictNameOverrides,
                     );
                     compressContentMs += safePerformance.now() - tCompressStart;
                     const tAppendStart = safePerformance.now();
@@ -2824,6 +3051,8 @@ export class DictionaryDatabase {
                 pendingContentHash1s = [];
                 pendingContentHash2s = [];
                 pendingContentBytes = [];
+                pendingContentDictNameOverrides = [];
+                pendingContentLocalityKeys = [];
                 pendingContentRowIndexByHash = shouldDedupWithinBatch ? new Map() : null;
                 pendingContentRowIndexByHashPair = shouldDedupWithinBatch ? new Map() : null;
             };
@@ -2908,6 +3137,8 @@ export class DictionaryDatabase {
                     pendingContentHash1s.push(contentHash1);
                     pendingContentHash2s.push(contentHash2);
                     pendingContentBytes.push(contentBytes);
+                    pendingContentDictNameOverrides.push(row.termEntryContentDictName ?? null);
+                    pendingContentLocalityKeys.push(getTermContentLocalityKey(row));
                 }
 
                 stagedRows.push(row);
@@ -4388,13 +4619,40 @@ export class DictionaryDatabase {
 
     /**
      * @param {Iterable<number>} ids
-     * @returns {Promise<Map<number, import('dictionary-database').DatabaseTermEntryWithId>>}
+     * @returns {Promise<{rowsById: Map<number, import('dictionary-database').DatabaseTermEntryWithId>, timingDiagnostics: Record<string, unknown>}>}
      */
     async _fetchTermRowsByIds(ids) {
+        const totalStartedAt = safePerformance.now();
+        const ensureLoadedForReadStartedAt = safePerformance.now();
         await this._termContentStore.ensureLoadedForRead();
+        const ensureLoadedForReadElapsedMs = Math.max(0, safePerformance.now() - ensureLoadedForReadStartedAt);
         /** @type {Map<number, import('dictionary-database').DatabaseTermEntryWithId>} */
         const rowsById = new Map();
+        const getRecordsByIdStartedAt = safePerformance.now();
         const recordsById = this._termRecordStore.getByIds(ids);
+        const getRecordsByIdElapsedMs = Math.max(0, safePerformance.now() - getRecordsByIdStartedAt);
+        /** @type {{rowCount: number, cacheHitCount: number, cacheMissCount: number, externalContentSpanCount: number, contentReadElapsedMs: number, nestedGlossaryReadElapsedMs: number, parseElapsedMs: number, contentReadBytes: number, contentReadSinglePageSliceCount: number, contentReadMultiPageSliceCount: number, contentReadPageCount: number, nestedGlossaryReadBytes: number, nestedGlossaryReadPageCount: number, readPageCacheHitCount: number, readPageCacheMissCount: number, readFileCallCount: number, readFileBytes: number}} */
+        const deserializeDiagnostics = {
+            rowCount: 0,
+            cacheHitCount: 0,
+            cacheMissCount: 0,
+            externalContentSpanCount: 0,
+            contentReadElapsedMs: 0,
+            nestedGlossaryReadElapsedMs: 0,
+            parseElapsedMs: 0,
+            contentReadBytes: 0,
+            contentReadSinglePageSliceCount: 0,
+            contentReadMultiPageSliceCount: 0,
+            contentReadPageCount: 0,
+            nestedGlossaryReadBytes: 0,
+            nestedGlossaryReadPageCount: 0,
+            readPageCacheHitCount: 0,
+            readPageCacheMissCount: 0,
+            readFileCallCount: 0,
+            readFileBytes: 0,
+        };
+        const readDiagnosticsBefore = this._termContentStore.getReadDiagnostics();
+        const deserializeTermRowsStartedAt = safePerformance.now();
         for (const [id, record] of recordsById) {
             const row = await this._deserializeTermRow({
                 id,
@@ -4413,22 +4671,44 @@ export class DictionaryDatabase {
                 score: record.score,
                 glossaryJson: '[]',
                 sequence: record.sequence,
-            });
+            }, deserializeDiagnostics);
             rowsById.set(id, row);
         }
-        return rowsById;
+        const readDiagnosticsAfter = this._termContentStore.getReadDiagnostics();
+        deserializeDiagnostics.readPageCacheHitCount = Math.max(0, readDiagnosticsAfter.cacheHitCount - readDiagnosticsBefore.cacheHitCount);
+        deserializeDiagnostics.readPageCacheMissCount = Math.max(0, readDiagnosticsAfter.cacheMissCount - readDiagnosticsBefore.cacheMissCount);
+        deserializeDiagnostics.readFileCallCount = Math.max(0, readDiagnosticsAfter.fileReadCallCount - readDiagnosticsBefore.fileReadCallCount);
+        deserializeDiagnostics.readFileBytes = Math.max(0, readDiagnosticsAfter.fileReadBytes - readDiagnosticsBefore.fileReadBytes);
+        const deserializeTermRowsElapsedMs = Math.max(0, safePerformance.now() - deserializeTermRowsStartedAt);
+        return {
+            rowsById,
+            timingDiagnostics: {
+                ensureLoadedForReadElapsedMs,
+                getRecordsByIdElapsedMs,
+                deserializeTermRowsElapsedMs,
+                totalElapsedMs: Math.max(0, safePerformance.now() - totalStartedAt),
+                ...deserializeDiagnostics,
+            },
+        };
     }
 
     /**
      * @param {import('core').SafeAny} row
+     * @param {{rowCount: number, cacheHitCount: number, cacheMissCount: number, externalContentSpanCount: number, contentReadElapsedMs: number, nestedGlossaryReadElapsedMs: number, parseElapsedMs: number, contentReadBytes: number, contentReadSinglePageSliceCount: number, contentReadMultiPageSliceCount: number, contentReadPageCount: number, nestedGlossaryReadBytes: number, nestedGlossaryReadPageCount: number, readPageCacheHitCount: number, readPageCacheMissCount: number, readFileCallCount: number, readFileBytes: number}|null} [timingDiagnostics]
      * @returns {Promise<import('dictionary-database').DatabaseTermEntryWithId>}
      */
-    async _deserializeTermRow(row) {
+    async _deserializeTermRow(row, timingDiagnostics = null) {
+        if (timingDiagnostics !== null) {
+            ++timingDiagnostics.rowCount;
+        }
         const entryContentId = this._asNullableNumber(row.entryContentId);
         const contentOffset = this._asNumber(row.entryContentOffset, -1);
         const contentLength = this._asNumber(row.entryContentLength, -1);
         const contentDictName = this._asNullableString(row.entryContentDictName) ?? '';
         const hasExternalContentSpan = contentOffset >= 0 && contentLength > 0;
+        if (timingDiagnostics !== null && hasExternalContentSpan) {
+            ++timingDiagnostics.externalContentSpanCount;
+        }
         const cacheKey = hasExternalContentSpan ?
             `span:${contentOffset}:${contentLength}:${contentDictName}` :
             (typeof entryContentId === 'number' && entryContentId > 0 ? `id:${entryContentId}` : '');
@@ -4446,135 +4726,13 @@ export class DictionaryDatabase {
         if (cacheKey.length > 0) {
             let cached = this._getCachedTermEntryContent(cacheKey);
             if (typeof cached === 'undefined') {
-                /** @type {Uint8Array|null} */
-                let contentBytes = null;
-                if (contentOffset >= 0 && contentLength > 0) {
-                    try {
-                        contentBytes = await this._termContentStore.readSlice(contentOffset, contentLength);
-                    } catch (e) {
-                        logTermContentZstdError(e);
-                        contentBytes = null;
-                    }
+                if (timingDiagnostics !== null) {
+                    ++timingDiagnostics.cacheMissCount;
                 }
-                if (contentBytes !== null && contentBytes.length > 0) {
-                    try {
-                        const rawSharedGlossaryHeader = (
-                            contentDictName === RAW_TERM_CONTENT_SHARED_GLOSSARY_DICT_NAME ||
-                            isRawTermContentSharedGlossaryBinary(contentBytes)
-                        ) ?
-                            decodeRawTermContentSharedGlossaryHeader(contentBytes, this._textDecoder) :
-                            null;
-                        if (rawSharedGlossaryHeader !== null) {
-                            definitionTags = this._asNullableString(rawSharedGlossaryHeader.definitionTags) ?? null;
-                            termTags = this._asNullableString(rawSharedGlossaryHeader.termTags);
-                            rules = this._asString(rawSharedGlossaryHeader.rules);
-                            const rawGlossaryJsonBytes = contentDictName === RAW_TERM_CONTENT_COMPRESSED_SHARED_GLOSSARY_DICT_NAME ?
-                                await this._readCompressedSharedGlossarySlice(
-                                    this._asString(row.dictionary),
-                                    rawSharedGlossaryHeader.glossaryOffset,
-                                    rawSharedGlossaryHeader.glossaryLength,
-                                ) :
-                                await this._termContentStore.readSlice(
-                                    rawSharedGlossaryHeader.glossaryOffset,
-                                    rawSharedGlossaryHeader.glossaryLength,
-                                );
-                            const glossaryJson = this._textDecoder.decode(rawGlossaryJsonBytes);
-                            glossary = this._safeParseJson(glossaryJson, []);
-                            cached = {
-                                definitionTags,
-                                termTags,
-                                rules,
-                                glossaryJson,
-                                glossary: Array.isArray(glossary) ? glossary : [],
-                            };
-                        } else {
-                            const rawContentHeader = (
-                                contentDictName === RAW_TERM_CONTENT_DICT_NAME ||
-                                isRawTermContentBinary(contentBytes)
-                            ) ?
-                                decodeRawTermContentHeader(contentBytes, this._textDecoder) :
-                                null;
-                            if (rawContentHeader !== null) {
-                                definitionTags = this._asNullableString(rawContentHeader.definitionTags) ?? null;
-                                termTags = this._asNullableString(rawContentHeader.termTags);
-                                rules = this._asString(rawContentHeader.rules);
-                                const rawGlossaryJsonBytes = getRawTermContentGlossaryJsonBytes(
-                                    contentBytes,
-                                    rawContentHeader.glossaryJsonOffset,
-                                    rawContentHeader.glossaryJsonLength,
-                                );
-                                const glossaryJson = this._textDecoder.decode(rawGlossaryJsonBytes);
-                                glossary = this._safeParseJson(glossaryJson, []);
-                                cached = {
-                                    definitionTags,
-                                    termTags,
-                                    rules,
-                                    glossaryJson,
-                                    glossary: Array.isArray(glossary) ? glossary : [],
-                                };
-                            } else {
-                                const contentJson = (contentDictName === 'raw') ?
-                                    this._textDecoder.decode(contentBytes) :
-                                    this._textDecoder.decode(decompressTermContentZstd(contentBytes, contentDictName.length > 0 ? contentDictName : null));
-                                const parsedHeader = this._parseSerializedTermEntryContentHeader(contentJson);
-                                if (parsedHeader !== null) {
-                                    definitionTags = parsedHeader.definitionTags;
-                                    termTags = parsedHeader.termTags;
-                                    rules = parsedHeader.rules;
-                                    glossary = this._safeParseJson(parsedHeader.glossaryJson, []);
-                                    cached = {
-                                        definitionTags,
-                                        termTags,
-                                        rules,
-                                        glossaryJson: parsedHeader.glossaryJson,
-                                        glossary: Array.isArray(glossary) ? glossary : [],
-                                    };
-                                } else {
-                                    const content = /** @type {{rules?: string, definitionTags?: string, termTags?: string, glossary?: import('dictionary-data').TermGlossary[]}} */ (
-                                        this._safeParseJson(contentJson, {})
-                                    );
-                                    definitionTags = this._asNullableString(content.definitionTags) ?? null;
-                                    termTags = this._asNullableString(content.termTags);
-                                    rules = this._asString(content.rules);
-                                    glossary = Array.isArray(content.glossary) ? content.glossary : [];
-                                    cached = {
-                                        definitionTags,
-                                        termTags,
-                                        rules,
-                                        glossaryJson: JSON.stringify(glossary),
-                                        glossary,
-                                    };
-                                }
-                            }
-                        }
-                    } catch (e) {
-                        logTermContentZstdError(e);
-                        definitionTags = null;
-                        termTags = '';
-                        rules = '';
-                        glossary = [];
-                        cached = {
-                            definitionTags,
-                            termTags,
-                            rules,
-                            glossaryJson: '[]',
-                            glossary,
-                        };
-                    }
-                } else {
-                    definitionTags = null;
-                    termTags = '';
-                    rules = '';
-                    glossary = [];
-                    cached = {
-                        definitionTags,
-                        termTags,
-                        rules,
-                        glossaryJson: '[]',
-                        glossary,
-                    };
-                }
+                cached = await this._loadTermEntryContentCacheEntry(row, contentOffset, contentLength, contentDictName, timingDiagnostics);
                 this._setCachedTermEntryContent(cacheKey, cached);
+            } else if (timingDiagnostics !== null) {
+                ++timingDiagnostics.cacheHitCount;
             }
             definitionTags = cached.definitionTags;
             termTags = cached.termTags;
@@ -4630,6 +4788,166 @@ export class DictionaryDatabase {
             });
         }
         return termEntry;
+    }
+
+    /**
+     * @param {import('core').SafeAny} row
+     * @param {number} contentOffset
+     * @param {number} contentLength
+     * @param {string} contentDictName
+     * @param {{rowCount: number, cacheHitCount: number, cacheMissCount: number, externalContentSpanCount: number, contentReadElapsedMs: number, nestedGlossaryReadElapsedMs: number, parseElapsedMs: number, contentReadBytes: number, contentReadSinglePageSliceCount: number, contentReadMultiPageSliceCount: number, contentReadPageCount: number, nestedGlossaryReadBytes: number, nestedGlossaryReadPageCount: number, readPageCacheHitCount: number, readPageCacheMissCount: number, readFileCallCount: number, readFileBytes: number}|null} timingDiagnostics
+     * @returns {Promise<{definitionTags: string|null, termTags: string|undefined, rules: string, glossaryJson?: string, glossary?: import('dictionary-data').TermGlossary[]}>}
+     */
+    async _loadTermEntryContentCacheEntry(row, contentOffset, contentLength, contentDictName, timingDiagnostics) {
+        /** @type {Uint8Array|null} */
+        let contentBytes = null;
+        if (contentOffset >= 0 && contentLength > 0) {
+            try {
+                if (timingDiagnostics !== null) {
+                    const startPage = Math.floor(contentOffset / TERM_CONTENT_READ_PAGE_SIZE_BYTES_DIAGNOSTIC);
+                    const endPage = Math.floor((contentOffset + contentLength - 1) / TERM_CONTENT_READ_PAGE_SIZE_BYTES_DIAGNOSTIC);
+                    const pageCount = Math.max(1, endPage - startPage + 1);
+                    timingDiagnostics.contentReadBytes += contentLength;
+                    timingDiagnostics.contentReadPageCount += pageCount;
+                    if (pageCount <= 1) {
+                        ++timingDiagnostics.contentReadSinglePageSliceCount;
+                    } else {
+                        ++timingDiagnostics.contentReadMultiPageSliceCount;
+                    }
+                }
+                const contentReadStartedAt = safePerformance.now();
+                contentBytes = await this._termContentStore.readSlice(contentOffset, contentLength);
+                if (timingDiagnostics !== null) {
+                    timingDiagnostics.contentReadElapsedMs += Math.max(0, safePerformance.now() - contentReadStartedAt);
+                }
+            } catch (e) {
+                logTermContentZstdError(e);
+                contentBytes = null;
+            }
+        }
+        if (!(contentBytes !== null && contentBytes.length > 0)) {
+            return {
+                definitionTags: null,
+                termTags: '',
+                rules: '',
+                glossaryJson: '[]',
+                glossary: [],
+            };
+        }
+
+        try {
+            const parseStartedAt = safePerformance.now();
+            const rawSharedGlossaryHeader = (
+                contentDictName === RAW_TERM_CONTENT_SHARED_GLOSSARY_DICT_NAME ||
+                isRawTermContentSharedGlossaryBinary(contentBytes)
+            ) ?
+                decodeRawTermContentSharedGlossaryHeader(contentBytes, this._textDecoder) :
+                null;
+            /** @type {{definitionTags: string|null, termTags: string|undefined, rules: string, glossaryJson?: string, glossary?: import('dictionary-data').TermGlossary[]}} */
+            let cached;
+            if (rawSharedGlossaryHeader !== null) {
+                const definitionTags = this._asNullableString(rawSharedGlossaryHeader.definitionTags) ?? null;
+                const termTags = this._asNullableString(rawSharedGlossaryHeader.termTags);
+                const rules = this._asString(rawSharedGlossaryHeader.rules);
+                const rawGlossaryJsonBytes = contentDictName === RAW_TERM_CONTENT_COMPRESSED_SHARED_GLOSSARY_DICT_NAME ?
+                    await this._readCompressedSharedGlossarySlice(
+                        this._asString(row.dictionary),
+                        rawSharedGlossaryHeader.glossaryOffset,
+                        rawSharedGlossaryHeader.glossaryLength,
+                    ) :
+                    (() => {
+                        const nestedGlossaryReadStartedAt = safePerformance.now();
+                        return this._termContentStore.readSlice(
+                            rawSharedGlossaryHeader.glossaryOffset,
+                            rawSharedGlossaryHeader.glossaryLength,
+                        ).then((result) => {
+                            if (timingDiagnostics !== null) {
+                                const startPage = Math.floor(rawSharedGlossaryHeader.glossaryOffset / TERM_CONTENT_READ_PAGE_SIZE_BYTES_DIAGNOSTIC);
+                                const endPage = Math.floor((rawSharedGlossaryHeader.glossaryOffset + rawSharedGlossaryHeader.glossaryLength - 1) / TERM_CONTENT_READ_PAGE_SIZE_BYTES_DIAGNOSTIC);
+                                timingDiagnostics.nestedGlossaryReadBytes += rawSharedGlossaryHeader.glossaryLength;
+                                timingDiagnostics.nestedGlossaryReadPageCount += Math.max(1, endPage - startPage + 1);
+                                timingDiagnostics.nestedGlossaryReadElapsedMs += Math.max(0, safePerformance.now() - nestedGlossaryReadStartedAt);
+                            }
+                            return result;
+                        });
+                    })();
+                const glossaryJson = this._textDecoder.decode(rawGlossaryJsonBytes);
+                const glossary = this._safeParseJson(glossaryJson, []);
+                cached = {
+                    definitionTags,
+                    termTags,
+                    rules,
+                    glossaryJson,
+                    glossary: Array.isArray(glossary) ? glossary : [],
+                };
+            } else {
+                const rawContentHeader = (
+                    contentDictName === RAW_TERM_CONTENT_DICT_NAME ||
+                    isRawTermContentBinary(contentBytes)
+                ) ?
+                    decodeRawTermContentHeader(contentBytes, this._textDecoder) :
+                    null;
+                if (rawContentHeader !== null) {
+                    const definitionTags = this._asNullableString(rawContentHeader.definitionTags) ?? null;
+                    const termTags = this._asNullableString(rawContentHeader.termTags);
+                    const rules = this._asString(rawContentHeader.rules);
+                    const rawGlossaryJsonBytes = getRawTermContentGlossaryJsonBytes(
+                        contentBytes,
+                        rawContentHeader.glossaryJsonOffset,
+                        rawContentHeader.glossaryJsonLength,
+                    );
+                    const glossaryJson = this._textDecoder.decode(rawGlossaryJsonBytes);
+                    const glossary = this._safeParseJson(glossaryJson, []);
+                    cached = {
+                        definitionTags,
+                        termTags,
+                        rules,
+                        glossaryJson,
+                        glossary: Array.isArray(glossary) ? glossary : [],
+                    };
+                } else {
+                    const contentJson = (contentDictName === 'raw') ?
+                        this._textDecoder.decode(contentBytes) :
+                        this._textDecoder.decode(decompressTermContentZstd(contentBytes, contentDictName.length > 0 ? contentDictName : null));
+                    const parsedHeader = this._parseSerializedTermEntryContentHeader(contentJson);
+                    if (parsedHeader !== null) {
+                        const glossary = this._safeParseJson(parsedHeader.glossaryJson, []);
+                        cached = {
+                            definitionTags: parsedHeader.definitionTags,
+                            termTags: parsedHeader.termTags,
+                            rules: parsedHeader.rules,
+                            glossaryJson: parsedHeader.glossaryJson,
+                            glossary: Array.isArray(glossary) ? glossary : [],
+                        };
+                    } else {
+                        const content = /** @type {{rules?: string, definitionTags?: string, termTags?: string, glossary?: import('dictionary-data').TermGlossary[]}} */ (
+                            this._safeParseJson(contentJson, {})
+                        );
+                        const glossary = Array.isArray(content.glossary) ? content.glossary : [];
+                        cached = {
+                            definitionTags: this._asNullableString(content.definitionTags) ?? null,
+                            termTags: this._asNullableString(content.termTags),
+                            rules: this._asString(content.rules),
+                            glossaryJson: JSON.stringify(glossary),
+                            glossary,
+                        };
+                    }
+                }
+            }
+            if (timingDiagnostics !== null) {
+                timingDiagnostics.parseElapsedMs += Math.max(0, safePerformance.now() - parseStartedAt);
+            }
+            return cached;
+        } catch (e) {
+            logTermContentZstdError(e);
+            return {
+                definitionTags: null,
+                termTags: '',
+                rules: '',
+                glossaryJson: '[]',
+                glossary: [],
+            };
+        }
     }
 
     /**

--- a/ext/js/dictionary/dictionary-database.js
+++ b/ext/js/dictionary/dictionary-database.js
@@ -227,6 +227,8 @@ export class DictionaryDatabase {
         this._termMetaTableHasRows = null;
         /** @type {number|null} */
         this._maxHeadwordLengthCache = null;
+        /** @type {Map<string, number>} */
+        this._maxHeadwordLengthCacheByDictionaryKey = new Map();
         /** @type {Map<string, Map<string, import('dictionary-database').Tag>>} */
         this._tagMetaIndexByDictionary = new Map();
         /** @type {Map<string, {expression: Map<string, number[]>, reading: Map<string, number[]>, expressionReverse: Map<string, number[]>, readingReverse: Map<string, number[]>, expressionPrefixes: Map<string, string[]>, readingPrefixes: Map<string, string[]>, expressionReversePrefixes: Map<string, string[]>, readingReversePrefixes: Map<string, string[]>, pair: Map<string, number[]>, sequence: Map<number, number[]>}>} */
@@ -986,6 +988,7 @@ export class DictionaryDatabase {
      */
     async _copyTermRowsToDatabase(targetDb) {
         await this._termContentStore.ensureLoadedForRead();
+        await this._termRecordStore.ensureAllShardsLoaded();
         const targetStmt = /** @type {import('@sqlite.org/sqlite-wasm').PreparedStatement} */ (targetDb.prepare(
             'INSERT INTO terms(dictionary, expression, reading, expressionReverse, readingReverse, definitionTags, termTags, rules, score, glossaryJson, sequence) VALUES($dictionary, $expression, $reading, $expressionReverse, $readingReverse, $definitionTags, $termTags, $rules, $score, $glossaryJson, $sequence)',
         ));
@@ -1129,8 +1132,9 @@ export class DictionaryDatabase {
 
         /** @type {number[]} */
         const counts = [];
-        const termCount = this._termRecordStore.getDictionaryIndex(dictionaryName).expression.size > 0 ?
-            [...this._termRecordStore.getDictionaryIndex(dictionaryName).expression.values()].reduce((sum, list) => sum + list.length, 0) :
+        const termIndex = await this._termRecordStore.getDictionaryIndex(dictionaryName);
+        const termCount = termIndex.expression.size > 0 ?
+            [...termIndex.expression.values()].reduce((sum, list) => sum + list.length, 0) :
             0;
         progressData.count += termCount;
         counts.push(termCount);
@@ -1231,6 +1235,15 @@ export class DictionaryDatabase {
     /** */
     _invalidateMaxHeadwordLengthCache() {
         this._maxHeadwordLengthCache = null;
+        this._maxHeadwordLengthCacheByDictionaryKey.clear();
+    }
+
+    /**
+     * @param {string[]} dictionaryNames
+     * @returns {string}
+     */
+    _getDictionarySetCacheKey(dictionaryNames) {
+        return dictionaryNames.join('\u001f');
     }
 
     /** */
@@ -1370,14 +1383,14 @@ export class DictionaryDatabase {
 
     /**
      * @param {string} dictionaryName
-     * @returns {{expression: Map<string, number[]>, reading: Map<string, number[]>, expressionReverse: Map<string, number[]>, readingReverse: Map<string, number[]>, expressionPrefixes: Map<string, string[]>, readingPrefixes: Map<string, string[]>, expressionReversePrefixes: Map<string, string[]>, readingReversePrefixes: Map<string, string[]>, pair: Map<string, number[]>, sequence: Map<number, number[]>}}
+     * @returns {Promise<{expression: Map<string, number[]>, reading: Map<string, number[]>, expressionReverse: Map<string, number[]>, readingReverse: Map<string, number[]>, expressionPrefixes: Map<string, string[]>, readingPrefixes: Map<string, string[]>, expressionReversePrefixes: Map<string, string[]>, readingReversePrefixes: Map<string, string[]>, pair: Map<string, number[]>, sequence: Map<number, number[]>}>}
      */
-    _ensureDirectTermIndex(dictionaryName) {
+    async _ensureDirectTermIndex(dictionaryName) {
         const existing = this._directTermIndexByDictionary.get(dictionaryName);
         if (typeof existing !== 'undefined') {
             return existing;
         }
-        const index = this._termRecordStore.getDictionaryIndex(dictionaryName);
+        const index = await this._termRecordStore.getDictionaryIndex(dictionaryName);
         this._directTermIndexByDictionary.set(dictionaryName, index);
         return index;
     }
@@ -1460,7 +1473,7 @@ export class DictionaryDatabase {
                 const itemIndexes = /** @type {number[]} */ (termIndexMap.get(term));
                 let found = false;
                 for (const dictionaryName of dictionaryNames) {
-                    const index = this._ensureDirectTermIndex(dictionaryName);
+                    const index = await this._ensureDirectTermIndex(dictionaryName);
                     const expressionIds = index.expression.get(term);
                     if (typeof expressionIds !== 'undefined') {
                         found = true;
@@ -1479,7 +1492,7 @@ export class DictionaryDatabase {
                     }
                 }
                 for (const dictionaryName of dictionaryNames) {
-                    const index = this._ensureDirectTermIndex(dictionaryName);
+                    const index = await this._ensureDirectTermIndex(dictionaryName);
                     const readingIds = index.reading.get(term);
                     if (typeof readingIds !== 'undefined') {
                         found = true;
@@ -1559,7 +1572,7 @@ export class DictionaryDatabase {
         const queriesToCheck = [...uniqueQueryMap.values()].filter(({query}) => !this._termPrefixNegativeCache.has(`${negativeCachePrefix}${query}`));
         /** @type {Set<string>} */
         const foundQueries = new Set();
-        const directTermLookups = dictionaryNames.map((dictionaryName) => this._ensureDirectTermIndex(dictionaryName));
+        const directTermLookups = await Promise.all(dictionaryNames.map((dictionaryName) => this._ensureDirectTermIndex(dictionaryName)));
         let prefixBucketHitCount = 0;
         let prefixBucketMissCount = 0;
         let prefixBucketCandidateValueCount = 0;
@@ -1698,7 +1711,7 @@ export class DictionaryDatabase {
             const itemIndexes = termReadingIndexes.get(pair);
             if (typeof itemIndexes === 'undefined') { continue; }
             for (const dictionaryName of dictionaryNames) {
-                const index = this._ensureDirectTermIndex(dictionaryName);
+                const index = await this._ensureDirectTermIndex(dictionaryName);
                 const ids = index.pair.get(pair);
                 if (typeof ids === 'undefined') { continue; }
                 for (const id of ids) {
@@ -1760,7 +1773,7 @@ export class DictionaryDatabase {
         /** @type {Map<number, number[]>} */
         const idMatches = new Map();
         for (const dictionaryName of dictionaryNames) {
-            const index = this._ensureDirectTermIndex(dictionaryName);
+            const index = await this._ensureDirectTermIndex(dictionaryName);
             for (const sequence of sequenceValues) {
                 const ids = index.sequence.get(sequence);
                 if (typeof ids === 'undefined') { continue; }
@@ -2136,9 +2149,42 @@ export class DictionaryDatabase {
     }
 
     /**
+     * @param {string[]|null} [dictionaryNames=null]
      * @returns {Promise<number>}
      */
-    async getMaxHeadwordLength() {
+    async getMaxHeadwordLength(dictionaryNames = null) {
+        if (Array.isArray(dictionaryNames)) {
+            const normalizedDictionaryNames = [...new Set(dictionaryNames
+                .map((value) => this._asString(value).trim())
+                .filter((value) => value.length > 0))]
+                .sort();
+            if (normalizedDictionaryNames.length === 0) {
+                return 0;
+            }
+
+            const cacheKey = this._getDictionarySetCacheKey(normalizedDictionaryNames);
+            const cachedByDictionarySet = this._maxHeadwordLengthCacheByDictionaryKey.get(cacheKey);
+            if (typeof cachedByDictionarySet === 'number') {
+                return cachedByDictionarySet;
+            }
+
+            const db = this._requireDb();
+            const {clause: dictionaryInClause, bind: dictionaryBind} = this._buildTextInClause(normalizedDictionaryNames, 'dict');
+            const value = db.selectValue(`
+                SELECT MAX(
+                    CASE
+                        WHEN LENGTH(COALESCE(reading, '')) > LENGTH(COALESCE(expression, '')) THEN LENGTH(COALESCE(reading, ''))
+                        ELSE LENGTH(COALESCE(expression, ''))
+                    END
+                )
+                FROM terms
+                WHERE dictionary IN (${dictionaryInClause})
+            `, dictionaryBind);
+            const maxHeadwordLength = Math.max(0, this._asNumber(value, 0));
+            this._maxHeadwordLengthCacheByDictionaryKey.set(cacheKey, maxHeadwordLength);
+            return maxHeadwordLength;
+        }
+
         const cached = this._maxHeadwordLengthCache;
         if (typeof cached === 'number') {
             return cached;
@@ -2363,6 +2409,7 @@ export class DictionaryDatabase {
         const counts = [];
 
         if (getTotal) {
+            await this._termRecordStore.ensureAllShardsLoaded();
             /** @type {import('dictionary-database').DictionaryCountGroup} */
             const total = {terms: this._termRecordStore.size};
             for (const table of tables) {
@@ -2374,7 +2421,7 @@ export class DictionaryDatabase {
         for (const dictionaryName of dictionaryNames) {
             /** @type {import('dictionary-database').DictionaryCountGroup} */
             const countGroup = {terms: 0};
-            const termIndex = this._termRecordStore.getDictionaryIndex(dictionaryName);
+            const termIndex = await this._termRecordStore.getDictionaryIndex(dictionaryName);
             countGroup.terms = [...termIndex.expression.values()].reduce((sum, list) => sum + list.length, 0);
             for (const table of tables) {
                 countGroup[table] = this._asNumber(
@@ -3857,6 +3904,7 @@ export class DictionaryDatabase {
         const mediaBefore = this._asNumber(db.selectValue('SELECT COUNT(*) FROM media'), 0);
         const termContentBefore = this._asNumber(db.selectValue('SELECT COUNT(*) FROM termEntryContent'), 0);
         const sharedGlossaryArtifactsBefore = this._asNumber(db.selectValue('SELECT COUNT(*) FROM sharedGlossaryArtifacts'), 0);
+        await this._termRecordStore.ensureAllShardsLoaded();
         const termRecordsBefore = this._termRecordStore.size;
 
         await this._termContentStore.reset();

--- a/ext/js/dictionary/term-content-opfs-store.js
+++ b/ext/js/dictionary/term-content-opfs-store.js
@@ -64,6 +64,8 @@ export class TermContentOpfsStore {
         this._readFile = null;
         /** @type {Map<number, Uint8Array>} */
         this._readPageCache = new Map();
+        /** @type {{cacheHitCount: number, cacheMissCount: number, fileReadCallCount: number, fileReadBytes: number}} */
+        this._readDiagnostics = this._createEmptyReadDiagnostics();
         /** @type {string} */
         this._lastSliceCacheKey = '';
         /** @type {Uint8Array|null} */
@@ -201,6 +203,13 @@ export class TermContentOpfsStore {
             this._lastSliceCacheKey = '';
             this._lastSliceCacheValue = null;
         }
+    }
+
+    /**
+     * @returns {{cacheHitCount: number, cacheMissCount: number, fileReadCallCount: number, fileReadBytes: number}}
+     */
+    getReadDiagnostics() {
+        return {...this._readDiagnostics};
     }
 
     /**
@@ -602,10 +611,10 @@ export class TermContentOpfsStore {
         }
         for (let attempt = 0; attempt < 2; ++attempt) {
             try {
-                const output = new Uint8Array(length);
                 const pageSize = READ_PAGE_SIZE_BYTES;
                 const startPage = Math.floor(offset / pageSize);
                 const endPage = Math.floor((offset + length - 1) / pageSize);
+                const output = new Uint8Array(length);
                 let outputOffset = 0;
                 for (let pageIndex = startPage; pageIndex <= endPage; ++pageIndex) {
                     const page = await this._getReadPage(pageIndex);
@@ -642,6 +651,7 @@ export class TermContentOpfsStore {
     async _getReadPage(pageIndex) {
         const cached = this._readPageCache.get(pageIndex);
         if (typeof cached !== 'undefined') {
+            ++this._readDiagnostics.cacheHitCount;
             this._touchReadPage(pageIndex, cached);
             return cached;
         }
@@ -655,6 +665,9 @@ export class TermContentOpfsStore {
         }
         const pageEnd = Math.min(this._length, pageOffset + READ_PAGE_SIZE_BYTES);
         const bytes = new Uint8Array(await file.slice(pageOffset, pageEnd).arrayBuffer());
+        ++this._readDiagnostics.cacheMissCount;
+        ++this._readDiagnostics.fileReadCallCount;
+        this._readDiagnostics.fileReadBytes += bytes.byteLength;
         this._setReadPage(pageIndex, bytes);
         return bytes;
     }
@@ -710,6 +723,7 @@ export class TermContentOpfsStore {
         this._loadedForRead = false;
         this._readFile = null;
         this._readPageCache.clear();
+        this._readDiagnostics = this._createEmptyReadDiagnostics();
         this._lastSliceCacheKey = '';
         this._lastSliceCacheValue = null;
     }
@@ -892,6 +906,18 @@ export class TermContentOpfsStore {
             flushFinalGroupCount: 0,
             writeCoalesceTargetBytes: this._writeCoalesceTargetBytes,
             writeCoalesceMaxChunks: this._writeCoalesceMaxChunks,
+        };
+    }
+
+    /**
+     * @returns {{cacheHitCount: number, cacheMissCount: number, fileReadCallCount: number, fileReadBytes: number}}
+     */
+    _createEmptyReadDiagnostics() {
+        return {
+            cacheHitCount: 0,
+            cacheMissCount: 0,
+            fileReadCallCount: 0,
+            fileReadBytes: 0,
         };
     }
 

--- a/ext/js/dictionary/term-record-opfs-store.js
+++ b/ext/js/dictionary/term-record-opfs-store.js
@@ -59,6 +59,7 @@ const ENTRY_CONTENT_DICT_NAME_FLAG_READING_EQUALS_EXPRESSION = 0x8000;
 const ENTRY_CONTENT_DICT_NAME_FLAG_READING_REVERSE_EQUALS_EXPRESSION_REVERSE = 0x40000000;
 const ENTRY_CONTENT_DICT_NAME_FLAGS_MASK = 0x8000;
 const ENTRY_CONTENT_DICT_NAME_VALUE_MASK = 0x7fff;
+const DIRECT_TERM_PREFIX_BUCKET_MAX_LENGTH = 2;
 
 /**
  * @typedef {object} TermRecord
@@ -85,6 +86,38 @@ const ENTRY_CONTENT_DICT_NAME_VALUE_MASK = 0x7fff;
  * @property {Uint8Array[]} pendingWriteChunks
  */
 
+/**
+ * @typedef {object} DictionaryTermIndex
+ * @property {Map<string, number[]>} expression
+ * @property {Map<string, number[]>} reading
+ * @property {Map<string, number[]>} expressionReverse
+ * @property {Map<string, number[]>} readingReverse
+ * @property {Map<string, string[]>} expressionPrefixes
+ * @property {Map<string, string[]>} readingPrefixes
+ * @property {Map<string, string[]>} expressionReversePrefixes
+ * @property {Map<string, string[]>} readingReversePrefixes
+ * @property {Map<string, number[]>} pair
+ * @property {Map<number, number[]>} sequence
+ */
+
+/**
+ * @param {string} value
+ * @returns {string[]}
+ */
+function getTermPrefixBucketKeys(value) {
+    /** @type {string[]} */
+    const result = [];
+    let prefix = '';
+    for (const char of value) {
+        prefix += char;
+        result.push(prefix);
+        if (result.length >= DIRECT_TERM_PREFIX_BUCKET_MAX_LENGTH) {
+            break;
+        }
+    }
+    return result;
+}
+
 export class TermRecordOpfsStore {
     constructor() {
         /** @type {FileSystemDirectoryHandle|null} */
@@ -101,7 +134,7 @@ export class TermRecordOpfsStore {
         this._recordsById = new Map();
         /** @type {number} */
         this._nextId = 1;
-        /** @type {Map<string, {expression: Map<string, number[]>, reading: Map<string, number[]>, expressionReverse: Map<string, number[]>, readingReverse: Map<string, number[]>, pair: Map<string, number[]>, sequence: Map<number, number[]>}>} */
+        /** @type {Map<string, DictionaryTermIndex>} */
         this._indexByDictionary = new Map();
         /** @type {boolean} */
         this._deferIndexBuild = false;
@@ -697,7 +730,7 @@ export class TermRecordOpfsStore {
 
     /**
      * @param {string} dictionaryName
-     * @returns {{expression: Map<string, number[]>, reading: Map<string, number[]>, expressionReverse: Map<string, number[]>, readingReverse: Map<string, number[]>, pair: Map<string, number[]>, sequence: Map<number, number[]>}}
+     * @returns {DictionaryTermIndex}
      */
     getDictionaryIndex(dictionaryName) {
         this._ensureIndexesReady();
@@ -718,6 +751,10 @@ export class TermRecordOpfsStore {
             reading: new Map(),
             expressionReverse: new Map(),
             readingReverse: new Map(),
+            expressionPrefixes: new Map(),
+            readingPrefixes: new Map(),
+            expressionReversePrefixes: new Map(),
+            readingReversePrefixes: new Map(),
             pair: new Map(),
             sequence: new Map(),
         };
@@ -1766,6 +1803,10 @@ export class TermRecordOpfsStore {
                 reading: new Map(),
                 expressionReverse: new Map(),
                 readingReverse: new Map(),
+                expressionPrefixes: new Map(),
+                readingPrefixes: new Map(),
+                expressionReversePrefixes: new Map(),
+                readingReversePrefixes: new Map(),
                 pair: new Map(),
                 sequence: new Map(),
             };
@@ -1775,13 +1816,14 @@ export class TermRecordOpfsStore {
     }
 
     /**
-     * @param {{expression: Map<string, number[]>, reading: Map<string, number[]>, expressionReverse: Map<string, number[]>, readingReverse: Map<string, number[]>, pair: Map<string, number[]>, sequence: Map<number, number[]>}} index
+     * @param {DictionaryTermIndex} index
      * @param {TermRecord} record
      */
     _addRecordToDictionaryIndex(index, record) {
         const expressionList = index.expression.get(record.expression);
         if (typeof expressionList === 'undefined') {
             index.expression.set(record.expression, [record.id]);
+            this._addValueToPrefixBuckets(index.expressionPrefixes, record.expression);
         } else {
             expressionList.push(record.id);
         }
@@ -1789,6 +1831,7 @@ export class TermRecordOpfsStore {
         const readingList = index.reading.get(record.reading);
         if (typeof readingList === 'undefined') {
             index.reading.set(record.reading, [record.id]);
+            this._addValueToPrefixBuckets(index.readingPrefixes, record.reading);
         } else {
             readingList.push(record.id);
         }
@@ -1796,6 +1839,7 @@ export class TermRecordOpfsStore {
             const expressionReverseList = index.expressionReverse.get(record.expressionReverse);
             if (typeof expressionReverseList === 'undefined') {
                 index.expressionReverse.set(record.expressionReverse, [record.id]);
+                this._addValueToPrefixBuckets(index.expressionReversePrefixes, record.expressionReverse);
             } else {
                 expressionReverseList.push(record.id);
             }
@@ -1804,6 +1848,7 @@ export class TermRecordOpfsStore {
             const readingReverseList = index.readingReverse.get(record.readingReverse);
             if (typeof readingReverseList === 'undefined') {
                 index.readingReverse.set(record.readingReverse, [record.id]);
+                this._addValueToPrefixBuckets(index.readingReversePrefixes, record.readingReverse);
             } else {
                 readingReverseList.push(record.id);
             }
@@ -1823,6 +1868,21 @@ export class TermRecordOpfsStore {
                 index.sequence.set(record.sequence, [record.id]);
             } else {
                 sequenceList.push(record.id);
+            }
+        }
+    }
+
+    /**
+     * @param {Map<string, string[]>} prefixes
+     * @param {string} value
+     */
+    _addValueToPrefixBuckets(prefixes, value) {
+        for (const prefix of getTermPrefixBucketKeys(value)) {
+            const bucket = prefixes.get(prefix);
+            if (typeof bucket === 'undefined') {
+                prefixes.set(prefix, [value]);
+            } else {
+                bucket.push(value);
             }
         }
     }

--- a/ext/js/dictionary/term-record-opfs-store.js
+++ b/ext/js/dictionary/term-record-opfs-store.js
@@ -78,8 +78,10 @@ const DIRECT_TERM_PREFIX_BUCKET_MAX_LENGTH = 2;
 
 /**
  * @typedef {object} TermRecordShardState
+ * @property {string|null} dictionaryName
  * @property {string} fileName
  * @property {FileSystemFileHandle} fileHandle
+ * @property {boolean} loaded
  * @property {FileSystemWritableFileStream|null} writable
  * @property {number} fileLength
  * @property {number} pendingWriteBytes
@@ -126,6 +128,8 @@ export class TermRecordOpfsStore {
         this._recordsDirectoryHandle = null;
         /** @type {Map<string, TermRecordShardState>} */
         this._shardStateByFileName = new Map();
+        /** @type {Set<string>} */
+        this._loadedDictionaryNames = new Set();
         /** @type {number} */
         this._flushThresholdBytes = this._computeFlushThresholdBytes();
         /** @type {boolean} */
@@ -148,6 +152,8 @@ export class TermRecordOpfsStore {
         this._wasmEncoderUnavailable = false;
         /** @type {string[]} */
         this._invalidShardFileNames = [];
+        /** @type {boolean} */
+        this._allShardsLoaded = true;
         /** @type {number} */
         this._writeCoalesceTargetBytes = this._computeWriteCoalesceTargetBytes();
     }
@@ -165,7 +171,9 @@ export class TermRecordOpfsStore {
         this._rootDirectoryHandle = null;
         this._recordsDirectoryHandle = null;
         this._shardStateByFileName.clear();
+        this._loadedDictionaryNames.clear();
         this._invalidShardFileNames = [];
+        this._allShardsLoaded = true;
         if (typeof navigator === 'undefined' || !('storage' in navigator) || !('getDirectory' in navigator.storage)) {
             return;
         }
@@ -175,7 +183,7 @@ export class TermRecordOpfsStore {
 
         const shardFileCount = await this._loadShardFiles();
         await (shardFileCount === 0 ? this._migrateLegacyMonolithicIfPresent() : this._deleteLegacyMonolithicIfPresent());
-        await this.verifyIntegrity();
+        this._updateAllShardsLoadedFlag();
     }
 
     /**
@@ -185,6 +193,7 @@ export class TermRecordOpfsStore {
         if (this._importSessionActive) {
             return;
         }
+        await this.ensureAllShardsLoaded();
         this._importSessionActive = true;
         this._deferIndexBuild = true;
         this._indexDirty = true;
@@ -223,7 +232,9 @@ export class TermRecordOpfsStore {
         this._deferIndexBuild = false;
         this._indexDirty = false;
         this._shardStateByFileName.clear();
+        this._loadedDictionaryNames.clear();
         this._invalidShardFileNames = [];
+        this._allShardsLoaded = true;
         if (this._recordsDirectoryHandle === null) {
             return;
         }
@@ -258,6 +269,7 @@ export class TermRecordOpfsStore {
      */
     async appendBatch(records) {
         if (records.length === 0) { return; }
+        await this.ensureAllShardsLoaded();
         /** @type {Map<string, TermRecord[]>} */
         const recordsByDictionary = new Map();
         for (const row of records) {
@@ -308,6 +320,7 @@ export class TermRecordOpfsStore {
      */
     async appendBatchFromTermRows(rows, start, count) {
         if (count <= 0) { return; }
+        await this.ensureAllShardsLoaded();
         /** @type {Map<string, TermRecord[]>|null} */
         let recordsByDictionary = null;
         /** @type {TermRecord[]} */
@@ -390,6 +403,7 @@ export class TermRecordOpfsStore {
         if (contentOffsets.length < (start + count) || contentLengths.length < (start + count) || contentDictNames.length < (start + count)) {
             throw new Error('appendBatchFromResolvedImportTermEntries content refs length is smaller than row count');
         }
+        await this.ensureAllShardsLoaded();
         const tBuildStart = safePerformance.now();
         let buildRecordsMs = 0;
         let encodeMs = 0;
@@ -481,6 +495,7 @@ export class TermRecordOpfsStore {
         if (spans.length < count) {
             throw new Error('appendBatchFromImportTermEntries spans length is smaller than row count');
         }
+        await this.ensureAllShardsLoaded();
         /** @type {Map<string, TermRecord[]>|null} */
         let recordsByDictionary = null;
         /** @type {TermRecord[]} */
@@ -564,6 +579,7 @@ export class TermRecordOpfsStore {
         if (contentOffsets.length < count || contentLengths.length < count) {
             throw new Error('appendBatchFromImportTermEntriesResolvedContent content arrays are smaller than row count');
         }
+        await this.ensureAllShardsLoaded();
         const tBuildStart = safePerformance.now();
         let buildRecordsMs = 0;
         let encodeMs = 0;
@@ -662,6 +678,7 @@ export class TermRecordOpfsStore {
      * @returns {Promise<number>}
      */
     async deleteByDictionary(dictionaryName) {
+        await this._ensureShardLoaded(dictionaryName);
         let deletedCount = 0;
         const ids = [...this._recordsById.keys()];
         for (const id of ids) {
@@ -672,6 +689,8 @@ export class TermRecordOpfsStore {
         }
         this._indexByDictionary.delete(dictionaryName);
         await this._deleteShardByDictionary(dictionaryName);
+        this._loadedDictionaryNames.delete(dictionaryName);
+        this._updateAllShardsLoadedFlag();
         return deletedCount;
     }
 
@@ -684,6 +703,7 @@ export class TermRecordOpfsStore {
         if (currentDictionaryName === nextDictionaryName) {
             return;
         }
+        await this.ensureAllShardsLoaded();
 
         let renamed = false;
         for (const record of this._recordsById.values()) {
@@ -730,9 +750,10 @@ export class TermRecordOpfsStore {
 
     /**
      * @param {string} dictionaryName
-     * @returns {DictionaryTermIndex}
+     * @returns {Promise<DictionaryTermIndex>}
      */
-    getDictionaryIndex(dictionaryName) {
+    async getDictionaryIndex(dictionaryName) {
+        await this._ensureShardLoaded(dictionaryName);
         this._ensureIndexesReady();
         const existing = this._indexByDictionary.get(dictionaryName);
         if (typeof existing !== 'undefined') {
@@ -775,6 +796,24 @@ export class TermRecordOpfsStore {
         }
         this._indexByDictionary.set(dictionaryName, created);
         return created;
+    }
+
+    /**
+     * @returns {Promise<void>}
+     */
+    async ensureAllShardsLoaded() {
+        if (this._allShardsLoaded) {
+            return;
+        }
+        const dictionaryNames = [];
+        for (const state of this._shardStateByFileName.values()) {
+            if (state.loaded || state.dictionaryName === null) { continue; }
+            dictionaryNames.push(state.dictionaryName);
+        }
+        for (const dictionaryName of dictionaryNames) {
+            await this._ensureShardLoaded(dictionaryName);
+        }
+        this._updateAllShardsLoadedFlag();
     }
 
     /**
@@ -1380,8 +1419,11 @@ export class TermRecordOpfsStore {
         if (this._recordsDirectoryHandle === null) {
             return;
         }
+        await this.ensureAllShardsLoaded();
         await this._closeAllWritables();
         this._shardStateByFileName.clear();
+        this._loadedDictionaryNames.clear();
+        this._allShardsLoaded = true;
 
         const existingShardFileNames = await this._listShardFileNames();
         for (const fileName of existingShardFileNames) {
@@ -1417,7 +1459,8 @@ export class TermRecordOpfsStore {
                 fileLength = output.byteLength;
             }
             await writable.close();
-            this._shardStateByFileName.set(fileName, this._createShardState(fileName, fileHandle, fileLength));
+            this._shardStateByFileName.set(fileName, this._createShardState(fileName, dictionaryName, fileHandle, fileLength, true));
+            this._loadedDictionaryNames.add(dictionaryName);
         }
     }
 
@@ -1447,28 +1490,19 @@ export class TermRecordOpfsStore {
             } catch (_) {
                 continue;
             }
-            ++shardFileCount;
-            const state = this._createShardState(name, fileHandle, file.size);
-            this._shardStateByFileName.set(name, state);
-            if (file.size <= 0) {
-                continue;
-            }
-            const arrayBuffer = await file.arrayBuffer();
-            const content = new Uint8Array(arrayBuffer);
-            if (this._isBinaryFormat(content)) {
-                this._loadBinary(content, this._decodeDictionaryNameFromShardFileName(name));
-                continue;
-            }
-            // Invalid shard payloads are discarded so they cannot poison future reads.
-            this._invalidShardFileNames.push(name);
-            this._shardStateByFileName.delete(name);
-            if (this._recordsDirectoryHandle !== null) {
+            const dictionaryName = this._decodeDictionaryNameFromShardFileName(name);
+            if (dictionaryName === null) {
+                this._invalidShardFileNames.push(name);
                 try {
                     await this._recordsDirectoryHandle.removeEntry(name);
                 } catch (_) {
                     // NOP
                 }
+                continue;
             }
+            ++shardFileCount;
+            const state = this._createShardState(name, dictionaryName, fileHandle, file.size);
+            this._shardStateByFileName.set(name, state);
         }
         return shardFileCount;
     }
@@ -1567,8 +1601,9 @@ export class TermRecordOpfsStore {
         }
         const fileHandle = await this._recordsDirectoryHandle.getFileHandle(fileName, {create: true});
         const file = await fileHandle.getFile();
-        const created = this._createShardState(fileName, fileHandle, file.size);
+        const created = this._createShardState(fileName, dictionaryName, fileHandle, file.size, this._loadedDictionaryNames.has(dictionaryName));
         this._shardStateByFileName.set(fileName, created);
+        this._updateAllShardsLoadedFlag();
         return created;
     }
 
@@ -1618,14 +1653,18 @@ export class TermRecordOpfsStore {
 
     /**
      * @param {string} fileName
+     * @param {string|null} dictionaryName
      * @param {FileSystemFileHandle} fileHandle
      * @param {number} fileLength
+     * @param {boolean} [loaded=false]
      * @returns {TermRecordShardState}
      */
-    _createShardState(fileName, fileHandle, fileLength) {
+    _createShardState(fileName, dictionaryName, fileHandle, fileLength, loaded = false) {
         return {
+            dictionaryName,
             fileName,
             fileHandle,
+            loaded,
             writable: null,
             fileLength,
             pendingWriteBytes: 0,
@@ -1772,6 +1811,72 @@ export class TermRecordOpfsStore {
         } catch (_) {
             return null;
         }
+    }
+
+    /**
+     * @param {string} dictionaryName
+     * @returns {Promise<void>}
+     */
+    async _ensureShardLoaded(dictionaryName) {
+        if (this._loadedDictionaryNames.has(dictionaryName)) {
+            return;
+        }
+        const fileName = this._getShardFileName(dictionaryName);
+        const state = this._shardStateByFileName.get(fileName);
+        if (typeof state === 'undefined') {
+            this._loadedDictionaryNames.add(dictionaryName);
+            this._updateAllShardsLoadedFlag();
+            return;
+        }
+        if (state.loaded) {
+            this._loadedDictionaryNames.add(dictionaryName);
+            this._updateAllShardsLoadedFlag();
+            return;
+        }
+        await this._flushPendingWritesForShard(state);
+        let file;
+        try {
+            file = await state.fileHandle.getFile();
+        } catch (_) {
+            return;
+        }
+        state.fileLength = file.size;
+        if (file.size > 0) {
+            const arrayBuffer = await file.arrayBuffer();
+            const content = new Uint8Array(arrayBuffer);
+            if (!this._isBinaryFormat(content)) {
+                this._invalidShardFileNames.push(state.fileName);
+                this._shardStateByFileName.delete(state.fileName);
+                if (this._recordsDirectoryHandle !== null) {
+                    try {
+                        await this._recordsDirectoryHandle.removeEntry(state.fileName);
+                    } catch (_) {
+                        // NOP
+                    }
+                }
+                this._updateAllShardsLoadedFlag();
+                return;
+            }
+            this._loadBinary(content, dictionaryName);
+        }
+        state.loaded = true;
+        this._loadedDictionaryNames.add(dictionaryName);
+        this._updateAllShardsLoadedFlag();
+    }
+
+    /** */
+    _updateAllShardsLoadedFlag() {
+        if (this._shardStateByFileName.size === 0) {
+            this._allShardsLoaded = true;
+            return;
+        }
+        for (const state of this._shardStateByFileName.values()) {
+            if (!state.loaded) {
+                this._allShardsLoaded = false;
+                return;
+            }
+        }
+        this._allShardsLoaded = true;
     }
 
     /** */

--- a/ext/js/display/display-history.js
+++ b/ext/js/display/display-history.js
@@ -298,10 +298,11 @@ export class DisplayHistory extends EventDispatcher {
         while (entry !== null) {
             if (depth > this._maxContentEntries && isObjectNotArray(entry.content)) {
                 const content = /** @type {Record<string, unknown>} */ (entry.content);
-                if (Array.isArray(content.dictionaryEntries)) {
+                if (Array.isArray(content.dictionaryEntries) || typeof content.dictionaryEntriesJson === 'string') {
                     entry.content = {
                         ...content,
                         dictionaryEntries: void 0,
+                        dictionaryEntriesJson: void 0,
                     };
                 }
             }

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -18,11 +18,13 @@
 
 import {ThemeController} from '../app/theme-controller.js';
 import {FrameEndpoint} from '../comm/frame-endpoint.js';
+import {publishDevTimingSnapshot} from '../core/dev-timing-diagnostics.js';
 import {extendApiMap, invokeApiMapHandler} from '../core/api-map.js';
 import {DynamicProperty} from '../core/dynamic-property.js';
 import {EventDispatcher} from '../core/event-dispatcher.js';
 import {EventListenerCollection} from '../core/event-listener-collection.js';
 import {ExtensionError} from '../core/extension-error.js';
+import {parseJson} from '../core/json.js';
 import {log} from '../core/log.js';
 import {safePerformance} from '../core/safe-performance.js';
 import {toError} from '../core/to-error.js';
@@ -42,6 +44,9 @@ import {DisplayNotification} from './display-notification.js';
 import {ElementOverflowController} from './element-overflow-controller.js';
 import {OptionToggleHotkeyHandler} from './option-toggle-hotkey-handler.js';
 import {QueryParser} from './query-parser.js';
+
+const POPUP_DISPLAY_DIAGNOSTICS_DATASET_KEY = 'manabitanDevPopupDisplayDiagnostics';
+const POPUP_DISPLAY_DIAGNOSTICS_EVENT = 'popup-display-phase-summary';
 
 /**
  * @augments EventDispatcher<import('display').Events>
@@ -81,6 +86,10 @@ export class Display extends EventDispatcher {
         this._eventListeners = new EventListenerCollection();
         /** @type {?import('core').TokenObject} */
         this._setContentToken = null;
+        /** @type {?Record<string, unknown>} */
+        this._pendingPopupSetContentDiagnostics = null;
+        /** @type {?Record<string, unknown>} */
+        this._latestSetContentTimingDiagnostics = null;
         /** @type {DisplayContentManager} */
         this._contentManager = new DisplayContentManager(this);
         /** @type {HotkeyHelpController} */
@@ -755,6 +764,42 @@ export class Display extends EventDispatcher {
 
     /** @type {import('display').DirectApiHandler<'displaySetContent'>} */
     _onMessageSetContent({details}) {
+        const content = (
+            typeof details?.content === 'object' &&
+            details.content !== null &&
+            !Array.isArray(details.content)
+        ) ?
+            /** @type {import('display').HistoryContent & Record<string, unknown>} */ (details.content) :
+            null;
+        let providedDictionaryEntriesJsonLength = 0;
+        const providedSerializedDictionaryEntries = (
+            content !== null &&
+            typeof Reflect.get(content, 'dictionaryEntriesJson') === 'string' &&
+            /** @type {string} */ (Reflect.get(content, 'dictionaryEntriesJson')).length > 0
+        );
+        if (providedSerializedDictionaryEntries) {
+            providedDictionaryEntriesJsonLength = /** @type {string} */ (Reflect.get(content, 'dictionaryEntriesJson')).length;
+        }
+        const params = (
+            typeof details?.params === 'object' &&
+            details.params !== null &&
+            !Array.isArray(details.params)
+        ) ?
+            details.params :
+            {};
+        const contentSafe = content !== null ? content : {};
+        const providedDictionaryEntries = Reflect.get(contentSafe, 'dictionaryEntries');
+        this._pendingPopupSetContentDiagnostics = {
+            receivedAtMs: safePerformance.now(),
+            queryLength: String(Reflect.get(params, 'query') || '').length,
+            type: String(Reflect.get(params, 'type') || ''),
+            providedDictionaryEntryCount: Array.isArray(providedDictionaryEntries) ? providedDictionaryEntries.length : 0,
+            lookupParam: Reflect.get(params, 'lookup') ?? null,
+            parseProvidedDictionaryEntriesElapsedMs: 0,
+            parsedProvidedDictionaryEntries: false,
+            providedSerializedDictionaryEntries,
+            providedDictionaryEntriesJsonLength,
+        };
         safePerformance.mark('invokeDisplaySetContent:end');
         this.setContent(details);
     }
@@ -810,6 +855,10 @@ export class Display extends EventDispatcher {
         if (this._historyChangeIgnore) { return; }
 
         safePerformance.mark('display:_onStateChanged:start');
+        const totalStartedAt = safePerformance.now();
+        const pendingPopupSetContentDiagnostics = this._pendingPopupSetContentDiagnostics;
+        this._pendingPopupSetContentDiagnostics = null;
+        this._latestSetContentTimingDiagnostics = null;
 
         /** @type {?import('core').TokenObject} */
         const token = {}; // Unique identifier token
@@ -817,6 +866,7 @@ export class Display extends EventDispatcher {
         try {
             // Clear
             safePerformance.mark('display:_onStateChanged:clear:start');
+            const clearStartedAt = safePerformance.now();
             this._closePopups();
             this._closeAllPopupMenus();
             this._eventListeners.removeAllEventListeners();
@@ -829,9 +879,11 @@ export class Display extends EventDispatcher {
             this._elementOverflowController.clearElements();
             safePerformance.mark('display:_onStateChanged:clear:end');
             safePerformance.measure('display:_onStateChanged:clear', 'display:_onStateChanged:clear:start', 'display:_onStateChanged:clear:end');
+            const clearElapsedMs = Math.max(0, safePerformance.now() - clearStartedAt);
 
             // Prepare
             safePerformance.mark('display:_onStateChanged:prepare:start');
+            const prepareStartedAt = safePerformance.now();
             const urlSearchParams = new URLSearchParams(location.search);
             let type = urlSearchParams.get('type');
             if (type === null && urlSearchParams.get('query') !== null) { type = 'terms'; }
@@ -842,8 +894,10 @@ export class Display extends EventDispatcher {
             this._historyHasChanged = true;
             safePerformance.mark('display:_onStateChanged:prepare:end');
             safePerformance.measure('display:_onStateChanged:prepare', 'display:_onStateChanged:prepare:start', 'display:_onStateChanged:prepare:end');
+            const prepareElapsedMs = Math.max(0, safePerformance.now() - prepareStartedAt);
 
             safePerformance.mark('display:_onStateChanged:setContent:start');
+            const setContentStartedAt = safePerformance.now();
             // Set content
             switch (type) {
                 case 'terms':
@@ -862,7 +916,35 @@ export class Display extends EventDispatcher {
             }
             safePerformance.mark('display:_onStateChanged:setContent:end');
             safePerformance.measure('display:_onStateChanged:setContent', 'display:_onStateChanged:setContent:start', 'display:_onStateChanged:setContent:end');
+            publishDevTimingSnapshot(
+                POPUP_DISPLAY_DIAGNOSTICS_DATASET_KEY,
+                {
+                    ...pendingPopupSetContentDiagnostics,
+                    ...(this._latestSetContentTimingDiagnostics ?? {}),
+                    pageType: this._pageType,
+                    contentType: this._contentType,
+                    clearElapsedMs,
+                    prepareElapsedMs,
+                    setContentElapsedMs: Math.max(0, safePerformance.now() - setContentStartedAt),
+                    totalElapsedMs: Math.max(0, safePerformance.now() - totalStartedAt),
+                    status: 'success',
+                },
+                POPUP_DISPLAY_DIAGNOSTICS_EVENT,
+            );
         } catch (e) {
+            publishDevTimingSnapshot(
+                POPUP_DISPLAY_DIAGNOSTICS_DATASET_KEY,
+                {
+                    ...pendingPopupSetContentDiagnostics,
+                    ...(this._latestSetContentTimingDiagnostics ?? {}),
+                    pageType: this._pageType,
+                    contentType: this._contentType,
+                    totalElapsedMs: Math.max(0, safePerformance.now() - totalStartedAt),
+                    status: 'error',
+                    errorMessage: e instanceof Error ? e.message : String(e),
+                },
+                POPUP_DISPLAY_DIAGNOSTICS_EVENT,
+            );
             this.onError(toError(e));
         }
         safePerformance.mark('display:_onStateChanged:end');
@@ -1378,12 +1460,20 @@ export class Display extends EventDispatcher {
      * @param {import('core').TokenObject} token
      */
     async _setContentTermsOrKanji(type, urlSearchParams, token) {
+        const totalStartedAt = safePerformance.now();
         const lookup = (urlSearchParams.get('lookup') !== 'false');
         const wildcardsEnabled = (urlSearchParams.get('wildcards') !== 'off');
         const hasEnabledDictionaries = this._options ? this._options.dictionaries.some(({enabled}) => enabled) : false;
+        /** @type {Record<string, unknown>} */
+        const timingDiagnostics = {
+            lookup,
+            wildcardsEnabled,
+            hasEnabledDictionaries,
+        };
 
         // Set query
         safePerformance.mark('display:setQuery:start');
+        const setQueryStartedAt = safePerformance.now();
         let query = urlSearchParams.get('query');
         if (query === null) { query = ''; }
         let queryFull = urlSearchParams.get('full');
@@ -1398,6 +1488,9 @@ export class Display extends EventDispatcher {
         this._setQuery(query, queryFull, queryOffset);
         safePerformance.mark('display:setQuery:end');
         safePerformance.measure('display:setQuery', 'display:setQuery:start', 'display:setQuery:end');
+        timingDiagnostics.queryLength = query.length;
+        timingDiagnostics.fullQueryLength = queryFull.length;
+        timingDiagnostics.setQueryElapsedMs = Math.max(0, safePerformance.now() - setQueryStartedAt);
 
         let {state, content} = this._history;
         let changeHistory = false;
@@ -1419,20 +1512,48 @@ export class Display extends EventDispatcher {
         }
 
         let {dictionaryEntries} = content;
+        const dictionaryEntriesJson = (typeof content.dictionaryEntriesJson === 'string' ? content.dictionaryEntriesJson : '');
+        let parseProvidedDictionaryEntriesElapsedMs = 0;
+        let parsedProvidedDictionaryEntries = false;
+        if (!Array.isArray(dictionaryEntries) && dictionaryEntriesJson.length > 0) {
+            const parseProvidedDictionaryEntriesStartedAt = safePerformance.now();
+            const parsedDictionaryEntries = parseJson(dictionaryEntriesJson);
+            parseProvidedDictionaryEntriesElapsedMs = Math.max(0, safePerformance.now() - parseProvidedDictionaryEntriesStartedAt);
+            if (!Array.isArray(parsedDictionaryEntries)) {
+                throw new Error('Invalid serialized dictionary entries payload');
+            }
+            dictionaryEntries = /** @type {import('dictionary').DictionaryEntry[]} */ (parsedDictionaryEntries);
+            parsedProvidedDictionaryEntries = true;
+        }
+        const providedDictionaryEntryCount = Array.isArray(dictionaryEntries) ? dictionaryEntries.length : 0;
+        timingDiagnostics.providedDictionaryEntryCount = providedDictionaryEntryCount;
+        timingDiagnostics.usedProvidedDictionaryEntries = Array.isArray(dictionaryEntries);
+        timingDiagnostics.providedSerializedDictionaryEntries = (dictionaryEntriesJson.length > 0);
+        timingDiagnostics.providedDictionaryEntriesJsonLength = dictionaryEntriesJson.length;
+        timingDiagnostics.parseProvidedDictionaryEntriesElapsedMs = parseProvidedDictionaryEntriesElapsedMs;
+        timingDiagnostics.parsedProvidedDictionaryEntries = parsedProvidedDictionaryEntries;
         if (lookup && Array.isArray(dictionaryEntries)) {
-            dictionaryEntries = void 0;
             content.dictionaryEntries = void 0;
+            content.dictionaryEntriesJson = void 0;
             changeHistory = true;
         }
         if (!Array.isArray(dictionaryEntries)) {
             safePerformance.mark('display:findDictionaryEntries:start');
+            const findDictionaryEntriesStartedAt = safePerformance.now();
             dictionaryEntries = hasEnabledDictionaries && lookup && query.length > 0 ? await this._findDictionaryEntries(type === 'kanji', query, primaryReading, wildcardsEnabled, optionsContext) : [];
             safePerformance.mark('display:findDictionaryEntries:end');
             safePerformance.measure('display:findDictionaryEntries', 'display:findDictionaryEntries:start', 'display:findDictionaryEntries:end');
+            timingDiagnostics.performedDictionaryLookup = true;
+            timingDiagnostics.findDictionaryEntriesElapsedMs = Math.max(0, safePerformance.now() - findDictionaryEntriesStartedAt);
             if (this._setContentToken !== token) { return; }
             content.dictionaryEntries = void 0;
+            content.dictionaryEntriesJson = void 0;
             changeHistory = true;
+        } else {
+            timingDiagnostics.performedDictionaryLookup = false;
+            timingDiagnostics.findDictionaryEntriesElapsedMs = 0;
         }
+        timingDiagnostics.dictionaryEntryCount = dictionaryEntries.length;
 
         let contentOriginValid = false;
         const {contentOrigin} = content;
@@ -1449,12 +1570,18 @@ export class Display extends EventDispatcher {
             changeHistory = true;
         }
 
+        const setOptionsContextStartedAt = safePerformance.now();
         await this._setOptionsContextIfDifferent(optionsContext);
+        timingDiagnostics.setOptionsContextElapsedMs = Math.max(0, safePerformance.now() - setOptionsContextStartedAt);
         if (this._setContentToken !== token) { return; }
 
         if (this._options === null) {
+            const updateOptionsStartedAt = safePerformance.now();
             await this.updateOptions();
+            timingDiagnostics.updateOptionsElapsedMs = Math.max(0, safePerformance.now() - updateOptionsStartedAt);
             if (this._setContentToken !== token) { return; }
+        } else {
+            timingDiagnostics.updateOptionsElapsedMs = 0;
         }
 
         if (changeHistory) {
@@ -1475,49 +1602,72 @@ export class Display extends EventDispatcher {
         container.textContent = '';
 
         safePerformance.mark('display:contentUpdate:start');
+        const contentUpdateStartedAt = safePerformance.now();
+        const shouldYieldBetweenEntries = (this._pageType !== 'popup');
+        const renderYieldIntervalEntries = 8;
+        const renderYieldIntervalMs = 12;
+        let yieldCount = 0;
+        let yieldElapsedMs = 0;
+        let createDictionaryEntryNodesElapsedMs = 0;
+        let createDictionaryEntryGeneratorElapsedMs = 0;
+        let createDictionaryEntryBookkeepingElapsedMs = 0;
+        let addDictionaryEntryNodesElapsedMs = 0;
+        let entriesSinceYield = 0;
+        let lastYieldAt = safePerformance.now();
+        const fragment = document.createDocumentFragment();
         this._triggerContentUpdateStart();
 
         let i = 0;
         for (const dictionaryEntry of dictionaryEntries) {
-            safePerformance.mark('display:createEntry:start');
-
-            if (i > 0) {
-                await promiseTimeout(1);
+            if (
+                shouldYieldBetweenEntries &&
+                i > 0 &&
+                (
+                    entriesSinceYield >= renderYieldIntervalEntries ||
+                    (safePerformance.now() - lastYieldAt) >= renderYieldIntervalMs
+                )
+            ) {
+                const yieldStartedAt = safePerformance.now();
+                await promiseTimeout(0);
+                yieldElapsedMs += Math.max(0, safePerformance.now() - yieldStartedAt);
+                ++yieldCount;
+                entriesSinceYield = 0;
+                lastYieldAt = safePerformance.now();
                 if (this._setContentToken !== token) { return; }
             }
 
-            safePerformance.mark('display:createEntryReal:start');
-
+            const createEntryStartedAt = safePerformance.now();
+            const createEntryGeneratorStartedAt = safePerformance.now();
             const entry = (
                 dictionaryEntry.type === 'term' ?
                 this._displayGenerator.createTermEntry(dictionaryEntry, this._dictionaryInfo) :
                 this._displayGenerator.createKanjiEntry(dictionaryEntry, this._dictionaryInfo)
             );
+            createDictionaryEntryGeneratorElapsedMs += Math.max(0, safePerformance.now() - createEntryGeneratorStartedAt);
+            const createEntryBookkeepingStartedAt = safePerformance.now();
             entry.dataset.index = `${i}`;
             this._dictionaryEntryNodes.push(entry);
             this._addEntryEventListeners(entry);
             this._triggerContentUpdateEntry(dictionaryEntry, entry, i);
             if (this._setContentToken !== token) { return; }
-            container.appendChild(entry);
-
-            if (focusEntry === i) {
-                this._focusEntry(i, 0, false);
-            }
-
+            fragment.appendChild(entry);
             this._elementOverflowController.addElements(entry);
-
-            safePerformance.mark('display:createEntryReal:end');
-            safePerformance.measure('display:createEntryReal', 'display:createEntryReal:start', 'display:createEntryReal:end');
-
-            safePerformance.mark('display:createEntry:end');
-            safePerformance.measure('display:createEntry', 'display:createEntry:start', 'display:createEntry:end');
+            createDictionaryEntryBookkeepingElapsedMs += Math.max(0, safePerformance.now() - createEntryBookkeepingStartedAt);
+            createDictionaryEntryNodesElapsedMs += Math.max(0, safePerformance.now() - createEntryStartedAt);
 
             if (i === 0) {
                 void this._contentManager.executeMediaRequests(); // prioritize loading media for first entry since it is visible
             }
+            ++entriesSinceYield;
             ++i;
         }
         if (this._setContentToken !== token) { return; }
+        const addDictionaryEntryNodesStartedAt = safePerformance.now();
+        container.appendChild(fragment);
+        addDictionaryEntryNodesElapsedMs = Math.max(0, safePerformance.now() - addDictionaryEntryNodesStartedAt);
+        if (focusEntry >= 0 && focusEntry < this._dictionaryEntryNodes.length) {
+            this._focusEntry(focusEntry, 0, false);
+        }
         void this._contentManager.executeMediaRequests();
 
         if (typeof scrollX === 'number' || typeof scrollY === 'number') {
@@ -1531,6 +1681,17 @@ export class Display extends EventDispatcher {
         this._triggerContentUpdateComplete();
         safePerformance.mark('display:contentUpdate:end');
         safePerformance.measure('display:contentUpdate', 'display:contentUpdate:start', 'display:contentUpdate:end');
+        timingDiagnostics.renderedDictionaryEntryCount = i;
+        timingDiagnostics.renderYieldEnabled = shouldYieldBetweenEntries;
+        timingDiagnostics.renderYieldCount = yieldCount;
+        timingDiagnostics.renderYieldElapsedMs = yieldElapsedMs;
+        timingDiagnostics.createDictionaryEntryNodesElapsedMs = createDictionaryEntryNodesElapsedMs;
+        timingDiagnostics.createDictionaryEntryGeneratorElapsedMs = createDictionaryEntryGeneratorElapsedMs;
+        timingDiagnostics.createDictionaryEntryBookkeepingElapsedMs = createDictionaryEntryBookkeepingElapsedMs;
+        timingDiagnostics.addDictionaryEntryNodesElapsedMs = addDictionaryEntryNodesElapsedMs;
+        timingDiagnostics.contentUpdateElapsedMs = Math.max(0, safePerformance.now() - contentUpdateStartedAt);
+        timingDiagnostics.totalElapsedMs = Math.max(0, safePerformance.now() - totalStartedAt);
+        this._latestSetContentTimingDiagnostics = timingDiagnostics;
     }
 
     /** */
@@ -2176,7 +2337,7 @@ export class Display extends EventDispatcher {
     /**
      * @param {import('text-scanner').EventArgument<'searchSuccess'>} details
      */
-    _onContentTextScannerSearchSuccess({type, dictionaryEntries, sentence, textSource, optionsContext}) {
+    _onContentTextScannerSearchSuccess({type, dictionaryEntries, dictionaryEntriesJson, sentence, textSource, optionsContext}) {
         const query = textSource.text();
         const url = window.location.href;
         const documentTitle = document.title;
@@ -2188,6 +2349,7 @@ export class Display extends EventDispatcher {
                 type,
                 query,
                 wildcards: 'off',
+                lookup: 'false',
             },
             state: {
                 focusEntry: 0,
@@ -2198,7 +2360,15 @@ export class Display extends EventDispatcher {
                 pageTheme: 'light',
             },
             content: {
-                dictionaryEntries: dictionaryEntries !== null ? dictionaryEntries : void 0,
+                dictionaryEntries: (
+                    dictionaryEntries !== null &&
+                    (
+                        dictionaryEntries.length > 0 ||
+                        typeof dictionaryEntriesJson !== 'string' ||
+                        dictionaryEntriesJson.length === 0
+                    )
+                ) ? dictionaryEntries : void 0,
+                dictionaryEntriesJson: typeof dictionaryEntriesJson === 'string' ? dictionaryEntriesJson : void 0,
                 contentOrigin: this.getContentOrigin(),
             },
         };

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -88,6 +88,8 @@ export class Display extends EventDispatcher {
         this._setContentToken = null;
         /** @type {?Record<string, unknown>} */
         this._pendingPopupSetContentDiagnostics = null;
+        /** @type {?import('settings').ProfileOptions} */
+        this._pendingResolvedOptions = null;
         /** @type {?Record<string, unknown>} */
         this._latestSetContentTimingDiagnostics = null;
         /** @type {DisplayContentManager} */
@@ -454,15 +456,31 @@ export class Display extends EventDispatcher {
 
     /**
      * @param {import('settings').OptionsContext} optionsContext
+     * @param {?import('settings').ProfileOptions} [resolvedOptions=null]
      */
-    async setOptionsContext(optionsContext) {
+    async setOptionsContext(optionsContext, resolvedOptions = null) {
         this._optionsContext = optionsContext;
+        if (
+            typeof resolvedOptions === 'object' &&
+            resolvedOptions !== null &&
+            !Array.isArray(resolvedOptions)
+        ) {
+            this._applyOptions(/** @type {import('settings').ProfileOptions} */ (resolvedOptions));
+            return;
+        }
         await this.updateOptions();
     }
 
     /** */
     async updateOptions() {
         const options = await this._application.api.optionsGet(this.getOptionsContext());
+        this._applyOptions(options);
+    }
+
+    /**
+     * @param {import('settings').ProfileOptions} options
+     */
+    _applyOptions(options) {
         const {scanning: scanningOptions, sentenceParsing: sentenceParsingOptions} = options;
         this._options = options;
 
@@ -763,7 +781,7 @@ export class Display extends EventDispatcher {
     }
 
     /** @type {import('display').DirectApiHandler<'displaySetContent'>} */
-    _onMessageSetContent({details}) {
+    _onMessageSetContent({details, resolvedOptions}) {
         const content = (
             typeof details?.content === 'object' &&
             details.content !== null &&
@@ -800,6 +818,11 @@ export class Display extends EventDispatcher {
             providedSerializedDictionaryEntries,
             providedDictionaryEntriesJsonLength,
         };
+        this._pendingResolvedOptions = (
+            typeof resolvedOptions === 'object' &&
+            resolvedOptions !== null &&
+            !Array.isArray(resolvedOptions)
+        ) ? /** @type {import('settings').ProfileOptions} */ (resolvedOptions) : null;
         safePerformance.mark('invokeDisplaySetContent:end');
         this.setContent(details);
     }
@@ -906,10 +929,12 @@ export class Display extends EventDispatcher {
                     await this._setContentTermsOrKanji(type, urlSearchParams, token);
                     break;
                 case 'unloaded':
+                    this._pendingResolvedOptions = null;
                     this._contentType = type;
                     this._setContentExtensionUnloaded();
                     break;
                 default:
+                    this._pendingResolvedOptions = null;
                     this._contentType = 'clear';
                     this._clearContent();
                     break;
@@ -1570,8 +1595,10 @@ export class Display extends EventDispatcher {
             changeHistory = true;
         }
 
+        const resolvedOptions = this._pendingResolvedOptions;
+        this._pendingResolvedOptions = null;
         const setOptionsContextStartedAt = safePerformance.now();
-        await this._setOptionsContextIfDifferent(optionsContext);
+        await this._setOptionsContextIfDifferent(optionsContext, resolvedOptions);
         timingDiagnostics.setOptionsContextElapsedMs = Math.max(0, safePerformance.now() - setOptionsContextStartedAt);
         if (this._setContentToken !== token) { return; }
 
@@ -2091,10 +2118,16 @@ export class Display extends EventDispatcher {
 
     /**
      * @param {import('settings').OptionsContext} optionsContext
+     * @param {?import('settings').ProfileOptions} [resolvedOptions=null]
      */
-    async _setOptionsContextIfDifferent(optionsContext) {
-        if (deepEqual(this._optionsContext, optionsContext)) { return; }
-        await this.setOptionsContext(optionsContext);
+    async _setOptionsContextIfDifferent(optionsContext, resolvedOptions = null) {
+        if (deepEqual(this._optionsContext, optionsContext)) {
+            if (resolvedOptions !== null && this._options === null) {
+                this._applyOptions(resolvedOptions);
+            }
+            return;
+        }
+        await this.setOptionsContext(optionsContext, resolvedOptions);
     }
 
     /**

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -120,6 +120,12 @@ export class TextScanner extends EventDispatcher {
         this._delay = 0;
         /** @type {number} */
         this._scanLength = 1;
+        /** @type {?{
+         * configuredScanLength: number,
+         * automaticScanLength: number | null,
+         * effectiveScanLength: number,
+         * }} */
+        this._hoverScanLengthDiagnostics = null;
         /** @type {boolean} */
         this._layoutAwareScan = false;
         /** @type {boolean} */
@@ -281,6 +287,7 @@ export class TextScanner extends EventDispatcher {
         selectText,
         delay,
         scanLength,
+        hoverScanLengthDiagnostics,
         layoutAwareScan,
         preventMiddleMouseOnPage,
         preventMiddleMouseOnTextHover,
@@ -307,6 +314,12 @@ export class TextScanner extends EventDispatcher {
         }
         if (typeof scanLength === 'number') {
             this._scanLength = scanLength;
+        }
+        if (
+            hoverScanLengthDiagnostics === null ||
+            (typeof hoverScanLengthDiagnostics === 'object' && !Array.isArray(hoverScanLengthDiagnostics))
+        ) {
+            this._hoverScanLengthDiagnostics = hoverScanLengthDiagnostics;
         }
         if (typeof layoutAwareScan === 'boolean') {
             this._layoutAwareScan = layoutAwareScan;
@@ -1334,13 +1347,16 @@ export class TextScanner extends EventDispatcher {
      */
     async _findTermDictionaryEntries(textSource, optionsContext) {
         const scanLength = this._scanLength;
+        const hoverScanLengthDiagnostics = this._hoverScanLengthDiagnostics;
         const sentenceScanExtent = this._sentenceScanExtent;
         const sentenceTerminateAtNewlines = this._sentenceTerminateAtNewlines;
         const sentenceTerminatorMap = this._sentenceTerminatorMap;
         const sentenceForwardQuoteMap = this._sentenceForwardQuoteMap;
         const sentenceBackwardQuoteMap = this._sentenceBackwardQuoteMap;
         const layoutAwareScan = this._layoutAwareScan;
+        const getSearchTextStartedAt = safePerformance.now();
         const searchText = this.getTextSourceContent(textSource, scanLength, layoutAwareScan, optionsContext.pointerType);
+        const getSearchTextElapsedMs = Math.max(0, safePerformance.now() - getSearchTextStartedAt);
         if (searchText.length === 0) { return null; }
 
         /** @type {import('api').FindTermsDetails} */
@@ -1395,6 +1411,9 @@ export class TextScanner extends EventDispatcher {
             sentence,
             type: 'terms',
             timingDiagnostics: {
+                ...(hoverScanLengthDiagnostics !== null ? hoverScanLengthDiagnostics : {}),
+                scanLength,
+                getSearchTextElapsedMs,
                 searchTextLength: searchText.length,
                 originalTextLength,
                 apiTermsFindElapsedMs,
@@ -1462,6 +1481,7 @@ export class TextScanner extends EventDispatcher {
 
         const lookupSequence = ++this._lookupSequence;
         this._activeLookupSequence = lookupSequence;
+        const hoverScanLengthDiagnostics = this._hoverScanLengthDiagnostics;
         /** @type {?import('text-source').TextSource} */
         let activeTextSource = null;
         /** @type {Record<string, unknown>} */
@@ -1473,6 +1493,9 @@ export class TextScanner extends EventDispatcher {
             eventType: inputInfo.eventType,
             passive: inputInfo.passive,
         };
+        if (hoverScanLengthDiagnostics !== null) {
+            Object.assign(hoverTimingDiagnostics, hoverScanLengthDiagnostics);
+        }
         const totalStartedAt = safePerformance.now();
         try {
             safePerformance.mark('scanner:_searchAt:start');

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -17,6 +17,7 @@
  */
 
 import {ThemeController} from '../app/theme-controller.js';
+import {publishDevTimingSnapshot} from '../core/dev-timing-diagnostics.js';
 import {EventDispatcher} from '../core/event-dispatcher.js';
 import {EventListenerCollection} from '../core/event-listener-collection.js';
 import {log} from '../core/log.js';
@@ -26,6 +27,8 @@ import {anyNodeMatchesSelector, everyNodeMatchesSelector, getActiveModifiers, ge
 import {TextSourceElement} from '../dom/text-source-element.js';
 
 const SCAN_RESOLUTION_EXCLUDED_LANGUAGES = new Set(['ja', 'zh', 'yue', 'ko']);
+const HOVER_SCANNER_DIAGNOSTICS_DATASET_KEY = 'manabitanDevHoverScannerDiagnostics';
+const HOVER_SCANNER_DIAGNOSTICS_EVENT = 'hover-scanner-phase-summary';
 
 /**
  * @augments EventDispatcher<import('text-scanner').Events>
@@ -482,8 +485,10 @@ export class TextScanner extends EventDispatcher {
      * @param {boolean} showEmpty shows a "No results found" popup if no results are found
      * @param {boolean} disallowExpandStartOffset disallows expanding the start offset of the range
      * @param {?number} lookupSequence
+     * @param {?Record<string, unknown>} searchTimingDiagnostics
      */
-    async _search(textSource, searchTerms, searchKanji, inputInfo, showEmpty = false, disallowExpandStartOffset = false, lookupSequence = null) {
+    async _search(textSource, searchTerms, searchKanji, inputInfo, showEmpty = false, disallowExpandStartOffset = false, lookupSequence = null, searchTimingDiagnostics = null) {
+        const totalStartedAt = safePerformance.now();
         try {
             safePerformance.mark('scanner:_search:start');
             if (this._isLookupStale(lookupSequence)) { return; }
@@ -508,32 +513,67 @@ export class TextScanner extends EventDispatcher {
                 null
             );
 
+            const expandStartOffsetStartedAt = safePerformance.now();
             if (this._scanResolution === 'word' && !disallowExpandStartOffset &&
             (this._language === null || !SCAN_RESOLUTION_EXCLUDED_LANGUAGES.has(this._language))) {
                 // Move the start offset to the beginning of the word
                 textSource.setStartOffset(this._scanLength, this._layoutAwareScan, true);
             }
+            if (searchTimingDiagnostics !== null) {
+                searchTimingDiagnostics.expandStartOffsetElapsedMs = Math.max(0, safePerformance.now() - expandStartOffsetStartedAt);
+            }
 
             if (this._textSourceCurrent !== null && this._textSourceCurrent.hasSameStart(textSource)) {
+                if (searchTimingDiagnostics !== null) {
+                    searchTimingDiagnostics.skippedReason = 'same-start-as-current-selection';
+                }
                 return;
             }
 
+            const getSearchContextStartedAt = safePerformance.now();
             const getSearchContextPromise = this._getSearchContext();
             const getSearchContextResult = getSearchContextPromise instanceof Promise ? await getSearchContextPromise : getSearchContextPromise;
+            if (searchTimingDiagnostics !== null) {
+                searchTimingDiagnostics.getSearchContextElapsedMs = Math.max(0, safePerformance.now() - getSearchContextStartedAt);
+            }
             if (this._isLookupStale(lookupSequence)) { return; }
             const {detail} = getSearchContextResult;
+            const createOptionsContextStartedAt = safePerformance.now();
             const optionsContext = this._createOptionsContextForInput(getSearchContextResult.optionsContext, inputInfo);
+            if (searchTimingDiagnostics !== null) {
+                searchTimingDiagnostics.createOptionsContextElapsedMs = Math.max(0, safePerformance.now() - createOptionsContextStartedAt);
+            }
 
             /** @type {?import('dictionary').DictionaryEntry[]} */
             let dictionaryEntries = null;
+            let dictionaryEntriesJson;
+            let dictionaryEntryCount = 0;
             /** @type {?import('display').HistoryStateSentence} */
             let sentence = null;
             /** @type {'terms'|'kanji'} */
             let type = 'terms';
+            let resultTimingDiagnostics = null;
+            const findDictionaryEntriesStartedAt = safePerformance.now();
             const result = await this._findDictionaryEntries(textSource, searchTerms, searchKanji, optionsContext);
+            if (searchTimingDiagnostics !== null) {
+                searchTimingDiagnostics.findDictionaryEntriesElapsedMs = Math.max(0, safePerformance.now() - findDictionaryEntriesStartedAt);
+            }
             if (this._isLookupStale(lookupSequence)) { return; }
             if (result !== null) {
-                ({dictionaryEntries, sentence, type} = result);
+                ({dictionaryEntries, dictionaryEntriesJson, sentence, type} = result);
+                dictionaryEntryCount = (
+                    typeof result.dictionaryEntryCount === 'number' &&
+                    Number.isFinite(result.dictionaryEntryCount) &&
+                    result.dictionaryEntryCount >= 0
+                ) ?
+                    result.dictionaryEntryCount :
+                    dictionaryEntries.length;
+                if (searchTimingDiagnostics !== null) {
+                    resultTimingDiagnostics = Reflect.get(result, 'timingDiagnostics');
+                    if (typeof resultTimingDiagnostics === 'object' && resultTimingDiagnostics !== null && !Array.isArray(resultTimingDiagnostics)) {
+                        searchTimingDiagnostics.findDictionaryEntriesTimingDiagnostics = resultTimingDiagnostics;
+                    }
+                }
             } else if (showEmpty || (textSource !== null && isAltText && await this._isTextLookupWorthy(textSource.content))) {
                 // Shows a "No results found" message
                 dictionaryEntries = [];
@@ -541,6 +581,7 @@ export class TextScanner extends EventDispatcher {
             }
             if (this._isLookupStale(lookupSequence)) { return; }
 
+            const triggerSearchResultStartedAt = safePerformance.now();
             if (dictionaryEntries !== null && sentence !== null) {
                 this._inputInfoCurrent = inputInfo;
                 this.setCurrentTextSource(textSource);
@@ -551,6 +592,8 @@ export class TextScanner extends EventDispatcher {
                 this.trigger('searchSuccess', {
                     type,
                     dictionaryEntries,
+                    dictionaryEntriesJson,
+                    dictionaryEntryCount,
                     sentence,
                     inputInfo,
                     textSource,
@@ -558,18 +601,38 @@ export class TextScanner extends EventDispatcher {
                     detail,
                     pageTheme,
                 });
+                if (searchTimingDiagnostics !== null) {
+                    searchTimingDiagnostics.resultState = 'success';
+                    searchTimingDiagnostics.resultType = type;
+                    searchTimingDiagnostics.dictionaryEntryCount = dictionaryEntryCount;
+                    searchTimingDiagnostics.sentenceTextLength = sentence.text.length;
+                }
             } else {
                 this._triggerSearchEmpty(inputInfo);
+                if (searchTimingDiagnostics !== null) {
+                    searchTimingDiagnostics.resultState = 'empty';
+                }
+            }
+            if (searchTimingDiagnostics !== null) {
+                searchTimingDiagnostics.triggerResultElapsedMs = Math.max(0, safePerformance.now() - triggerSearchResultStartedAt);
             }
             safePerformance.mark('scanner:_search:end');
             safePerformance.measure('scanner:_search', 'scanner:_search:start', 'scanner:_search:end');
         } catch (error) {
             if (this._isLookupStale(lookupSequence)) { return; }
+            if (searchTimingDiagnostics !== null) {
+                searchTimingDiagnostics.resultState = 'error';
+                searchTimingDiagnostics.errorMessage = error instanceof Error ? error.message : String(error);
+            }
             this.trigger('searchError', {
                 error: error instanceof Error ? error : new Error(`A search error occurred: ${error}`),
                 textSource,
                 inputInfo,
             });
+        } finally {
+            if (searchTimingDiagnostics !== null) {
+                searchTimingDiagnostics.totalElapsedMs = Math.max(0, safePerformance.now() - totalStartedAt);
+            }
         }
     }
 
@@ -1281,10 +1344,38 @@ export class TextScanner extends EventDispatcher {
         if (searchText.length === 0) { return null; }
 
         /** @type {import('api').FindTermsDetails} */
-        const details = {};
-        const {dictionaryEntries, originalTextLength} = await this._api.termsFind(searchText, details, optionsContext);
-        if (dictionaryEntries.length === 0) { return null; }
+        const details = {
+            includeTimingDiagnostics: (
+                Reflect.get(globalThis, 'manabitanDevIncludeApiTimingDiagnostics') === true ||
+                document.documentElement?.dataset.manabitanDevIncludeApiTimingDiagnostics === 'true'
+            ),
+            serializeDictionaryEntries: true,
+        };
+        const apiTermsFindStartedAt = safePerformance.now();
+        const {
+            dictionaryEntries: dictionaryEntriesRaw,
+            dictionaryEntriesJson,
+            dictionaryEntryCount: dictionaryEntryCountRaw = null,
+            originalTextLength,
+            timingDiagnostics = null,
+        } = await this._api.termsFind(searchText, details, optionsContext);
+        const apiTermsFindElapsedMs = Math.max(0, safePerformance.now() - apiTermsFindStartedAt);
+        let dictionaryEntries = dictionaryEntriesRaw;
+        let serializedDictionaryEntriesLength = 0;
+        const serializedDictionaryEntries = (typeof dictionaryEntriesJson === 'string' && dictionaryEntriesJson.length > 0);
+        if (serializedDictionaryEntries) {
+            serializedDictionaryEntriesLength = dictionaryEntriesJson.length;
+        }
+        const dictionaryEntryCount = (
+            typeof dictionaryEntryCountRaw === 'number' &&
+            Number.isFinite(dictionaryEntryCountRaw) &&
+            dictionaryEntryCountRaw >= 0
+        ) ?
+            dictionaryEntryCountRaw :
+            dictionaryEntries.length;
+        if (dictionaryEntryCount === 0) { return null; }
 
+        const extractSentenceStartedAt = safePerformance.now();
         textSource.setEndOffset(originalTextLength, false, layoutAwareScan);
         const sentence = this._textSourceGenerator.extractSentence(
             textSource,
@@ -1295,8 +1386,24 @@ export class TextScanner extends EventDispatcher {
             sentenceForwardQuoteMap,
             sentenceBackwardQuoteMap,
         );
+        const extractSentenceElapsedMs = Math.max(0, safePerformance.now() - extractSentenceStartedAt);
 
-        return {dictionaryEntries, sentence, type: 'terms'};
+        return {
+            dictionaryEntries,
+            dictionaryEntriesJson,
+            dictionaryEntryCount,
+            sentence,
+            type: 'terms',
+            timingDiagnostics: {
+                searchTextLength: searchText.length,
+                originalTextLength,
+                apiTermsFindElapsedMs,
+                deferredSerializedDictionaryEntries: serializedDictionaryEntries,
+                serializedDictionaryEntriesLength,
+                extractSentenceElapsedMs,
+                apiTimingDiagnostics: timingDiagnostics,
+            },
+        };
     }
 
     /**
@@ -1314,9 +1421,12 @@ export class TextScanner extends EventDispatcher {
         const searchText = this.getTextSourceContent(textSource, 1, layoutAwareScan, optionsContext.pointerType);
         if (searchText.length === 0) { return null; }
 
+        const apiKanjiFindStartedAt = safePerformance.now();
         const dictionaryEntries = await this._api.kanjiFind(searchText, optionsContext);
+        const apiKanjiFindElapsedMs = Math.max(0, safePerformance.now() - apiKanjiFindStartedAt);
         if (dictionaryEntries.length === 0) { return null; }
 
+        const extractSentenceStartedAt = safePerformance.now();
         textSource.setEndOffset(1, false, layoutAwareScan);
         const sentence = this._textSourceGenerator.extractSentence(
             textSource,
@@ -1327,8 +1437,19 @@ export class TextScanner extends EventDispatcher {
             sentenceForwardQuoteMap,
             sentenceBackwardQuoteMap,
         );
+        const extractSentenceElapsedMs = Math.max(0, safePerformance.now() - extractSentenceStartedAt);
 
-        return {dictionaryEntries, sentence, type: 'kanji'};
+        return {
+            dictionaryEntries,
+            dictionaryEntryCount: dictionaryEntries.length,
+            sentence,
+            type: 'kanji',
+            timingDiagnostics: {
+                searchTextLength: searchText.length,
+                apiKanjiFindElapsedMs,
+                extractSentenceElapsedMs,
+            },
+        };
     }
 
     /**
@@ -1343,6 +1464,16 @@ export class TextScanner extends EventDispatcher {
         this._activeLookupSequence = lookupSequence;
         /** @type {?import('text-source').TextSource} */
         let activeTextSource = null;
+        /** @type {Record<string, unknown>} */
+        const hoverTimingDiagnostics = {
+            lookupSequence,
+            x,
+            y,
+            pointerType: inputInfo.pointerType,
+            eventType: inputInfo.eventType,
+            passive: inputInfo.passive,
+        };
+        const totalStartedAt = safePerformance.now();
         try {
             safePerformance.mark('scanner:_searchAt:start');
             const sourceInput = inputInfo.input;
@@ -1352,24 +1483,42 @@ export class TextScanner extends EventDispatcher {
                 if (searchTerms && !sourceInput.searchTerms) { searchTerms = false; }
                 if (searchKanji && !sourceInput.searchKanji) { searchKanji = false; }
             }
+            hoverTimingDiagnostics.searchTerms = searchTerms;
+            hoverTimingDiagnostics.searchKanji = searchKanji;
 
             this._pendingLookup = true;
             this._scanTimerClear();
 
-            if (typeof this._ignorePoint === 'function' && await this._ignorePoint(x, y)) {
-                return;
+            const ignorePointStartedAt = safePerformance.now();
+            if (typeof this._ignorePoint === 'function') {
+                const ignored = await this._ignorePoint(x, y);
+                hoverTimingDiagnostics.ignorePointElapsedMs = Math.max(0, safePerformance.now() - ignorePointStartedAt);
+                hoverTimingDiagnostics.ignoredPoint = ignored;
+                if (ignored) {
+                    return;
+                }
+            } else {
+                hoverTimingDiagnostics.ignorePointElapsedMs = 0;
             }
 
+            const getRangeFromPointStartedAt = safePerformance.now();
             activeTextSource = this._textSourceGenerator.getRangeFromPoint(x, y, {
                 deepContentScan: this._deepContentScan,
                 normalizeCssZoom: this._normalizeCssZoom,
                 language: this._language,
             });
+            hoverTimingDiagnostics.getRangeFromPointElapsedMs = Math.max(0, safePerformance.now() - getRangeFromPointStartedAt);
+            hoverTimingDiagnostics.hadTextSource = (activeTextSource !== null);
             if (activeTextSource !== null) {
                 try {
                     this._isMouseOverText = true;
-                    const searchPromise = this._search(activeTextSource, searchTerms, searchKanji, inputInfo, false, false, lookupSequence);
+                    /** @type {Record<string, unknown>} */
+                    const searchTimingDiagnostics = {};
+                    hoverTimingDiagnostics.search = searchTimingDiagnostics;
+                    const searchStartedAt = safePerformance.now();
+                    const searchPromise = this._search(activeTextSource, searchTerms, searchKanji, inputInfo, false, false, lookupSequence, searchTimingDiagnostics);
                     const timeoutMs = this._lookupTimeoutMs;
+                    hoverTimingDiagnostics.lookupTimeoutMs = timeoutMs;
                     if (Number.isFinite(timeoutMs) && timeoutMs > 0) {
                         /** @type {?import('core').Timeout} */
                         let timeout = null;
@@ -1388,24 +1537,41 @@ export class TextScanner extends EventDispatcher {
                             clearTimeout(timeout);
                             timeout = null;
                         }
+                        hoverTimingDiagnostics.searchElapsedMs = Math.max(0, safePerformance.now() - searchStartedAt);
+                        hoverTimingDiagnostics.searchTimedOut = timedOut;
                         if (this._isLookupStale(lookupSequence) || timedOut) {
+                            hoverTimingDiagnostics.staleAfterSearch = this._isLookupStale(lookupSequence);
                             return;
                         }
                     } else {
                         await searchPromise;
+                        hoverTimingDiagnostics.searchElapsedMs = Math.max(0, safePerformance.now() - searchStartedAt);
+                        hoverTimingDiagnostics.searchTimedOut = false;
                     }
                 } finally {
+                    const cleanupStartedAt = safePerformance.now();
                     activeTextSource.cleanup();
+                    hoverTimingDiagnostics.cleanupElapsedMs = Math.max(0, safePerformance.now() - cleanupStartedAt);
                 }
             } else {
                 this._isMouseOverText = false;
                 this._triggerSearchEmpty(inputInfo);
+                hoverTimingDiagnostics.resultState = 'empty-no-text-source';
             }
             safePerformance.mark('scanner:_searchAt:end');
             safePerformance.measure('scanner:_searchAt', 'scanner:_searchAt:start', 'scanner:_searchAt:end');
         } catch (e) {
+            hoverTimingDiagnostics.resultState = 'error';
+            hoverTimingDiagnostics.errorMessage = e instanceof Error ? e.message : String(e);
             log.error(e);
         } finally {
+            hoverTimingDiagnostics.totalElapsedMs = Math.max(0, safePerformance.now() - totalStartedAt);
+            hoverTimingDiagnostics.isMouseOverText = this._isMouseOverText;
+            publishDevTimingSnapshot(
+                HOVER_SCANNER_DIAGNOSTICS_DATASET_KEY,
+                hoverTimingDiagnostics,
+                HOVER_SCANNER_DIAGNOSTICS_EVENT,
+            );
             if (this._activeLookupSequence === lookupSequence) {
                 this._activeLookupSequence = null;
             }

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -67,6 +67,8 @@ export class TextScanner extends EventDispatcher {
         this._searchOnClickOnly = searchOnClickOnly;
         /** @type {import('../dom/text-source-generator').TextSourceGenerator} */
         this._textSourceGenerator = textSourceGenerator;
+        /** @type {ThemeController} */
+        this._themeController = new ThemeController(document.documentElement);
 
         /** @type {boolean} */
         this._isPrepared = false;
@@ -102,6 +104,8 @@ export class TextScanner extends EventDispatcher {
 
         /** @type {PointerEvent | null} */
         this._lastMouseMove = null;
+        /** @type {?{x: number, y: number, inputInfo: import('text-scanner').InputInfo}} */
+        this._pendingMouseMoveSearch = null;
 
         /** @type {boolean} */
         this._deepContentScan = false;
@@ -254,6 +258,7 @@ export class TextScanner extends EventDispatcher {
         this._preventScroll = false;
         this._penPointerState = 0;
         this._pointerIdTypeMap.clear();
+        this._pendingMouseMoveSearch = null;
 
         this._enabledValue = value;
 
@@ -541,8 +546,6 @@ export class TextScanner extends EventDispatcher {
                 this.setCurrentTextSource(textSource);
                 this._selectionRestoreInfo = selectionRestoreInfo;
 
-                /** @type {ThemeController} */
-                this._themeController = new ThemeController(document.documentElement);
                 const pageTheme = this._themeController.computeSiteTheme();
 
                 this.trigger('searchSuccess', {
@@ -707,6 +710,7 @@ export class TextScanner extends EventDispatcher {
     /** */
     _onMouseOut() {
         this._scanTimerClear();
+        this._pendingMouseMoveSearch = null;
         this.clearMousePosition();
     }
 
@@ -958,6 +962,11 @@ export class TextScanner extends EventDispatcher {
 
         const inputInfo = this._getMatchingInputGroupFromEvent('mouse', 'mouseMove', e);
         if (inputInfo === null) { return; }
+
+        if (this._pendingLookup) {
+            this._pendingMouseMoveSearch = {x: e.clientX, y: e.clientY, inputInfo};
+            return;
+        }
 
         void this._searchAtFromMouseMove(e.clientX, e.clientY, inputInfo);
     }
@@ -1401,6 +1410,7 @@ export class TextScanner extends EventDispatcher {
                 this._activeLookupSequence = null;
             }
             this._pendingLookup = false;
+            this._dispatchPendingMouseMoveSearch();
         }
     }
 
@@ -1418,14 +1428,36 @@ export class TextScanner extends EventDispatcher {
      * @param {import('text-scanner').InputInfo} inputInfo
      */
     async _searchAtFromMouseMove(x, y, inputInfo) {
-        if (this._pendingLookup) { return; }
+        if (this._pendingLookup) {
+            this._pendingMouseMoveSearch = {x, y, inputInfo};
+            return;
+        }
 
         if (inputInfo.passive && !await this._scanTimerWait()) {
             // Aborted
             return;
         }
 
+        if (this._pendingLookup) {
+            this._pendingMouseMoveSearch = {x, y, inputInfo};
+            return;
+        }
+
         await this._searchAt(x, y, inputInfo);
+    }
+
+    /**
+     * @returns {void}
+     */
+    _dispatchPendingMouseMoveSearch() {
+        if (this._pendingLookup) { return; }
+
+        const pendingMouseMoveSearch = this._pendingMouseMoveSearch;
+        if (pendingMouseMoveSearch === null) { return; }
+
+        this._pendingMouseMoveSearch = null;
+        const {x, y, inputInfo} = pendingMouseMoveSearch;
+        void this._searchAt(x, y, inputInfo);
     }
 
     /**

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+import {isObjectNotArray} from '../core/object-utilities.js';
 import {safePerformance} from '../core/safe-performance.js';
 import {applyTextReplacement} from '../general/regex-util.js';
 import {isCodePointJapanese} from './ja/japanese.js';
@@ -80,6 +81,10 @@ export class Translator {
      */
     clearDatabaseCaches() {
         this._tagCache.clear();
+        const clearTagCaches = /** @type {unknown} */ (Reflect.get(this._database, 'clearTagCaches'));
+        if (typeof clearTagCaches === 'function') {
+            clearTagCaches.call(this._database);
+        }
     }
 
     /**
@@ -87,14 +92,22 @@ export class Translator {
      * @param {import('translator').FindTermsMode} mode The mode to use for finding terms, which determines the format of the resulting array.
      * @param {string} text The text to find terms for.
      * @param {import('translation').FindTermsOptions} options A object describing settings about the lookup.
-     * @returns {Promise<{dictionaryEntries: import('dictionary').TermDictionaryEntry[], originalTextLength: number}>} An object containing dictionary entries and the length of the original source text.
+     * @returns {Promise<import('translator').FindTermsResult>} An object containing dictionary entries and the length of the original source text.
      */
-    async findTerms(mode, text, options) {
+    async findTerms(mode, text, options, includeTimingDiagnostics = true) {
         safePerformance.mark('translator:findTerms:start');
+        const totalStartedAt = safePerformance.now();
         const {enabledDictionaryMap, excludeDictionaryDefinitions, sortFrequencyDictionary, sortFrequencyDictionaryOrder, language, primaryReading} = options;
         const tagAggregator = new TranslatorTagAggregator();
-        let {dictionaryEntries, originalTextLength} = await this._findTermsInternal(text, options, tagAggregator, primaryReading);
+        const findTermsInternalStartedAt = safePerformance.now();
+        let {
+            dictionaryEntries,
+            originalTextLength,
+            timingDiagnostics: internalTimingDiagnostics = null,
+        } = await this._findTermsInternal(text, options, tagAggregator, primaryReading);
+        const findTermsInternalElapsedMs = Math.max(0, safePerformance.now() - findTermsInternalStartedAt);
 
+        const groupEntriesStartedAt = safePerformance.now();
         switch (mode) {
             case 'group':
                 dictionaryEntries = this._groupDictionaryEntriesByHeadword(language, dictionaryEntries, tagAggregator, primaryReading);
@@ -106,14 +119,19 @@ export class Translator {
                 dictionaryEntries = await this._getRelatedDictionaryEntries(dictionaryEntries, options, tagAggregator);
                 break;
         }
+        const groupEntriesElapsedMs = Math.max(0, safePerformance.now() - groupEntriesStartedAt);
 
+        const removeExcludedDefinitionsStartedAt = safePerformance.now();
         if (excludeDictionaryDefinitions !== null) {
             this._removeExcludedDefinitions(dictionaryEntries, excludeDictionaryDefinitions);
         }
+        const removeExcludedDefinitionsElapsedMs = Math.max(0, safePerformance.now() - removeExcludedDefinitionsStartedAt);
 
+        let addTermMetaDiagnostics = null;
+        let expandTagGroupsDiagnostics = null;
         if (mode !== 'simple') {
-            await this._addTermMeta(dictionaryEntries, enabledDictionaryMap, tagAggregator);
-            await this._expandTagGroupsAndGroup(tagAggregator.getTagExpansionTargets());
+            addTermMetaDiagnostics = await this._addTermMeta(dictionaryEntries, enabledDictionaryMap, tagAggregator);
+            expandTagGroupsDiagnostics = await this._expandTagGroupsAndGroup(tagAggregator.getTagExpansionTargets());
         } else {
             if (sortFrequencyDictionary !== null) {
                 /** @type {import('translation').TermEnabledDictionaryMap} */
@@ -126,6 +144,7 @@ export class Translator {
             }
         }
 
+        const finalizeStartedAt = safePerformance.now();
         if (sortFrequencyDictionary !== null) {
             this._updateSortFrequencies(dictionaryEntries, sortFrequencyDictionary, sortFrequencyDictionaryOrder === 'ascending');
         }
@@ -139,10 +158,39 @@ export class Translator {
             if (pronunciations.length > 1) { this._sortTermDictionaryEntrySimpleData(pronunciations); }
         }
         const withUserFacingInflections = this._addUserFacingInflections(language, dictionaryEntries);
+        const finalizeElapsedMs = Math.max(0, safePerformance.now() - finalizeStartedAt);
         safePerformance.mark('translator:findTerms:end');
         safePerformance.measure('translator:findTerms', 'translator:findTerms:start', 'translator:findTerms:end');
 
-        return {dictionaryEntries: withUserFacingInflections, originalTextLength};
+        if (!includeTimingDiagnostics) {
+            return {
+                dictionaryEntries: withUserFacingInflections,
+                originalTextLength,
+            };
+        }
+        return {
+            dictionaryEntries: withUserFacingInflections,
+            originalTextLength,
+            timingDiagnostics: {
+                translator: {
+                    findTermsInternalElapsedMs,
+                    groupEntriesElapsedMs,
+                    removeExcludedDefinitionsElapsedMs,
+                    addTermMetaElapsedMs: Number(addTermMetaDiagnostics?.totalElapsedMs || 0),
+                    expandTagGroupsElapsedMs: Number(expandTagGroupsDiagnostics?.totalElapsedMs || 0),
+                    finalizeElapsedMs,
+                    totalElapsedMs: Math.max(0, safePerformance.now() - totalStartedAt),
+                    dictionaryEntryCount: withUserFacingInflections.length,
+                    originalTextLength,
+                    mode,
+                    language,
+                    sortFrequencyDictionary: sortFrequencyDictionary !== null,
+                },
+                translatorInternal: internalTimingDiagnostics,
+                translatorAddTermMeta: addTermMetaDiagnostics,
+                translatorExpandTagGroups: expandTagGroupsDiagnostics,
+            },
+        };
     }
 
     /**
@@ -241,20 +289,54 @@ export class Translator {
      * @param {import('translation').FindTermsOptions} options
      * @param {TranslatorTagAggregator} tagAggregator
      * @param {string} primaryReading
-     * @returns {Promise<{dictionaryEntries: import('translation-internal').TermDictionaryEntry[], originalTextLength: number}>}
+     * @returns {Promise<{dictionaryEntries: import('translation-internal').TermDictionaryEntry[], originalTextLength: number, timingDiagnostics: Record<string, unknown>}>}
      */
     async _findTermsInternal(text, options, tagAggregator, primaryReading) {
+        const totalStartedAt = safePerformance.now();
         const {removeNonJapaneseCharacters, enabledDictionaryMap} = options;
+        const normalizeInputStartedAt = safePerformance.now();
         if (removeNonJapaneseCharacters && (['ja', 'zh', 'yue', 'ko'].includes(options.language))) {
             text = this._getJapaneseChineseKoreanOnlyText(text);
         }
+        const normalizeInputElapsedMs = Math.max(0, safePerformance.now() - normalizeInputStartedAt);
         if (text.length === 0) {
-            return {dictionaryEntries: [], originalTextLength: 0};
+            return {
+                dictionaryEntries: [],
+                originalTextLength: 0,
+                timingDiagnostics: {
+                    normalizeInputElapsedMs,
+                    getDeinflectionsElapsedMs: 0,
+                    getDictionaryEntriesElapsedMs: 0,
+                    totalElapsedMs: Math.max(0, safePerformance.now() - totalStartedAt),
+                    normalizedTextLength: 0,
+                    deinflectionCount: 0,
+                },
+            };
         }
 
-        const deinflections = await this._getDeinflections(text, options);
+        const getDeinflectionsStartedAt = safePerformance.now();
+        const {
+            deinflections,
+            timingDiagnostics: deinflectionTimingDiagnostics = null,
+        } = await this._getDeinflections(text, options);
+        const getDeinflectionsElapsedMs = Math.max(0, safePerformance.now() - getDeinflectionsStartedAt);
+        const getDictionaryEntriesStartedAt = safePerformance.now();
+        const {dictionaryEntries, originalTextLength} = this._getDictionaryEntries(deinflections, enabledDictionaryMap, tagAggregator, primaryReading);
+        const getDictionaryEntriesElapsedMs = Math.max(0, safePerformance.now() - getDictionaryEntriesStartedAt);
 
-        return this._getDictionaryEntries(deinflections, enabledDictionaryMap, tagAggregator, primaryReading);
+        return {
+            dictionaryEntries,
+            originalTextLength,
+            timingDiagnostics: {
+                normalizeInputElapsedMs,
+                getDeinflectionsElapsedMs,
+                getDictionaryEntriesElapsedMs,
+                totalElapsedMs: Math.max(0, safePerformance.now() - totalStartedAt),
+                normalizedTextLength: text.length,
+                deinflectionCount: deinflections.length,
+                deinflections: deinflectionTimingDiagnostics,
+            },
+        };
     }
 
     /**
@@ -372,24 +454,58 @@ export class Translator {
     /**
      * @param {string} text
      * @param {import('translation').FindTermsOptions} options
-     * @returns {Promise<import('translation-internal').DatabaseDeinflection[]>}
+     * @returns {Promise<{deinflections: import('translation-internal').DatabaseDeinflection[], timingDiagnostics: Record<string, unknown>}>}
      */
     async _getDeinflections(text, options) {
         safePerformance.mark('translator:getDeinflections:start');
-        let deinflections = (
-            options.deinflect ?
-                this._getAlgorithmDeinflections(text, options) :
-                [this._createDeinflection(text, text, text, 0, [], [])]
-        );
-        if (deinflections.length === 0) { return []; }
+        const totalStartedAt = safePerformance.now();
+        let deinflections;
+        let algorithmDiagnostics = null;
+        const getAlgorithmDeinflectionsStartedAt = safePerformance.now();
+        if (options.deinflect) {
+            ({
+                deinflections,
+                timingDiagnostics: algorithmDiagnostics = null,
+            } = this._getAlgorithmDeinflections(text, options));
+        } else {
+            deinflections = [this._createDeinflection(text, text, text, 0, [], [])];
+        }
+        const getAlgorithmDeinflectionsElapsedMs = Math.max(0, safePerformance.now() - getAlgorithmDeinflectionsStartedAt);
+        if (deinflections.length === 0) {
+            return {
+                deinflections: [],
+                timingDiagnostics: {
+                    getAlgorithmDeinflectionsElapsedMs,
+                    addEntriesElapsedMs: 0,
+                    dictionaryDeinflectionsElapsedMs: 0,
+                    cleanupElapsedMs: 0,
+                    totalElapsedMs: Math.max(0, safePerformance.now() - totalStartedAt),
+                    usedAlgorithmDeinflections: options.deinflect,
+                    initialDeinflectionCount: 0,
+                    dictionaryDeinflectionCount: 0,
+                    finalDeinflectionCount: 0,
+                    algorithm: algorithmDiagnostics,
+                    initialDatabaseMatch: null,
+                    dictionaryDeinflections: null,
+                },
+            };
+        }
 
         const {matchType, language, enabledDictionaryMap} = options;
 
-        await this._addEntriesToDeinflections(language, deinflections, enabledDictionaryMap, matchType);
+        const addEntriesStartedAt = safePerformance.now();
+        const initialDatabaseMatchDiagnostics = await this._addEntriesToDeinflections(language, deinflections, enabledDictionaryMap, matchType);
+        const addEntriesElapsedMs = Math.max(0, safePerformance.now() - addEntriesStartedAt);
 
-        const dictionaryDeinflections = await this._getDictionaryDeinflections(language, deinflections, enabledDictionaryMap, matchType);
+        const getDictionaryDeinflectionsStartedAt = safePerformance.now();
+        const {
+            dictionaryDeinflections,
+            timingDiagnostics: dictionaryDeinflectionsDiagnostics = null,
+        } = await this._getDictionaryDeinflections(language, deinflections, enabledDictionaryMap, matchType);
+        const dictionaryDeinflectionsElapsedMs = Math.max(0, safePerformance.now() - getDictionaryDeinflectionsStartedAt);
         deinflections.push(...dictionaryDeinflections);
 
+        const cleanupStartedAt = safePerformance.now();
         for (const deinflection of deinflections) {
             for (const entry of deinflection.databaseEntries) {
                 entry.definitions = entry.definitions.filter((definition) => !Array.isArray(definition));
@@ -397,10 +513,27 @@ export class Translator {
             deinflection.databaseEntries = deinflection.databaseEntries.filter((entry) => entry.definitions.length);
         }
         deinflections = deinflections.filter((deinflection) => deinflection.databaseEntries.length);
+        const cleanupElapsedMs = Math.max(0, safePerformance.now() - cleanupStartedAt);
 
         safePerformance.mark('translator:getDeinflections:end');
         safePerformance.measure('translator:getDeinflections', 'translator:getDeinflections:start', 'translator:getDeinflections:end');
-        return deinflections;
+        return {
+            deinflections,
+            timingDiagnostics: {
+                getAlgorithmDeinflectionsElapsedMs,
+                addEntriesElapsedMs,
+                dictionaryDeinflectionsElapsedMs,
+                cleanupElapsedMs,
+                totalElapsedMs: Math.max(0, safePerformance.now() - totalStartedAt),
+                usedAlgorithmDeinflections: options.deinflect,
+                initialDeinflectionCount: Number(algorithmDiagnostics?.deinflectionCount || deinflections.length),
+                dictionaryDeinflectionCount: dictionaryDeinflections.length,
+                finalDeinflectionCount: deinflections.length,
+                algorithm: algorithmDiagnostics,
+                initialDatabaseMatch: initialDatabaseMatchDiagnostics,
+                dictionaryDeinflections: dictionaryDeinflectionsDiagnostics,
+            },
+        };
     }
 
     /**
@@ -408,12 +541,16 @@ export class Translator {
      * @param {import('translation-internal').DatabaseDeinflection[]} deinflections
      * @param {Map<string, import('translation').FindTermDictionary>} enabledDictionaryMap
      * @param {import('dictionary').TermSourceMatchType} matchType
-     * @returns {Promise<import('translation-internal').DatabaseDeinflection[]>}
+     * @returns {Promise<{dictionaryDeinflections: import('translation-internal').DatabaseDeinflection[], timingDiagnostics: Record<string, unknown>}>}
      */
     async _getDictionaryDeinflections(language, deinflections, enabledDictionaryMap, matchType) {
         safePerformance.mark('translator:getDictionaryDeinflections:start');
+        const totalStartedAt = safePerformance.now();
         /** @type {import('translation-internal').DatabaseDeinflection[]} */
         const dictionaryDeinflections = [];
+        let definitionCount = 0;
+        let inflectedDefinitionCount = 0;
+        const buildDictionaryDeinflectionsStartedAt = safePerformance.now();
         for (const deinflection of deinflections) {
             const {originalText, transformedText, textProcessorRuleChainCandidates, inflectionRuleChainCandidates: algorithmChains, databaseEntries} = deinflection;
             for (const entry of databaseEntries) {
@@ -422,9 +559,11 @@ export class Translator {
                 const useDeinflections = entryDictionary?.useDeinflections ?? true;
                 if (!useDeinflections) { continue; }
                 for (const definition of definitions) {
+                    ++definitionCount;
                     if (Array.isArray(definition)) {
                         const [formOf, inflectionRules] = definition;
                         if (!formOf) { continue; }
+                        ++inflectedDefinitionCount;
 
                         const inflectionRuleChainCandidates = algorithmChains.map(({inflectionRules: algInflections}) => {
                             return {
@@ -439,12 +578,26 @@ export class Translator {
                 }
             }
         }
+        const buildDictionaryDeinflectionsElapsedMs = Math.max(0, safePerformance.now() - buildDictionaryDeinflectionsStartedAt);
 
-        await this._addEntriesToDeinflections(language, dictionaryDeinflections, enabledDictionaryMap, matchType);
+        const addEntriesStartedAt = safePerformance.now();
+        const addEntriesDiagnostics = await this._addEntriesToDeinflections(language, dictionaryDeinflections, enabledDictionaryMap, matchType);
+        const addEntriesElapsedMs = Math.max(0, safePerformance.now() - addEntriesStartedAt);
 
         safePerformance.mark('translator:getDictionaryDeinflections:end');
         safePerformance.measure('translator:getDictionaryDeinflections', 'translator:getDictionaryDeinflections:start', 'translator:getDictionaryDeinflections:end');
-        return dictionaryDeinflections;
+        return {
+            dictionaryDeinflections,
+            timingDiagnostics: {
+                buildDictionaryDeinflectionsElapsedMs,
+                addEntriesElapsedMs,
+                totalElapsedMs: Math.max(0, safePerformance.now() - totalStartedAt),
+                definitionCount,
+                inflectedDefinitionCount,
+                dictionaryDeinflectionCount: dictionaryDeinflections.length,
+                addEntries: addEntriesDiagnostics,
+            },
+        };
     }
 
     /**
@@ -454,12 +607,35 @@ export class Translator {
      * @param {import('dictionary').TermSourceMatchType} matchType
      */
     async _addEntriesToDeinflections(language, deinflections, enabledDictionaryMap, matchType) {
+        const totalStartedAt = safePerformance.now();
+        const groupDeinflectionsStartedAt = safePerformance.now();
         const uniqueDeinflectionsMap = this._groupDeinflectionsByTerm(deinflections);
+        const groupDeinflectionsElapsedMs = Math.max(0, safePerformance.now() - groupDeinflectionsStartedAt);
         const uniqueDeinflectionArrays = [...uniqueDeinflectionsMap.values()];
         const uniqueDeinflectionTerms = [...uniqueDeinflectionsMap.keys()];
 
+        const findTermsBulkStartedAt = safePerformance.now();
         const databaseEntries = await this._database.findTermsBulk(uniqueDeinflectionTerms, enabledDictionaryMap, matchType);
+        const findTermsBulkElapsedMs = Math.max(0, safePerformance.now() - findTermsBulkStartedAt);
+        const findTermsBulkDiagnostics = (
+            Array.isArray(databaseEntries) &&
+            isObjectNotArray(Reflect.get(databaseEntries, 'timingDiagnostics'))
+        ) ?
+            /** @type {Record<string, unknown>} */ (Reflect.get(databaseEntries, 'timingDiagnostics')) :
+            null;
+        const matchEntriesStartedAt = safePerformance.now();
         this._matchEntriesToDeinflections(language, databaseEntries, uniqueDeinflectionArrays, enabledDictionaryMap);
+        const matchEntriesElapsedMs = Math.max(0, safePerformance.now() - matchEntriesStartedAt);
+        return {
+            groupDeinflectionsElapsedMs,
+            findTermsBulkElapsedMs,
+            matchEntriesElapsedMs,
+            totalElapsedMs: Math.max(0, safePerformance.now() - totalStartedAt),
+            deinflectionCount: deinflections.length,
+            uniqueDeinflectionTermCount: uniqueDeinflectionTerms.length,
+            databaseEntryCount: databaseEntries.length,
+            findTermsBulk: findTermsBulkDiagnostics,
+        };
     }
 
     /**
@@ -506,10 +682,11 @@ export class Translator {
     /**
      * @param {string} text
      * @param {import('translation').FindTermsOptions} options
-     * @returns {import('translation-internal').DatabaseDeinflection[]}
+     * @returns {{deinflections: import('translation-internal').DatabaseDeinflection[], timingDiagnostics: Record<string, unknown>}}
      * @throws {Error}
      */
     _getAlgorithmDeinflections(text, options) {
+        const totalStartedAt = safePerformance.now();
         const {language} = options;
         const processorsForLanguage = this._textProcessors.get(language);
         if (typeof processorsForLanguage === 'undefined') { throw new Error(`Unsupported language: ${language}`); }
@@ -519,18 +696,27 @@ export class Translator {
         const deinflections = [];
         /** @type {import('translation-internal').TextCache} */
         const sourceCache = new Map(); // For reusing text processors' outputs
+        let rawSourceCount = 0;
+        let preprocessedVariantCount = 0;
+        let algorithmDeinflectionCount = 0;
+        let postprocessedVariantCount = 0;
+        let textProcessorRuleChainCandidateCount = 0;
 
         for (
             let rawSource = text;
             rawSource.length > 0;
             rawSource = this._getNextSubstring(options.searchResolution, rawSource)
         ) {
+            ++rawSourceCount;
             const preprocessedTextVariants = this._getTextVariants(rawSource, textPreprocessors, this._getTextReplacementsVariants(options), sourceCache);
+            preprocessedVariantCount += preprocessedTextVariants.size;
 
             for (const [source, preprocessorRuleChainCandidates] of preprocessedTextVariants) {
                 for (const deinflection of this._multiLanguageTransformer.transform(language, source)) {
+                    ++algorithmDeinflectionCount;
                     const {trace, conditions} = deinflection;
                     const postprocessedTextVariants = this._getTextVariants(deinflection.text, textPostprocessors, [null], sourceCache);
+                    postprocessedVariantCount += postprocessedTextVariants.size;
                     for (const [transformedText, postprocessorRuleChainCandidates] of postprocessedTextVariants) {
                         /** @type {import('translation-internal').InflectionRuleChainCandidate} */
                         const inflectionRuleChainCandidate = {
@@ -544,12 +730,24 @@ export class Translator {
                                 (postprocessorRuleChainCandidate) => [...preprocessorRuleChainCandidate, ...postprocessorRuleChainCandidate],
                             ),
                         );
+                        textProcessorRuleChainCandidateCount += textProcessorRuleChainCandidates.length;
                         deinflections.push(this._createDeinflection(rawSource, source, transformedText, conditions, textProcessorRuleChainCandidates, [inflectionRuleChainCandidate]));
                     }
                 }
             }
         }
-        return deinflections;
+        return {
+            deinflections,
+            timingDiagnostics: {
+                totalElapsedMs: Math.max(0, safePerformance.now() - totalStartedAt),
+                rawSourceCount,
+                preprocessedVariantCount,
+                algorithmDeinflectionCount,
+                postprocessedVariantCount,
+                textProcessorRuleChainCandidateCount,
+                deinflectionCount: deinflections.length,
+            },
+        };
     }
 
     /**
@@ -1049,8 +1247,20 @@ export class Translator {
      * @param {import('translator').TagExpansionTarget[]} tagExpansionTargets
      */
     async _expandTagGroupsAndGroup(tagExpansionTargets) {
-        await this._expandTagGroups(tagExpansionTargets);
+        const totalStartedAt = safePerformance.now();
+        const expandTagGroupsStartedAt = safePerformance.now();
+        const expandTagGroupsDiagnostics = await this._expandTagGroups(tagExpansionTargets);
+        const expandTagGroupsElapsedMs = Math.max(0, safePerformance.now() - expandTagGroupsStartedAt);
+        const groupTagsStartedAt = safePerformance.now();
         this._groupTags(tagExpansionTargets);
+        const groupTagsElapsedMs = Math.max(0, safePerformance.now() - groupTagsStartedAt);
+        return {
+            expandTagGroupsElapsedMs,
+            groupTagsElapsedMs,
+            totalElapsedMs: Math.max(0, safePerformance.now() - totalStartedAt),
+            tagExpansionTargetCount: tagExpansionTargets.length,
+            ...expandTagGroupsDiagnostics,
+        };
     }
 
     /**
@@ -1099,8 +1309,15 @@ export class Translator {
         }
 
         const nonCachedItemCount = nonCachedItems.length;
+        const findTagMetaBulkStartedAt = safePerformance.now();
+        let findTagMetaBulkDiagnostics = null;
         if (nonCachedItemCount > 0) {
             const databaseTags = await this._database.findTagMetaBulk(nonCachedItems);
+            findTagMetaBulkDiagnostics = (
+                isObjectNotArray(Reflect.get(databaseTags, 'timingDiagnostics')) ?
+                /** @type {Record<string, unknown>} */ (Reflect.get(databaseTags, 'timingDiagnostics')) :
+                null
+            );
             for (let i = 0; i < nonCachedItemCount; ++i) {
                 const item = nonCachedItems[i];
                 const databaseTag = databaseTags[i];
@@ -1111,12 +1328,19 @@ export class Translator {
                 }
             }
         }
+        const findTagMetaBulkElapsedMs = Math.max(0, safePerformance.now() - findTagMetaBulkStartedAt);
 
         for (const {dictionary, tagName, databaseTag, targets} of allItems) {
             for (const tags of targets) {
                 tags.push(this._createTag(databaseTag, tagName, dictionary));
             }
         }
+        return {
+            totalTagCount: allItems.length,
+            nonCachedTagCount: nonCachedItemCount,
+            findTagMetaBulkElapsedMs,
+            findTagMetaBulk: findTagMetaBulkDiagnostics,
+        };
     }
 
     /**
@@ -1222,6 +1446,7 @@ export class Translator {
      * @param {TranslatorTagAggregator} tagAggregator
      */
     async _addTermMeta(dictionaryEntries, enabledDictionaryMap, tagAggregator) {
+        const totalStartedAt = safePerformance.now();
         /** @type {Map<string, Map<string, {headwordIndex: number, pronunciations: import('dictionary').TermPronunciation[], frequencies: import('dictionary').TermFrequency[]}[]>>} */
         const headwordMap = new Map();
         /** @type {string[]} */
@@ -1229,6 +1454,7 @@ export class Translator {
         /** @type {Map<string, {headwordIndex: number, pronunciations: import('dictionary').TermPronunciation[], frequencies: import('dictionary').TermFrequency[]}[]>[]} */
         const headwordReadingMaps = [];
 
+        const buildHeadwordTargetsStartedAt = safePerformance.now();
         for (const {headwords, pronunciations, frequencies} of dictionaryEntries) {
             for (let i = 0, ii = headwords.length; i < ii; ++i) {
                 const {term, reading} = headwords[i];
@@ -1247,8 +1473,15 @@ export class Translator {
                 targets.push({headwordIndex: i, pronunciations, frequencies});
             }
         }
+        const buildHeadwordTargetsElapsedMs = Math.max(0, safePerformance.now() - buildHeadwordTargetsStartedAt);
 
+        const findTermMetaBulkStartedAt = safePerformance.now();
         const metas = await this._database.findTermMetaBulk(headwordMapKeys, enabledDictionaryMap);
+        const findTermMetaBulkElapsedMs = Math.max(0, safePerformance.now() - findTermMetaBulkStartedAt);
+        let frequencyMetaCount = 0;
+        let pitchMetaCount = 0;
+        let ipaMetaCount = 0;
+        const applyMetasStartedAt = safePerformance.now();
         for (const {mode, data, dictionary, index} of metas) {
             const {index: dictionaryIndex} = this._getDictionaryOrder(dictionary, enabledDictionaryMap);
             const dictionaryAlias = this._getDictionaryAlias(dictionary, enabledDictionaryMap);
@@ -1257,6 +1490,7 @@ export class Translator {
                 switch (mode) {
                     case 'freq':
                         {
+                            ++frequencyMetaCount;
                             const hasReading = (data !== null && typeof data === 'object' && typeof data.reading === 'string');
                             if (hasReading && data.reading !== reading) { continue; }
                             const frequency = hasReading ? data.frequency : /** @type {import('dictionary-data').GenericFrequencyData} */ (data);
@@ -1278,6 +1512,7 @@ export class Translator {
                         break;
                     case 'pitch':
                         {
+                            ++pitchMetaCount;
                             if (data.reading !== reading) { continue; }
                             /** @type {import('dictionary').PitchAccent[]} */
                             const pitches = [];
@@ -1311,6 +1546,7 @@ export class Translator {
                         break;
                     case 'ipa':
                     {
+                        ++ipaMetaCount;
                         if (data.reading !== reading) { continue; }
                         /** @type {import('dictionary').PhoneticTranscription[]} */
                         const phoneticTranscriptions = [];
@@ -1340,6 +1576,17 @@ export class Translator {
                 }
             }
         }
+        return {
+            buildHeadwordTargetsElapsedMs,
+            findTermMetaBulkElapsedMs,
+            applyMetasElapsedMs: Math.max(0, safePerformance.now() - applyMetasStartedAt),
+            totalElapsedMs: Math.max(0, safePerformance.now() - totalStartedAt),
+            uniqueHeadwordCount: headwordMapKeys.length,
+            metaCount: metas.length,
+            frequencyMetaCount,
+            pitchMetaCount,
+            ipaMetaCount,
+        };
     }
 
     /**

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -512,6 +512,15 @@
         </div></div>
         <div class="settings-item advanced-only"><div class="settings-item-inner settings-item-inner-wrappable">
             <div class="settings-item-left">
+                <div class="settings-item-label">Hover scan length cap</div>
+                <div class="settings-item-description">Limit how many characters hover lookup scans before resolving a word. Lower values can speed up lookups on pages with many installed dictionaries.</div>
+            </div>
+            <div class="settings-item-right">
+                <input type="number" data-setting="scanning.length" min="1" step="1">
+            </div>
+        </div></div>
+        <div class="settings-item advanced-only"><div class="settings-item-inner settings-item-inner-wrappable">
+            <div class="settings-item-left">
                 <div class="settings-item-label">Scan without mouse move</div>
                 <div class="settings-item-description">Allow scanning words under the pointer without the pointer being in motion.</div>
             </div>

--- a/test/backend-scan-length.test.js
+++ b/test/backend-scan-length.test.js
@@ -40,86 +40,143 @@ function getBackendMethod(name) {
     return method;
 }
 
-describe('Backend derived scan length', () => {
-    test('optionsGet injects the cached max headword length plus buffer', async () => {
+describe('Backend hover scan length', () => {
+    test('optionsGet returns the raw stored scan length', async () => {
         const rawProfileOptions = {scanning: {length: 16}};
         const context = {
             _getProfileOptions: vi.fn(() => rawProfileOptions),
-            _getEffectiveScanLength: vi.fn(async () => 32),
-            _createEffectiveProfileOptions: getBackendMethod('_createEffectiveProfileOptions'),
-        };
-
-        const result = await getBackendMethod('_onApiOptionsGet').call(context, {optionsContext: {current: true}});
-
-        expect(result).toStrictEqual({scanning: {length: 32}});
-        expect(rawProfileOptions).toStrictEqual({scanning: {length: 16}});
-        expect(context._getEffectiveScanLength).toHaveBeenCalledWith(16);
-    });
-
-    test('missing cached max headword length backfills from the database once', async () => {
-        const rawProfileOptions = {scanning: {length: 16}};
-        const saveOptions = vi.fn(async () => {});
-        const context = {
-            _options: {
-                global: {
-                    database: {
-                        maxHeadwordLength: 0,
-                    },
-                },
-            },
-            _dictionaryDatabase: {
-                getMaxHeadwordLength: vi.fn(async () => 21),
-            },
-            _dictionaryImportModeActive: false,
-            _ensureDictionaryDatabaseReady: vi.fn(async () => {}),
-            _saveOptions: saveOptions,
-            _getProfileOptions: vi.fn(() => rawProfileOptions),
-            _getStoredGlobalMaxHeadwordLength: getBackendMethod('_getStoredGlobalMaxHeadwordLength'),
-            _setGlobalMaxHeadwordLength: getBackendMethod('_setGlobalMaxHeadwordLength'),
-            _computeMaxHeadwordLengthFromDatabase: getBackendMethod('_computeMaxHeadwordLengthFromDatabase'),
-            _getEffectiveScanLength: getBackendMethod('_getEffectiveScanLength'),
-            _createEffectiveProfileOptions: getBackendMethod('_createEffectiveProfileOptions'),
-        };
-
-        const result = await getBackendMethod('_onApiOptionsGet').call(context, {optionsContext: {current: true}});
-
-        expect(result).toStrictEqual({scanning: {length: 29}});
-        expect(rawProfileOptions).toStrictEqual({scanning: {length: 16}});
-        expect(context._dictionaryDatabase.getMaxHeadwordLength).toHaveBeenCalledTimes(1);
-        expect(context._options.global.database.maxHeadwordLength).toBe(21);
-        expect(saveOptions).toHaveBeenCalledTimes(1);
-        expect(saveOptions).toHaveBeenCalledWith('background');
-    });
-
-    test('falls back to the stored scan length when the database max is 0', async () => {
-        const rawProfileOptions = {scanning: {length: 16}};
-        const saveOptions = vi.fn(async () => {});
-        const context = {
-            _options: {
-                global: {
-                    database: {
-                        maxHeadwordLength: 0,
-                    },
-                },
-            },
-            _dictionaryDatabase: {
-                getMaxHeadwordLength: vi.fn(async () => 0),
-            },
-            _dictionaryImportModeActive: false,
-            _ensureDictionaryDatabaseReady: vi.fn(async () => {}),
-            _saveOptions: saveOptions,
-            _getProfileOptions: vi.fn(() => rawProfileOptions),
-            _getStoredGlobalMaxHeadwordLength: getBackendMethod('_getStoredGlobalMaxHeadwordLength'),
-            _setGlobalMaxHeadwordLength: getBackendMethod('_setGlobalMaxHeadwordLength'),
-            _computeMaxHeadwordLengthFromDatabase: getBackendMethod('_computeMaxHeadwordLengthFromDatabase'),
-            _getEffectiveScanLength: getBackendMethod('_getEffectiveScanLength'),
-            _createEffectiveProfileOptions: getBackendMethod('_createEffectiveProfileOptions'),
         };
 
         const result = await getBackendMethod('_onApiOptionsGet').call(context, {optionsContext: {current: true}});
 
         expect(result).toStrictEqual({scanning: {length: 16}});
-        expect(saveOptions).not.toHaveBeenCalled();
+        expect(result).not.toBe(rawProfileOptions);
+        expect(rawProfileOptions).toStrictEqual({scanning: {length: 16}});
+    });
+
+    test('getEffectiveHoverScanLength caps enabled dictionaries by the stored scan length and caches the result', async () => {
+        const rawProfileOptions = {
+            scanning: {length: 32},
+            dictionaries: [
+                {name: 'Enabled B', enabled: true},
+                {name: 'Disabled', enabled: false},
+                {name: 'Enabled A', enabled: true},
+            ],
+        };
+        const getMaxHeadwordLength = vi.fn(async (dictionaryNames) => {
+            expect(dictionaryNames).toStrictEqual(['Enabled A', 'Enabled B']);
+            return 21;
+        });
+        const context = {
+            _effectiveScanLengthMaxHeadwordLengthCache: new Map(),
+            _dictionaryDatabase: {getMaxHeadwordLength},
+            _dictionaryImportModeActive: false,
+            _ensureDictionaryDatabaseReady: vi.fn(async () => {}),
+            _getProfileOptions: vi.fn(() => rawProfileOptions),
+            _getEffectiveHoverScanLength: getBackendMethod('_getEffectiveHoverScanLength'),
+            _computeMaxHeadwordLengthFromDatabase: getBackendMethod('_computeMaxHeadwordLengthFromDatabase'),
+            _getEnabledDictionaryNames: getBackendMethod('_getEnabledDictionaryNames'),
+            _getDictionarySetCacheKey: getBackendMethod('_getDictionarySetCacheKey'),
+            _getStoredGlobalMaxHeadwordLength: getBackendMethod('_getStoredGlobalMaxHeadwordLength'),
+            _setGlobalMaxHeadwordLength: vi.fn(async () => false),
+            _options: {
+                global: {
+                    database: {
+                        maxHeadwordLength: 0,
+                    },
+                },
+            },
+        };
+
+        const first = await getBackendMethod('_onApiGetEffectiveHoverScanLength').call(context, {optionsContext: {current: true}});
+        const second = await getBackendMethod('_onApiGetEffectiveHoverScanLength').call(context, {optionsContext: {current: true}});
+
+        expect(first).toBe(29);
+        expect(second).toBe(29);
+        expect(getMaxHeadwordLength).toHaveBeenCalledTimes(1);
+    });
+
+    test('getEffectiveHoverScanLength falls back to the stored scan length when the database returns 0', async () => {
+        const rawProfileOptions = {
+            scanning: {length: 16},
+            dictionaries: [{name: 'Enabled', enabled: true}],
+        };
+        const context = {
+            _effectiveScanLengthMaxHeadwordLengthCache: new Map(),
+            _dictionaryDatabase: {getMaxHeadwordLength: vi.fn(async () => 0)},
+            _dictionaryImportModeActive: false,
+            _ensureDictionaryDatabaseReady: vi.fn(async () => {}),
+            _getProfileOptions: vi.fn(() => rawProfileOptions),
+            _getEffectiveHoverScanLength: getBackendMethod('_getEffectiveHoverScanLength'),
+            _computeMaxHeadwordLengthFromDatabase: getBackendMethod('_computeMaxHeadwordLengthFromDatabase'),
+            _getEnabledDictionaryNames: getBackendMethod('_getEnabledDictionaryNames'),
+            _getDictionarySetCacheKey: getBackendMethod('_getDictionarySetCacheKey'),
+            _getStoredGlobalMaxHeadwordLength: getBackendMethod('_getStoredGlobalMaxHeadwordLength'),
+            _setGlobalMaxHeadwordLength: vi.fn(async () => false),
+            _options: {
+                global: {
+                    database: {
+                        maxHeadwordLength: 0,
+                    },
+                },
+            },
+        };
+
+        const result = await getBackendMethod('_onApiGetEffectiveHoverScanLength').call(context, {optionsContext: {current: true}});
+
+        expect(result).toBe(16);
+    });
+
+    test('getEffectiveHoverScanLength falls back to the stored scan length when the database is unavailable', async () => {
+        const rawProfileOptions = {
+            scanning: {length: 16},
+            dictionaries: [{name: 'Enabled', enabled: true}],
+        };
+        const context = {
+            _effectiveScanLengthMaxHeadwordLengthCache: new Map(),
+            _dictionaryDatabase: {getMaxHeadwordLength: vi.fn(async () => 21)},
+            _dictionaryImportModeActive: false,
+            _ensureDictionaryDatabaseReady: vi.fn(async () => {
+                throw new Error('database unavailable');
+            }),
+            _getProfileOptions: vi.fn(() => rawProfileOptions),
+            _getEffectiveHoverScanLength: getBackendMethod('_getEffectiveHoverScanLength'),
+            _computeMaxHeadwordLengthFromDatabase: getBackendMethod('_computeMaxHeadwordLengthFromDatabase'),
+            _getEnabledDictionaryNames: getBackendMethod('_getEnabledDictionaryNames'),
+            _getDictionarySetCacheKey: getBackendMethod('_getDictionarySetCacheKey'),
+            _getStoredGlobalMaxHeadwordLength: getBackendMethod('_getStoredGlobalMaxHeadwordLength'),
+            _setGlobalMaxHeadwordLength: vi.fn(async () => false),
+            _options: {
+                global: {
+                    database: {
+                        maxHeadwordLength: 0,
+                    },
+                },
+            },
+        };
+
+        const result = await getBackendMethod('_onApiGetEffectiveHoverScanLength').call(context, {optionsContext: {current: true}});
+
+        expect(result).toBe(16);
+        expect(context._dictionaryDatabase.getMaxHeadwordLength).not.toHaveBeenCalled();
+    });
+
+    test('dictionary updates clear the cached hover scan lengths', async () => {
+        const refreshCachedMaxHeadwordLength = vi.fn(async () => 21);
+        const triggerDatabaseUpdated = vi.fn(async () => {});
+        const cache = new Map([['Enabled', 21]]);
+        const context = {
+            _effectiveScanLengthMaxHeadwordLengthCache: cache,
+            _refreshCachedMaxHeadwordLength: refreshCachedMaxHeadwordLength,
+            _triggerDatabaseUpdated: triggerDatabaseUpdated,
+            _dictionaryMutationActive: false,
+        };
+
+        await getBackendMethod('_handleDatabaseUpdated').call(context, 'dictionary', 'import');
+
+        expect(cache.size).toBe(0);
+        expect(refreshCachedMaxHeadwordLength).toHaveBeenCalledWith('background', {allowDuringMutation: false});
+        expect(triggerDatabaseUpdated).toHaveBeenCalledWith('dictionary', 'import');
     });
 
     test('optionsGetFull still returns the raw stored options object', () => {

--- a/test/backend-translator-options-cache.test.js
+++ b/test/backend-translator-options-cache.test.js
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2023-2025  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* eslint-disable no-underscore-dangle */
+
+import {describe, expect, test} from 'vitest';
+import {Backend} from '../ext/js/background/backend.js';
+
+/**
+ * @returns {import('settings').ProfileOptions}
+ */
+function createProfileOptions() {
+    return /** @type {import('settings').ProfileOptions} */ ({
+        general: {
+            mainDictionary: 'Main Dictionary',
+            sortFrequencyDictionary: null,
+            sortFrequencyDictionaryOrder: 'descending',
+            language: 'ja',
+        },
+        scanning: {
+            alphanumeric: false,
+        },
+        translation: {
+            searchResolution: 'letter',
+            textReplacements: {
+                searchOriginal: true,
+                groups: [[
+                    {pattern: 'foo', ignoreCase: false, replacement: 'bar'},
+                ]],
+            },
+        },
+        dictionaries: [{
+            name: 'Terms Dictionary',
+            enabled: true,
+            alias: 'Terms Dictionary',
+            allowSecondarySearches: false,
+            partsOfSpeechFilter: true,
+            useDeinflections: true,
+        }],
+    });
+}
+
+/**
+ * @returns {Backend}
+ */
+function createBackendForTesting() {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const backend = /** @type {Backend} */ (Object.create(Backend.prototype));
+    backend._translatorProfileOptionsCache = new WeakMap();
+    return backend;
+}
+
+describe('Backend translator option cache', () => {
+    test('reuses compiled lookup state for repeated term lookups', () => {
+        const backend = createBackendForTesting();
+        const options = createProfileOptions();
+
+        const first = backend._getTranslatorFindTermsOptions('split', {}, options);
+        const second = backend._getTranslatorFindTermsOptions('split', {}, options);
+
+        expect(second.enabledDictionaryMap).toBe(first.enabledDictionaryMap);
+        expect(second.textReplacements).toBe(first.textReplacements);
+        expect(second.textReplacements[1]?.[0].pattern).toBeInstanceOf(RegExp);
+    });
+
+    test('keeps merge fallback state isolated from the base dictionary map', () => {
+        const backend = createBackendForTesting();
+        const options = createProfileOptions();
+
+        const split = backend._getTranslatorFindTermsOptions('split', {}, options);
+        const mergeFirst = backend._getTranslatorFindTermsOptions('merge', {}, options);
+        const mergeSecond = backend._getTranslatorFindTermsOptions('merge', {}, options);
+
+        expect(split.enabledDictionaryMap.has('Main Dictionary')).toBe(false);
+        expect(mergeFirst.enabledDictionaryMap.has('Main Dictionary')).toBe(true);
+        expect(mergeSecond.enabledDictionaryMap).toBe(mergeFirst.enabledDictionaryMap);
+        expect(mergeSecond.excludeDictionaryDefinitions).toBe(mergeFirst.excludeDictionaryDefinitions);
+    });
+});
+
+/* eslint-enable no-underscore-dangle */

--- a/test/chromium/extension-two-dictionary-import.e2e.js
+++ b/test/chromium/extension-two-dictionary-import.e2e.js
@@ -161,6 +161,28 @@ function parseBooleanEnv(value, defaultValue) {
     return defaultValue;
 }
 
+function parseIntegerEnv(value, defaultValue, minimum = Number.NEGATIVE_INFINITY, maximum = Number.POSITIVE_INFINITY) {
+    if (typeof value !== 'string') {
+        return defaultValue;
+    }
+    const parsed = Number.parseInt(value.trim(), 10);
+    if (!Number.isFinite(parsed)) {
+        return defaultValue;
+    }
+    return Math.min(maximum, Math.max(minimum, parsed));
+}
+
+function parseStringListEnv(value, fallbackValues) {
+    if (typeof value !== 'string') {
+        return fallbackValues;
+    }
+    const parsed = value
+        .split(',')
+        .map((item) => item.trim())
+        .filter((item) => item.length > 0);
+    return parsed.length > 0 ? parsed : fallbackValues;
+}
+
 const strictUnsupportedRuntime = parseBooleanEnv(
     process.env.MANABITAN_E2E_STRICT_RUNTIME,
     parseBooleanEnv(process.env.CI, false),
@@ -170,6 +192,16 @@ const maxReportLogLines = Number.isFinite(maxReportLogLinesRaw) && maxReportLogL
 const quickImportBenchmarkMode = parseBooleanEnv(process.env.MANABITAN_E2E_IMPORT_BENCH_QUICK, false);
 const stopAfterIsolatedProbes = parseBooleanEnv(process.env.MANABITAN_E2E_STOP_AFTER_ISOLATED_PROBES, false);
 const stopAfterHoverStress = parseBooleanEnv(process.env.MANABITAN_E2E_STOP_AFTER_HOVER_STRESS, false);
+const hoverStressIterations = parseIntegerEnv(process.env.MANABITAN_E2E_HOVER_STRESS_ITERATIONS, 12, 1, 64);
+const hoverStressTargets = parseStringListEnv(process.env.MANABITAN_E2E_HOVER_TARGETS, [
+    '#target-word',
+    '#target-cat',
+    '#target-name',
+    '#target-kotoba',
+    '#target-born',
+    '#target-mitou',
+]);
+const overrideJmdictUrl = typeof process.env.MANABITAN_E2E_JMDICT_URL === 'string' ? process.env.MANABITAN_E2E_JMDICT_URL.trim() : '';
 const concurrentDbOpenPressureEnabled = (
     !quickImportBenchmarkMode &&
     parseBooleanEnv(process.env.MANABITAN_E2E_DB_OPEN_PRESSURE, true)
@@ -682,11 +714,28 @@ async function loadRecommendedDictionaryUrls() {
         return '';
     };
     const jitendexUrl = findDownloadUrl('Jitendex');
-    const jmdictUrl = findDownloadUrl('JMdict') || fallbackJmdictUrl;
+    const jmdictUrl = (
+        overrideJmdictUrl.length > 0 ?
+        overrideJmdictUrl :
+        (findDownloadUrl('JMdict') || fallbackJmdictUrl)
+    );
     if (jitendexUrl.length === 0 || jmdictUrl.length === 0) {
         fail(`Unable to resolve recommended dictionary URLs (jitendex="${jitendexUrl}", jmdict="${jmdictUrl}")`);
     }
     return {jitendexUrl, jmdictUrl};
+}
+
+function getCachedDownloadFileName(url, fallbackFileName) {
+    try {
+        const parsedUrl = new URL(url);
+        const baseName = path.basename(parsedUrl.pathname || '');
+        if (/^[A-Za-z0-9._-]+\.zip$/u.test(baseName)) {
+            return baseName;
+        }
+    } catch (_) {
+        // Fall back to the provided file name when URL parsing fails.
+    }
+    return fallbackFileName;
 }
 
 async function ensureCachedDownload(url, outputPath) {
@@ -711,7 +760,7 @@ async function ensureRealDictionaryCache() {
     await mkdir(dictionaryCacheDir, {recursive: true});
     const {jitendexUrl, jmdictUrl} = await loadRecommendedDictionaryUrls();
     const jitendexPath = path.join(dictionaryCacheDir, 'jitendex-yomitan.zip');
-    const jmdictPath = path.join(dictionaryCacheDir, 'JMdict.zip');
+    const jmdictPath = path.join(dictionaryCacheDir, getCachedDownloadFileName(jmdictUrl, 'JMdict.zip'));
     await ensureCachedDownload(jitendexUrl, jitendexPath);
     await ensureCachedDownload(jmdictUrl, jmdictPath);
     return {jitendexPath, jmdictPath};
@@ -2106,6 +2155,19 @@ async function hoverLookupOnWagahai(page, targetSelector) {
                 }
                 await popupFrame.waitForSelector('#dictionary-entries, #no-results, #no-dictionaries', {timeout: 5000});
                 const popupText = (await popupFrame.locator('body').textContent()) ?? '';
+                const popupMetrics = await popupFrame.evaluate(() => {
+                    const body = document.body;
+                    const dictionaryEntries = document.querySelector('#dictionary-entries');
+                    return {
+                        bodyHtmlLength: body?.innerHTML.length ?? 0,
+                        bodyTextLength: body?.textContent?.length ?? 0,
+                        dictionaryEntryNodeCount: dictionaryEntries?.querySelectorAll('.entry').length ?? 0,
+                        definitionItemCount: dictionaryEntries?.querySelectorAll('.definition-item').length ?? 0,
+                        structuredContentNodeCount: dictionaryEntries?.querySelectorAll('.structured-content').length ?? 0,
+                        structuredContentTableCount: dictionaryEntries?.querySelectorAll('.structured-content table').length ?? 0,
+                        glossaryImageCount: dictionaryEntries?.querySelectorAll('.gloss-image-link, .gloss-image-container img').length ?? 0,
+                    };
+                });
                 if (popupText.trim().length === 0) {
                     lastDiagnostics = {
                         page: await readDocumentDatasetDiagnostics(page, hoverPageDiagnosticsDatasetKeys),
@@ -2121,6 +2183,7 @@ async function hoverLookupOnWagahai(page, targetSelector) {
                 };
                 return {
                     popupText,
+                    popupMetrics,
                     usedModifier: modifier,
                     diagnostics: {
                         page: pageDiagnostics,
@@ -3494,19 +3557,11 @@ async function main() {
                         throw new Error('Local E2E server is unavailable for scanning stress test');
                     }
                     await page.goto(`${localServer.baseUrl}/wagahai-neko.html`);
-                    const scanTargets = [
-                        '#target-word',
-                        '#target-cat',
-                        '#target-name',
-                        '#target-kotoba',
-                        '#target-born',
-                        '#target-mitou',
-                    ];
                     const iterations = [];
-                    for (let i = 0; i < 12; ++i) {
-                        const selector = scanTargets[i % scanTargets.length];
+                    for (let i = 0; i < hoverStressIterations; ++i) {
+                        const selector = hoverStressTargets[i % hoverStressTargets.length];
                         const iterationStart = safePerformance.now();
-                        const {popupText, usedModifier, diagnostics = null} = await hoverLookupOnWagahai(page, selector);
+                        const {popupText, popupMetrics = null, usedModifier, diagnostics = null} = await hoverLookupOnWagahai(page, selector);
                         const iterationEnd = safePerformance.now();
                         const hasDictionaryResult = /jmdict|jitendex/i.test(popupText);
                         iterations.push({
@@ -3516,6 +3571,7 @@ async function main() {
                             durationMs: Math.max(0, iterationEnd - iterationStart),
                             hasDictionaryResult,
                             popupTextPreview: popupText.replaceAll(/\s+/g, ' ').trim().slice(0, 180),
+                            popupMetrics,
                             diagnostics,
                         });
                         if (!hasDictionaryResult) {

--- a/test/chromium/extension-two-dictionary-import.e2e.js
+++ b/test/chromium/extension-two-dictionary-import.e2e.js
@@ -48,6 +48,15 @@ const e2eLogTag = `[${browserFlavor}-e2e]`;
 const browserChannel = browserFlavor === 'edge' ? 'msedge' : null;
 const expectedLookupDictionaries = ['Jitendex', 'JMdict'];
 const autoUpdateStateStorageKey = 'manabitanDictionaryAutoUpdateState';
+const hoverPageDiagnosticsDatasetKeys = [
+    'manabitanDevHoverScannerDiagnostics',
+    'manabitanDevHoverFrontendDiagnostics',
+    'manabitanDevPopupDiagnostics',
+    'manabitanDevApiInvokeDiagnostics',
+];
+const hoverPopupDiagnosticsDatasetKeys = [
+    'manabitanDevPopupDisplayDiagnostics',
+];
 const overlapLookupCandidates = [
     '日本',
     '名前',
@@ -160,6 +169,7 @@ const maxReportLogLinesRaw = Number.parseInt(process.env.MANABITAN_CHROMIUM_E2E_
 const maxReportLogLines = Number.isFinite(maxReportLogLinesRaw) && maxReportLogLinesRaw > 0 ? maxReportLogLinesRaw : 1000;
 const quickImportBenchmarkMode = parseBooleanEnv(process.env.MANABITAN_E2E_IMPORT_BENCH_QUICK, false);
 const stopAfterIsolatedProbes = parseBooleanEnv(process.env.MANABITAN_E2E_STOP_AFTER_ISOLATED_PROBES, false);
+const stopAfterHoverStress = parseBooleanEnv(process.env.MANABITAN_E2E_STOP_AFTER_HOVER_STRESS, false);
 const concurrentDbOpenPressureEnabled = (
     !quickImportBenchmarkMode &&
     parseBooleanEnv(process.env.MANABITAN_E2E_DB_OPEN_PRESSURE, true)
@@ -1059,10 +1069,14 @@ async function evalSendMessage(page, expression, arg = null) {
             const installedTitles = (Array.isArray(dictionaryInfo) ? dictionaryInfo : [])
                 .map((row) => String(row?.title || '').trim())
                 .filter((value) => value.length > 0);
+            const clearDatabaseCaches = async () => {
+                await send('clearDatabaseCaches', undefined);
+            };
             const collectTermLookup = async (details) => {
                 const termsFind = await send('termsFind', {
                     text: term,
                     details: {
+                        includeTimingDiagnostics: true,
                         primaryReading: '',
                         ...details,
                     },
@@ -1078,9 +1092,15 @@ async function evalSendMessage(page, expression, arg = null) {
                 return {
                     termResultCount: Array.isArray(termsFind?.dictionaryEntries) ? termsFind.dictionaryEntries.length : 0,
                     termDictionaryNames: [...new Set(termDictionaryNames)],
+                    originalTextLength: Number(termsFind?.originalTextLength || 0),
+                    timingDiagnostics: (typeof termsFind?.timingDiagnostics === 'object' && termsFind?.timingDiagnostics !== null) ?
+                        termsFind.timingDiagnostics :
+                        null,
                 };
             };
             const termLookupDefault = await collectTermLookup({});
+            await clearDatabaseCaches();
+            const termLookupExactNoDeinflectColdTagCache = await collectTermLookup({matchType: 'exact', deinflect: false});
             const termLookupExactNoDeinflect = await collectTermLookup({matchType: 'exact', deinflect: false});
             const termLookupPrefixNoDeinflect = await collectTermLookup({matchType: 'prefix', deinflect: false});
             const enabledDictionaryNames = [];
@@ -1108,6 +1128,7 @@ async function evalSendMessage(page, expression, arg = null) {
                 termDictionaryNames: termLookupDefault.termDictionaryNames,
                 termLookupDiagnostics: {
                     default: termLookupDefault,
+                    exactNoDeinflectColdTagCache: termLookupExactNoDeinflectColdTagCache,
                     exactNoDeinflect: termLookupExactNoDeinflect,
                     prefixNoDeinflect: termLookupPrefixNoDeinflect,
                 },
@@ -1232,6 +1253,40 @@ async function evalSendMessage(page, expression, arg = null) {
             });
             const profileMainDictionaries = (updatedOptions?.profiles || []).map((profile) => String(profile?.options?.general?.mainDictionary || '').trim());
             return {ok: true, targetNames, profileEnabledDictionaryNames, profileMainDictionaries};
+        }
+        if (expression === 'configureHoverScanning') {
+            const optionsFull = await send('optionsGetFull', undefined);
+            const nextOptions = structuredClone(optionsFull);
+            for (const profile of nextOptions.profiles || []) {
+                const general = profile?.options?.general;
+                const scanning = profile?.options?.scanning;
+                if (!(general && scanning && Array.isArray(scanning.inputs))) { continue; }
+                general.enable = true;
+                scanning.delay = 0;
+                scanning.scanWithoutMousemove = false;
+                for (const input of scanning.inputs) {
+                    if (!(input?.types?.mouse === true)) { continue; }
+                    input.include = '';
+                    if (typeof input.exclude !== 'string' || input.exclude.length === 0) {
+                        input.exclude = 'mouse0';
+                    }
+                }
+            }
+            await send('setAllSettings', {value: nextOptions, source: 'chromium-e2e-hover-scanning'});
+            const updatedOptions = await send('optionsGetFull', undefined);
+            return {
+                ok: true,
+                profiles: (updatedOptions?.profiles || []).map((profile) => ({
+                    enabled: profile?.options?.general?.enable === true,
+                    delay: Number(profile?.options?.scanning?.delay || 0),
+                    mouseInputs: (profile?.options?.scanning?.inputs || [])
+                        .filter((input) => input?.types?.mouse === true)
+                        .map((input) => ({
+                            include: String(input?.include || ''),
+                            exclude: String(input?.exclude || ''),
+                        })),
+                })),
+            };
         }
         if (expression === 'backendProbe') {
             const dictionaryInfo = await send('getDictionaryInfo', undefined);
@@ -1950,45 +2005,127 @@ async function waitForVisiblePopupFrameHandle(page, timeoutMs = 6000) {
     return null;
 }
 
+async function clearDocumentDatasetDiagnostics(frameOrPage, datasetKeys) {
+    await frameOrPage.evaluate((keys) => {
+        const {documentElement} = document;
+        if (!(documentElement instanceof HTMLElement)) { return; }
+        for (const key of keys) {
+            delete documentElement.dataset[key];
+        }
+    }, datasetKeys);
+}
+
+async function readDocumentDatasetDiagnostics(frameOrPage, datasetKeys) {
+    return await frameOrPage.evaluate((keys) => {
+        const {documentElement} = document;
+        if (!(documentElement instanceof HTMLElement)) { return {}; }
+        const results = {};
+        for (const key of keys) {
+            const value = documentElement.dataset[key];
+            if (typeof value !== 'string' || value.length === 0) {
+                results[key] = null;
+                continue;
+            }
+            try {
+                results[key] = JSON.parse(value);
+            } catch (_) {
+                results[key] = value;
+            }
+        }
+        return results;
+    }, datasetKeys);
+}
+
+async function waitForDocumentDatasetDiagnostics(frameOrPage, datasetKeys, timeoutMs = 1000) {
+    const deadline = safePerformance.now() + timeoutMs;
+    while (safePerformance.now() < deadline) {
+        const diagnostics = await readDocumentDatasetDiagnostics(frameOrPage, datasetKeys);
+        if (Object.values(diagnostics).some((value) => value !== null)) {
+            return diagnostics;
+        }
+        await frameOrPage.waitForTimeout(25);
+    }
+    return await readDocumentDatasetDiagnostics(frameOrPage, datasetKeys);
+}
+
+async function clearPopupFrameDiagnostics(page, datasetKeys) {
+    const frameHandles = await page.$$('iframe.yomitan-popup');
+    for (const frameHandle of frameHandles) {
+        const popupFrame = await frameHandle.contentFrame();
+        if (popupFrame === null) { continue; }
+        await clearDocumentDatasetDiagnostics(popupFrame, datasetKeys);
+    }
+}
+
 async function hoverLookupOnWagahai(page, targetSelector) {
     const target = page.locator(targetSelector).first();
     await target.waitFor({state: 'visible', timeout: 10000});
     await target.scrollIntoViewIfNeeded();
     await page.bringToFront();
-    await page.locator('body').click({position: {x: 12, y: 12}});
+    await page.evaluate(() => {
+        document.documentElement.dataset.manabitanDevIncludeApiTimingDiagnostics = 'true';
+    });
+    await clearDocumentDatasetDiagnostics(page, hoverPageDiagnosticsDatasetKeys);
+    let lastDiagnostics = null;
     const box = await target.boundingBox();
     if (box === null) {
         throw new Error(`Unable to resolve bounding box for selector ${targetSelector}`);
     }
+    const viewportSize = page.viewportSize();
     const hoverX = box.x + Math.max(2, Math.min(10, box.width * 0.25));
     const hoverY = box.y + Math.max(2, Math.min(12, box.height * 0.5));
-    const resetX = Math.max(2, hoverX - 120);
-    const modifierCandidates = ['Shift', 'Alt', 'Control', null];
+    const resetX = Math.max(2, Math.min((viewportSize?.width ?? hoverX + 220) - 24, hoverX + 180));
+    await page.locator('body').click({position: {x: resetX, y: Math.max(12, hoverY)}});    
+    const modifierCandidates = [null, 'Shift', 'Alt', 'Control'];
     for (const modifier of modifierCandidates) {
         if (modifier !== null) {
             await page.keyboard.down(modifier);
         }
         try {
             for (let attempt = 0; attempt < 3; ++attempt) {
+                await clearDocumentDatasetDiagnostics(page, hoverPageDiagnosticsDatasetKeys);
+                await clearPopupFrameDiagnostics(page, hoverPopupDiagnosticsDatasetKeys);
                 await page.mouse.move(resetX, hoverY, {steps: 6});
                 await page.waitForTimeout(35);
                 await page.mouse.move(hoverX, hoverY, {steps: 16});
                 const popupFrameHandle = await waitForVisiblePopupFrameHandle(page, 3000);
                 if (popupFrameHandle === null) {
+                    lastDiagnostics = {
+                        page: await readDocumentDatasetDiagnostics(page, hoverPageDiagnosticsDatasetKeys),
+                        popup: null,
+                    };
                     continue;
                 }
                 const popupFrame = await popupFrameHandle.contentFrame();
                 if (popupFrame === null) {
+                    lastDiagnostics = {
+                        page: await readDocumentDatasetDiagnostics(page, hoverPageDiagnosticsDatasetKeys),
+                        popup: null,
+                    };
                     continue;
                 }
                 await popupFrame.waitForSelector('#dictionary-entries, #no-results, #no-dictionaries', {timeout: 5000});
                 const popupText = (await popupFrame.locator('body').textContent()) ?? '';
                 if (popupText.trim().length === 0) {
+                    lastDiagnostics = {
+                        page: await readDocumentDatasetDiagnostics(page, hoverPageDiagnosticsDatasetKeys),
+                        popup: await readDocumentDatasetDiagnostics(popupFrame, hoverPopupDiagnosticsDatasetKeys),
+                    };
                     continue;
                 }
+                const pageDiagnostics = await readDocumentDatasetDiagnostics(page, hoverPageDiagnosticsDatasetKeys);
+                const popupDiagnostics = await waitForDocumentDatasetDiagnostics(popupFrame, hoverPopupDiagnosticsDatasetKeys, 1000);
+                lastDiagnostics = {
+                    page: pageDiagnostics,
+                    popup: popupDiagnostics,
+                };
                 return {
                     popupText,
                     usedModifier: modifier,
+                    diagnostics: {
+                        page: pageDiagnostics,
+                        popup: popupDiagnostics,
+                    },
                 };
             }
         } finally {
@@ -1997,7 +2134,7 @@ async function hoverLookupOnWagahai(page, targetSelector) {
             }
         }
     }
-    throw new Error(`Hover scan did not produce a visible popup for selector ${targetSelector}`);
+    throw new Error(`Hover scan did not produce a visible popup for selector ${targetSelector}. diagnostics=${JSON.stringify(lastDiagnostics)}`);
 }
 
 async function loadDictionaryProbeTermsFromArchive(zipPath, maxTerms = 80) {
@@ -3319,6 +3456,33 @@ async function main() {
                 processSampler,
             );
 
+            const configureHoverScanningStart = safePerformance.now();
+            let configureHoverScanningProfile = null;
+            let configureHoverScanningResult = null;
+            let configureHoverScanningError = '';
+            try {
+                configureHoverScanningProfile = await runPhaseProfile(cdpSession, async () => {
+                    return await evalSendMessage(page, 'configureHoverScanning');
+                });
+                configureHoverScanningResult = configureHoverScanningProfile.result;
+            } catch (e) {
+                configureHoverScanningError = errorMessage(e);
+                verificationErrors.push(`Hover scanning configuration failed: ${configureHoverScanningError}`);
+            }
+            const configureHoverScanningEnd = safePerformance.now();
+            await addReportPhase(
+                report,
+                page,
+                'Configure hover scanning profile',
+                configureHoverScanningError.length > 0 ?
+                    `Failed to configure hover scanning defaults for Playwright mouse hover: ${configureHoverScanningError}` :
+                    `Configured hover scanning defaults for Playwright mouse hover: ${JSON.stringify(configureHoverScanningResult)}`,
+                configureHoverScanningStart,
+                configureHoverScanningEnd,
+                configureHoverScanningProfile,
+                processSampler,
+            );
+
             const scanningStressStart = safePerformance.now();
             let scanningStressProfile = null;
             let scanningStressError = '';
@@ -3342,7 +3506,7 @@ async function main() {
                     for (let i = 0; i < 12; ++i) {
                         const selector = scanTargets[i % scanTargets.length];
                         const iterationStart = safePerformance.now();
-                        const {popupText, usedModifier} = await hoverLookupOnWagahai(page, selector);
+                        const {popupText, usedModifier, diagnostics = null} = await hoverLookupOnWagahai(page, selector);
                         const iterationEnd = safePerformance.now();
                         const hasDictionaryResult = /jmdict|jitendex/i.test(popupText);
                         iterations.push({
@@ -3352,6 +3516,7 @@ async function main() {
                             durationMs: Math.max(0, iterationEnd - iterationStart),
                             hasDictionaryResult,
                             popupTextPreview: popupText.replaceAll(/\s+/g, ' ').trim().slice(0, 180),
+                            diagnostics,
                         });
                         if (!hasDictionaryResult) {
                             throw new Error(`Scan iteration ${String(i + 1)} (${selector}) produced popup without dictionary result`);
@@ -3399,6 +3564,12 @@ async function main() {
                 scanningStressProfile,
                 processSampler,
             );
+            if (stopAfterHoverStress) {
+                report.status = 'success';
+                appendLog(report, 'info', 'Stopped after hover scanning stress by MANABITAN_E2E_STOP_AFTER_HOVER_STRESS=1.');
+                console.log(`${e2eLogTag} PASS: Stopped after hover scanning stress by MANABITAN_E2E_STOP_AFTER_HOVER_STRESS=1.`);
+                return;
+            }
 
             const postUsageSearchStart = safePerformance.now();
             let postUsageSearchProfile = null;

--- a/test/dictionary-database-max-headword.test.js
+++ b/test/dictionary-database-max-headword.test.js
@@ -36,6 +36,7 @@ describe('DictionaryDatabase max headword length cache', () => {
         const selectValue = vi.fn(() => null);
         const context = {
             _maxHeadwordLengthCache: null,
+            _maxHeadwordLengthCacheByDictionaryKey: new Map(),
             _requireDb: () => ({selectValue}),
             _asNumber: getDictionaryDatabaseMethod('_asNumber'),
         };
@@ -53,6 +54,7 @@ describe('DictionaryDatabase max headword length cache', () => {
         const selectValue = vi.fn(() => 11);
         const context = {
             _maxHeadwordLengthCache: null,
+            _maxHeadwordLengthCacheByDictionaryKey: new Map(),
             _requireDb: () => ({selectValue}),
             _asNumber: getDictionaryDatabaseMethod('_asNumber'),
         };
@@ -70,11 +72,40 @@ describe('DictionaryDatabase max headword length cache', () => {
         expect(sql).toContain('LENGTH(COALESCE(expression');
     });
 
+    test('filters headword length by dictionary set and caches the result per set', async () => {
+        const selectValue = vi.fn(() => 17);
+        const context = {
+            _maxHeadwordLengthCache: null,
+            _maxHeadwordLengthCacheByDictionaryKey: new Map(),
+            _requireDb: () => ({selectValue}),
+            _asNumber: getDictionaryDatabaseMethod('_asNumber'),
+            _asString: getDictionaryDatabaseMethod('_asString'),
+            _buildTextInClause: getDictionaryDatabaseMethod('_buildTextInClause'),
+            _getDictionarySetCacheKey: getDictionaryDatabaseMethod('_getDictionarySetCacheKey'),
+        };
+
+        const getMaxHeadwordLength = getDictionaryDatabaseMethod('getMaxHeadwordLength');
+        const first = await getMaxHeadwordLength.call(context, ['Beta', 'Alpha', 'Beta']);
+        const second = await getMaxHeadwordLength.call(context, ['Alpha', 'Beta']);
+
+        expect(first).toBe(17);
+        expect(second).toBe(17);
+        expect(selectValue).toHaveBeenCalledTimes(1);
+        const firstCall = selectValue.mock.calls[0];
+        if (typeof firstCall === 'undefined') {
+            throw new Error('Expected selectValue to be called');
+        }
+        const [sql, bind] = /** @type {[string, Record<string, string>]} */ (/** @type {unknown} */ (firstCall));
+        expect(sql).toContain('WHERE dictionary IN');
+        expect(Object.values(bind)).toStrictEqual(['Alpha', 'Beta']);
+    });
+
     test('term mutations invalidate the memoized max headword length', async () => {
         const clearTermEntryContentMetaCaches = vi.fn();
         const bulkAddTerms = vi.fn(async () => {});
         const context = {
             _maxHeadwordLengthCache: 12,
+            _maxHeadwordLengthCacheByDictionaryKey: new Map([['Alpha\u001fBeta', 17]]),
             _requireDb: () => ({}),
             _invalidateMaxHeadwordLengthCache: getDictionaryDatabaseMethod('_invalidateMaxHeadwordLengthCache'),
             _lastBulkAddTermsMetrics: null,
@@ -92,6 +123,7 @@ describe('DictionaryDatabase max headword length cache', () => {
         await getDictionaryDatabaseMethod('bulkAdd').call(context, 'terms', [{}], 0, 1);
 
         expect(context._maxHeadwordLengthCache).toBeNull();
+        expect(context._maxHeadwordLengthCacheByDictionaryKey.size).toBe(0);
         expect(bulkAddTerms).toHaveBeenCalledTimes(1);
         expect(clearTermEntryContentMetaCaches).toHaveBeenCalledTimes(1);
     });

--- a/test/display-scan-length.test.js
+++ b/test/display-scan-length.test.js
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2026  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {afterAll, describe, expect, test, vi} from 'vitest';
+import {Display} from '../ext/js/display/display.js';
+import {setupDomTest} from './fixtures/dom-test.js';
+
+const {teardown} = await setupDomTest('ext/search.html');
+
+/**
+ * @param {string} name
+ * @returns {(this: unknown, ...args: unknown[]) => unknown}
+ * @throws {Error}
+ */
+function getDisplayMethod(name) {
+    const method = Reflect.get(Display.prototype, name);
+    if (typeof method !== 'function') {
+        throw new Error(`Expected ${name} method`);
+    }
+    return method;
+}
+
+/**
+ * @param {number} scanLength
+ * @returns {import('settings').ProfileOptions}
+ */
+function createProfileOptions(scanLength) {
+    return /** @type {import('settings').ProfileOptions} */ ({
+        general: {
+            language: 'ja',
+        },
+        parsing: {
+            selectedParser: null,
+            termSpacing: true,
+            readingMode: 'default',
+            enableScanningParser: true,
+            enableMecabParser: false,
+        },
+        scanning: {
+            inputs: [],
+            deepDomScan: false,
+            normalizeCssZoom: true,
+            selectText: false,
+            delay: 10,
+            length: scanLength,
+            layoutAwareScan: false,
+            preventMiddleMouse: {
+                onSearchQuery: false,
+                onTextHover: false,
+            },
+            preventBackForward: {
+                onSearchQuery: false,
+                onTextHover: false,
+            },
+            scanWithoutMousemove: false,
+            scanResolution: 'sentence',
+            enablePopupSearch: true,
+            enableOnSearchPage: true,
+        },
+        sentenceParsing: {
+            scanExtent: 200,
+            terminationCharacterMode: 'newlines',
+            terminationCharacters: [],
+        },
+    });
+}
+
+describe('Display scan length usage', () => {
+    afterAll(async () => {
+        await teardown(global);
+    });
+
+    test('query parser keeps using the stored scan length', () => {
+        const options = createProfileOptions(31);
+        const context = {
+            _options: null,
+            _updateHotkeys: vi.fn(),
+            _updateDocumentOptions: vi.fn(),
+            _setTheme: vi.fn(),
+            _setStickyHeader: vi.fn(),
+            _hotkeyHelpController: {setOptions: vi.fn(), setupNode: vi.fn()},
+            _displayGenerator: {updateHotkeys: vi.fn(), updateLanguage: vi.fn()},
+            _elementOverflowController: {setOptions: vi.fn()},
+            _queryParser: {setOptions: vi.fn()},
+            _updateNestedFrontend: vi.fn(),
+            _updateContentTextScanner: vi.fn(),
+            trigger: vi.fn(),
+        };
+
+        getDisplayMethod('_applyOptions').call(context, options);
+
+        expect(context._queryParser.setOptions).toHaveBeenCalledWith(expect.objectContaining({
+            scanning: expect.objectContaining({
+                scanLength: 31,
+            }),
+        }));
+        expect(context._updateContentTextScanner).toHaveBeenCalledWith(options);
+    });
+
+    test('embedded popup/search scanner keeps using the stored scan length', () => {
+        const options = createProfileOptions(27);
+        const contentTextScanner = {
+            language: null,
+            setOptions: vi.fn(),
+            setEnabled: vi.fn(),
+        };
+        const context = {
+            _pageType: 'search',
+            _application: {api: {}},
+            _textSourceGenerator: {},
+            _getSearchContext: vi.fn(() => ({optionsContext: {depth: 0, url: 'https://example.test/'}, detail: {documentTitle: 'Example'}})),
+            _contentTextScanner: contentTextScanner,
+        };
+
+        getDisplayMethod('_updateContentTextScanner').call(context, options);
+
+        expect(contentTextScanner.language).toBe('ja');
+        expect(contentTextScanner.setOptions).toHaveBeenCalledWith(expect.objectContaining({
+            scanLength: 27,
+        }));
+        expect(contentTextScanner.setEnabled).toHaveBeenCalledWith(true);
+    });
+});

--- a/test/frontend-hover-scan-length.test.js
+++ b/test/frontend-hover-scan-length.test.js
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2026  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {describe, expect, test, vi} from 'vitest';
+import {Frontend} from '../ext/js/app/frontend.js';
+
+/**
+ * @param {string} name
+ * @returns {(this: unknown, ...args: unknown[]) => unknown}
+ * @throws {Error}
+ */
+function getFrontendMethod(name) {
+    const method = Reflect.get(Frontend.prototype, name);
+    if (typeof method !== 'function') {
+        throw new Error(`Expected ${name} method`);
+    }
+    return method;
+}
+
+/**
+ * @param {number} scanLength
+ * @returns {import('settings').ProfileOptions}
+ */
+function createProfileOptions(scanLength) {
+    return /** @type {import('settings').ProfileOptions} */ ({
+        general: {
+            language: 'ja',
+        },
+        inputs: {
+            hotkeys: [],
+        },
+        dictionaries: [
+            {name: 'Enabled', enabled: true},
+            {name: 'Disabled', enabled: false},
+        ],
+        scanning: {
+            inputs: [],
+            deepDomScan: false,
+            normalizeCssZoom: true,
+            selectText: false,
+            delay: 20,
+            length: scanLength,
+            layoutAwareScan: false,
+            preventMiddleMouse: {
+                onWebPages: false,
+                onSearchQuery: false,
+                onPopupExpressions: false,
+                onPopupHorizontalText: false,
+                onSearchPage: false,
+                onSearchPageTextField: false,
+                onTextHover: false,
+            },
+            preventBackForward: {
+                onWebPages: false,
+                onSearchQuery: false,
+                onPopupExpressions: false,
+                onPopupHorizontalText: false,
+                onSearchPage: false,
+                onSearchPageTextField: false,
+                onTextHover: false,
+            },
+            scanWithoutMousemove: false,
+            scanResolution: 'sentence',
+            enableOnPopupExpressions: false,
+        },
+        sentenceParsing: {
+            scanExtent: 200,
+            terminationCharacterMode: 'newlines',
+            terminationCharacters: [],
+        },
+    });
+}
+
+describe('Frontend hover scan length', () => {
+    test('web hover uses the hover-effective scan length without mutating stored options', async () => {
+        const optionsContext = {depth: 0, url: 'https://example.test/'};
+        const options = createProfileOptions(24);
+        const api = {
+            optionsGet: vi.fn(async () => options),
+            getEffectiveHoverScanLength: vi.fn(async () => 12),
+        };
+        const textScanner = {
+            language: null,
+            setOptions: vi.fn(),
+            searchLast: vi.fn(async () => {}),
+        };
+        const context = {
+            _pageType: 'web',
+            _application: {api},
+            _options: null,
+            _hotkeyHandler: {setHotkeys: vi.fn()},
+            _textScanner: textScanner,
+            _getOptionsContext: vi.fn(async () => optionsContext),
+            _updatePopup: vi.fn(async () => {}),
+            _getPreventSecondaryMouseValueForPageType: vi.fn(() => false),
+            _updateTextScannerEnabled: vi.fn(),
+            _updateContentScale: vi.fn(),
+        };
+
+        await getFrontendMethod('_updateOptionsInternal').call(context);
+
+        expect(api.optionsGet).toHaveBeenCalledWith(optionsContext);
+        expect(api.getEffectiveHoverScanLength).toHaveBeenCalledWith(optionsContext);
+        expect(context._options).toBe(options);
+        expect(options.scanning.length).toBe(24);
+        expect(textScanner.language).toBe('ja');
+        expect(textScanner.setOptions).toHaveBeenCalledWith(expect.objectContaining({
+            scanLength: 12,
+            hoverScanLengthDiagnostics: {
+                configuredScanLength: 24,
+                automaticScanLength: 12,
+                effectiveScanLength: 12,
+            },
+        }));
+    });
+
+    test('non-hover pages keep the stored scan length and skip hover-effective lookup', async () => {
+        const optionsContext = {depth: 0, url: 'https://example.test/'};
+        const options = createProfileOptions(18);
+        const api = {
+            optionsGet: vi.fn(async () => options),
+            getEffectiveHoverScanLength: vi.fn(async () => 9),
+        };
+        const textScanner = {
+            language: null,
+            excludeSelector: null,
+            touchEventExcludeSelector: null,
+            setOptions: vi.fn(),
+            searchLast: vi.fn(async () => {}),
+        };
+        const context = {
+            _pageType: 'popup',
+            _application: {api},
+            _options: null,
+            _hotkeyHandler: {setHotkeys: vi.fn()},
+            _textScanner: textScanner,
+            _getOptionsContext: vi.fn(async () => optionsContext),
+            _updatePopup: vi.fn(async () => {}),
+            _getPreventSecondaryMouseValueForPageType: vi.fn(() => false),
+            _updateTextScannerEnabled: vi.fn(),
+            _updateContentScale: vi.fn(),
+        };
+
+        await getFrontendMethod('_updateOptionsInternal').call(context);
+
+        expect(api.getEffectiveHoverScanLength).not.toHaveBeenCalled();
+        expect(textScanner.setOptions).toHaveBeenCalledWith(expect.objectContaining({
+            scanLength: 18,
+            hoverScanLengthDiagnostics: null,
+        }));
+        expect(textScanner.excludeSelector).toContain('.scan-disable');
+        expect(textScanner.touchEventExcludeSelector).toContain('.gloss-link');
+    });
+});

--- a/test/settings-ui.test.js
+++ b/test/settings-ui.test.js
@@ -23,11 +23,11 @@ import {describe, expect, test} from 'vitest';
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 
 describe('Settings UI scan length exposure', () => {
-    test('settings page no longer renders a manual scan length control', () => {
+    test('settings page renders a manual hover scan length cap', () => {
         const html = fs.readFileSync(path.join(dirname, '..', 'ext', 'settings.html'), {encoding: 'utf8'});
 
-        expect(html).not.toContain('data-setting="scanning.length"');
-        expect(html).not.toContain('Text scan length');
+        expect(html).toContain('data-setting="scanning.length"');
+        expect(html).toContain('Hover scan length cap');
     });
 
     test('recommended settings no longer modify scanning.length', () => {

--- a/test/text-scanner.test.js
+++ b/test/text-scanner.test.js
@@ -134,7 +134,7 @@ function createMockTermEntry() {
 }
 
 describe('TextScanner lookup robustness', () => {
-    const {teardown} = testEnv;
+    const {window, teardown} = testEnv;
     const searchAt = getSearchAtMethod();
 
     afterAll(async () => {
@@ -274,5 +274,59 @@ describe('TextScanner lookup robustness', () => {
         // Late completions from stale timed-out lookups must not emit extra events.
         expect(searchSuccessCount).toBe(totalScans - pendingResolvers.length);
         expect(searchErrorCount).toBe(0);
+    });
+
+    test('coalesces repeated mouse moves to the latest pending lookup', async () => {
+        const scanner = new TextScanner({
+            api: /** @type {import('../ext/js/comm/api.js').API} */ ({}),
+            node: window,
+            getSearchContext: () => ({optionsContext: {url: 'https://example.com'}, detail: {documentTitle: 'Bench'}}),
+            textSourceGenerator: /** @type {import('../ext/js/dom/text-source-generator.js').TextSourceGenerator} */ ({
+                getRangeFromPoint: () => null,
+                extractSentence: () => ({text: '', offset: 0}),
+            }),
+        });
+
+        const inputInfo = createInputInfo();
+        Reflect.set(scanner, '_getMatchingInputGroupFromEvent', vi.fn(() => inputInfo));
+        Reflect.set(scanner, '_scanTimerClear', vi.fn());
+
+        /** @type {() => void} */
+        let releaseFirstLookup = () => {};
+        const firstLookupPromise = new Promise((resolve) => {
+            releaseFirstLookup = resolve;
+        });
+        /** @type {Array<{x: number, y: number}>} */
+        const calls = [];
+        const searchAtSpy = vi.fn(async (x, y, searchInputInfo) => {
+            const nextX = Number(x);
+            const nextY = Number(y);
+            calls.push({x: nextX, y: nextY});
+            Reflect.set(scanner, '_pendingLookup', true);
+            if (calls.length === 1) {
+                await firstLookupPromise;
+            }
+            Reflect.set(scanner, '_pendingLookup', false);
+            Reflect.get(scanner, '_dispatchPendingMouseMoveSearch').call(scanner);
+            void searchInputInfo;
+        });
+        Reflect.set(scanner, '_searchAt', searchAtSpy);
+
+        Reflect.get(scanner, '_onMousePointerMove').call(scanner, /** @type {PointerEvent} */ ({clientX: 10, clientY: 10}));
+        await Promise.resolve();
+
+        Reflect.get(scanner, '_onMousePointerMove').call(scanner, /** @type {PointerEvent} */ ({clientX: 20, clientY: 20}));
+        Reflect.get(scanner, '_onMousePointerMove').call(scanner, /** @type {PointerEvent} */ ({clientX: 30, clientY: 30}));
+
+        expect(calls).toStrictEqual([{x: 10, y: 10}]);
+
+        releaseFirstLookup();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(calls).toStrictEqual([
+            {x: 10, y: 10},
+            {x: 30, y: 30},
+        ]);
     });
 });

--- a/test/text-scanner.test.js
+++ b/test/text-scanner.test.js
@@ -41,6 +41,18 @@ function getSearchAtMethod() {
 }
 
 /**
+ * @returns {(scanner: TextScanner, textSource: import('text-source').TextSource, optionsContext: import('settings').OptionsContext) => Promise<import('text-scanner').TermSearchResults|null>}
+ * @throws {Error}
+ */
+function getFindTermDictionaryEntriesMethod() {
+    const findTermDictionaryEntries = Reflect.get(TextScanner.prototype, '_findTermDictionaryEntries');
+    if (typeof findTermDictionaryEntries !== 'function') {
+        throw new Error('Expected TextScanner._findTermDictionaryEntries to be available');
+    }
+    return (scanner, textSource, optionsContext) => findTermDictionaryEntries.call(scanner, textSource, optionsContext);
+}
+
+/**
  * @param {string} text
  * @returns {import('text-source').TextSource}
  */
@@ -136,6 +148,7 @@ function createMockTermEntry() {
 describe('TextScanner lookup robustness', () => {
     const {window, teardown} = testEnv;
     const searchAt = getSearchAtMethod();
+    const findTermDictionaryEntries = getFindTermDictionaryEntriesMethod();
 
     afterAll(async () => {
         await teardown(global);
@@ -328,5 +341,42 @@ describe('TextScanner lookup robustness', () => {
             {x: 10, y: 10},
             {x: 30, y: 30},
         ]);
+    });
+
+    test('hover scan length diagnostics are included in term lookup timing', async () => {
+        const termsFindImpl = vi.fn().mockResolvedValue({
+            dictionaryEntries: [createMockTermEntry()],
+            originalTextLength: 2,
+        });
+        const termsFind = /** @type {import('../ext/js/comm/api.js').API['termsFind']} */ (/** @type {unknown} */ (termsFindImpl));
+        const scanner = createScanner(termsFind, [createFakeTextSource('暗記')]);
+        scanner.setOptions({
+            scanLength: 8,
+            hoverScanLengthDiagnostics: {
+                configuredScanLength: 24,
+                automaticScanLength: 12,
+                effectiveScanLength: 8,
+            },
+        });
+
+        const result = await findTermDictionaryEntries(
+            scanner,
+            createFakeTextSource('暗記'),
+            {
+                depth: 0,
+                url: 'https://example.test/',
+                modifiers: [],
+                modifierKeys: [],
+                pointerType: 'mouse',
+            },
+        );
+
+        expect(result).not.toBeNull();
+        expect(result?.timingDiagnostics).toMatchObject({
+            configuredScanLength: 24,
+            automaticScanLength: 12,
+            effectiveScanLength: 8,
+            scanLength: 8,
+        });
     });
 });

--- a/types/ext/api.d.ts
+++ b/types/ext/api.d.ts
@@ -134,6 +134,12 @@ type ApiSurface = {
         };
         return: Settings.ProfileOptions;
     };
+    getEffectiveHoverScanLength: {
+        params: {
+            optionsContext: Settings.OptionsContext;
+        };
+        return: number;
+    };
     optionsGetFull: {
         params: void;
         return: Settings.Options;

--- a/types/ext/api.d.ts
+++ b/types/ext/api.d.ts
@@ -49,6 +49,8 @@ export type FindTermsDetails = {
     matchType?: Translation.FindTermsMatchType;
     deinflect?: boolean;
     primaryReading?: string;
+    includeTimingDiagnostics?: boolean;
+    serializeDictionaryEntries?: boolean;
 };
 
 export type ParseTextResultItem = {
@@ -144,7 +146,10 @@ type ApiSurface = {
         };
         return: {
             dictionaryEntries: Dictionary.TermDictionaryEntry[];
+            dictionaryEntriesJson?: string;
+            dictionaryEntryCount?: number;
             originalTextLength: number;
+            timingDiagnostics?: Record<string, unknown>;
         };
     };
     parseText: {
@@ -412,6 +417,10 @@ type ApiSurface = {
             type: Backend.DatabaseUpdateType;
             cause: Backend.DatabaseUpdateCause;
         };
+        return: void;
+    };
+    clearDatabaseCaches: {
+        params: void;
         return: void;
     };
     testMecab: {

--- a/types/ext/display.d.ts
+++ b/types/ext/display.d.ts
@@ -181,6 +181,7 @@ export type DirectApiSurface = {
     displaySetContent: {
         params: {
             details: ContentDetails;
+            resolvedOptions?: Settings.ProfileOptions;
         };
         return: void;
     };

--- a/types/ext/display.d.ts
+++ b/types/ext/display.d.ts
@@ -117,6 +117,8 @@ export type HistoryContent = {
     animate?: boolean;
     /** An array of dictionary entries to display as content. */
     dictionaryEntries?: Dictionary.DictionaryEntry[];
+    /** JSON-serialized dictionary entries for more efficient popup transport. */
+    dictionaryEntriesJson?: string;
     /** The identifying information for the frame the content originated from. */
     contentOrigin?: Extension.ContentOrigin;
 };

--- a/types/ext/offscreen.d.ts
+++ b/types/ext/offscreen.d.ts
@@ -192,6 +192,8 @@ export type FindTermsOptionsOffscreen = Omit<Translation.FindTermsOptions, 'enab
     ][];
     excludeDictionaryDefinitions: string[] | null;
     textReplacements: (FindTermsTextReplacementOffscreen[] | null)[];
+    maxResults?: number;
+    includeTimingDiagnostics?: boolean;
 };
 
 export type FindTermsTextReplacementOffscreen = Omit<Translation.FindTermsTextReplacement, 'pattern'> & {

--- a/types/ext/offscreen.d.ts
+++ b/types/ext/offscreen.d.ts
@@ -58,7 +58,9 @@ type ApiSurface = {
         return: DictionaryImporter.Summary | null;
     };
     getMaxHeadwordLengthOffscreen: {
-        params: void;
+        params: {
+            dictionaryNames: string[] | null;
+        };
         return: number;
     };
     deleteDictionaryOffscreen: {

--- a/types/ext/text-scanner.d.ts
+++ b/types/ext/text-scanner.d.ts
@@ -36,6 +36,7 @@ export type Options = {
     selectText?: boolean;
     delay?: number;
     scanLength?: number;
+    hoverScanLengthDiagnostics?: HoverScanLengthDiagnostics | null;
     layoutAwareScan?: boolean;
     preventMiddleMouseOnPage?: boolean;
     preventMiddleMouseOnTextHover?: boolean;
@@ -46,6 +47,12 @@ export type Options = {
     scanWithoutMousemove?: boolean;
     scanResolution?: string;
     pageType?: PageType;
+};
+
+export type HoverScanLengthDiagnostics = {
+    configuredScanLength: number;
+    automaticScanLength: number | null;
+    effectiveScanLength: number;
 };
 
 export type InputOptionsOuter = {

--- a/types/ext/text-scanner.d.ts
+++ b/types/ext/text-scanner.d.ts
@@ -124,6 +124,8 @@ export type Events = {
     searchSuccess: {
         type: 'terms' | 'kanji';
         dictionaryEntries: Dictionary.DictionaryEntry[];
+        dictionaryEntriesJson?: string;
+        dictionaryEntryCount?: number;
         sentence: Display.HistoryStateSentence;
         inputInfo: InputInfo;
         textSource: TextSource.TextSource;
@@ -176,13 +178,19 @@ export type SelectionRestoreInfo = {
 export type TermSearchResults = {
     type: 'terms';
     dictionaryEntries: Dictionary.TermDictionaryEntry[];
+    dictionaryEntriesJson?: string;
+    dictionaryEntryCount?: number;
     sentence: Sentence;
+    timingDiagnostics?: Record<string, unknown>;
 };
 
 export type KanjiSearchResults = {
     type: 'kanji';
     dictionaryEntries: Dictionary.KanjiDictionaryEntry[];
+    dictionaryEntriesJson?: string;
+    dictionaryEntryCount?: number;
     sentence: Sentence;
+    timingDiagnostics?: Record<string, unknown>;
 };
 
 export type SearchResults = TermSearchResults | KanjiSearchResults;

--- a/types/ext/translator.d.ts
+++ b/types/ext/translator.d.ts
@@ -80,4 +80,5 @@ export type TermReadingList = TermReadingItem[];
 export type FindTermsResult = {
     dictionaryEntries: Dictionary.TermDictionaryEntry[];
     originalTextLength: number;
+    timingDiagnostics?: Record<string, unknown>;
 };


### PR DESCRIPTION
## Summary
- fix the real browser hover lookup path rather than only the search page or synthetic microbenchmarks
- add end-to-end timing instrumentation for content-script, popup, display, background, offscreen, translator, and dictionary-storage phases
- remove multiple sources of actual hover latency across lookup transport, popup rendering, offscreen lifecycle, dictionary metadata lookup, prefix matching, and OPFS content locality
- extend the Chromium extension harness so repeated hover scans can be profiled and stopped in a tight loop

## Context
The user-reported problem here was real hover lookup latency in the extension popup path, including cases that felt like seconds rather than milliseconds. This work intentionally focused on the actual runtime path triggered by hovering text in the browser, not just the search page.

A large part of the work in this branch was investigative: add timings, rerun the extension, inspect the logs, narrow the hotspot, and repeat until the remaining latency was attributable to real code paths instead of guesswork.

## What Changed
### 1. End-to-end hover diagnostics and tighter repro harness
Added timing snapshots and/or diagnostics reporting for the real hover path across:
- `ext/js/language/text-scanner.js`
- `ext/js/app/frontend.js`
- `ext/js/app/popup.js`
- `ext/js/display/display.js`
- `ext/js/comm/api.js`
- `ext/js/background/backend.js`
- `ext/js/background/offscreen-proxy.js`
- `ext/js/background/offscreen-dictionary-worker.js`
- `ext/js/language/translator.js`
- `ext/js/dictionary/dictionary-database.js`
- `ext/js/dictionary/term-content-opfs-store.js`
- `ext/js/dictionary/term-record-opfs-store.js`
- `ext/js/core/dev-timing-diagnostics.js`

Extended `test/chromium/extension-two-dictionary-import.e2e.js` so it can:
- stop after isolated dictionary probes
- stop after repeated hover stress
- configure hover-scanning settings automatically for Playwright mouse hover
- collect page-side and popup-frame timing datasets
- keep reruns tight enough for iterative drilldown

### 2. Real hover transport fixes
The original hover path was paying for multiple heavy structured-clone / parse / reserialize steps across the background, content script, popup container, and popup display.

Kept fixes:
- `backend.js` can now return serialized `dictionaryEntriesJson` plus `dictionaryEntryCount` for `termsFind`
- `text-scanner.js` requests serialized hover results and carries them forward
- `frontend.js` now sends `lookup: 'false'` with provided hover content so the popup display does not rerun lookup
- `popup.js` reuses serialized dictionary-entry payloads when they already exist instead of serializing again
- `display.js` defers parsing until the popup display path and parses once there
- `display-history.js` clears persisted `dictionaryEntriesJson` when pruning history state
- `api.js` now records page-side invoke timings and correctly rejects on `chrome.runtime.lastError`

### 3. Popup/display rendering fixes
The popup display path had its own real cost even after lookup returned.

Kept fixes:
- added popup and popup-display timing breakdowns for handoff and rendering
- stopped the popup-mode display renderer from yielding with `await promiseTimeout(1)` between every entry
- switched popup rendering to build entries into a `DocumentFragment` and append once
- added render-loop timings for parsing, node generation, bookkeeping, append cost, and yield cost

### 4. Offscreen/background lifecycle and metadata cache fixes
Kept fixes that affected real hover cost:
- `offscreen-proxy.js`: track `DictionaryDatabaseProxy.isPrepared()` so background/offscreen lookup does not keep re-running prepare and clearing translator caches
- `dictionary-database.js`: add empty `termMeta` fast path
- `dictionary-database.js`: add per-dictionary `tagMeta` index caching and diagnostics
- `translator.js`: clear DB tag caches when translator caches are cleared
- `backend.js` / `api.d.ts`: expose narrow cache clear hooks used by the harness to measure cold vs warm metadata behavior

### 5. Dictionary lookup/storage algorithm improvements that survived the profiling loop
Kept fixes:
- `term-record-opfs-store.js` + `dictionary-database.js`: prefix buckets for term-key lookup instead of rescanning the entire key space for each prefix query
- `dictionary-database.js` + `term-content-opfs-store.js`: import-time locality ordering for external term content, plus shared-glossary warm-up so locality wins do not simply shift cost into first-parse inflate
- `backend.js` / `offscreen-proxy.js` / `offscreen-dictionary-worker.js`: trim offscreen results before crossing the runtime boundary
- `term-content-opfs-store.js`: page-I/O diagnostics for actual OPFS read behavior

## Investigation Findings
### Actual hover-path findings
Earlier visible-hover baseline from `builds/chromium-hover-visible-popup-diags-final.json`:
- page-side `apiTermsFindElapsedMs`: about `87.4ms`
- popup handoff `displaySetContentCompletedElapsedMs`: about `116.3ms`

Current kept-state hover sample from `builds/chromium-hover-display-pipeline-fix-repeat.json`:
- page-side `apiTermsFindElapsedMs`: about `12.3ms`
- popup handoff `displaySetContentCompletedElapsedMs`: about `12.1ms`
- frontend popup dispatch/complete: about `0.6ms`
- backend total inside the same hover sample: about `6.5ms`

That means the measured real hover path for the same small 2-entry payload dropped from roughly:
- `~87ms + ~116ms` before

to roughly:
- `~12ms + ~12ms` now

### Earlier backend/storage findings that informed the kept fixes
Selected examples from the iterative drilldown:
- empty `termMeta` query cost dropped from roughly `~6ms` to `~0.05ms`
- warm `tagMeta` lookup dropped from roughly `~5-6ms` to effectively `~0ms`
- pathological prefix lookup dropped from roughly `~4.1s` to about `~422ms`
- content-locality work dropped a cold prefix row-fetch sample from roughly `~337.7ms` to about `~166.3ms`
- offscreen-side result capping dropped one kept prefix sample from roughly `~319.3ms` to about `~199.4ms`

### What turned out not to be worth keeping
During the investigation I also tested and discarded several ideas because they regressed real behavior or had no reliable win, including:
- a `runtime-port` invoke path for hover lookups
- sync OPFS reads
- larger OPFS page sizes / readahead / batched slice reads
- content-offset sort for reads
- deeper translator-side early result capping
- one sorted-key prefix-matching variant with expensive one-time setup

Those experiments were intentionally removed from the final code so the branch keeps only changes that paid off in real runs.

## Verification
Ran repeatedly while iterating:
- `node --check ext/js/comm/api.js`
- `node --check ext/js/background/backend.js`
- `node --check ext/js/language/text-scanner.js`
- `node --check ext/js/app/frontend.js`
- `node --check ext/js/app/popup.js`
- `node --check ext/js/display/display.js`
- `node --check ext/js/core/dev-timing-diagnostics.js`
- `node --check test/chromium/extension-two-dictionary-import.e2e.js`
- `npm run test:ts:main`
- `node ./test/chromium/extension-two-dictionary-import.e2e.js` with `MANABITAN_E2E_STOP_AFTER_ISOLATED_PROBES=1`
- `node ./test/chromium/extension-two-dictionary-import.e2e.js` with `MANABITAN_E2E_STOP_AFTER_HOVER_STRESS=1`
- `node ./dev/bin/build.js --target chrome-dev`

Latest relevant report artifacts:
- `builds/chromium-hover-display-pipeline-fix-repeat.json`
- `builds/chromium-hover-display-pipeline-fix.json`
- `builds/chromium-hover-serialized-transport-stop-after-hover-final.json`
- `builds/chromium-hover-visible-popup-diags-final.json`
- multiple earlier `chromium-backend-termsfind-*.json` drilldown reports in `builds/`

## Remaining Notes
- The repeated-hover Chromium harness still has a known popup-visibility flake in some runs. The page-side hover diagnostics still captured successful lookup timings even when the popup frame dataset was null on the final failed iteration.
- I did not run the full repository validation suite in this branch; the verification above is the targeted coverage I used for the hover-path and dictionary-path changes.