### PR TITLE
Upgrade Playwright to 1.63 / Chromium 153

### DIFF
--- a/dev/bin/run-playwright.js
+++ b/dev/bin/run-playwright.js
@@ -21,9 +21,9 @@ import {fileURLToPath} from 'node:url';
 import path from 'path';
 
 const nodeMajorVersion = Number.parseInt(process.versions.node.split('.')[0], 10);
-if (!Number.isFinite(nodeMajorVersion) || nodeMajorVersion < 18 || nodeMajorVersion > 22) {
+if (!Number.isFinite(nodeMajorVersion) || nodeMajorVersion < 22) {
     console.error(
-        `Playwright tests require Node.js 18-22. Detected ${process.version}. ` +
+        `Playwright tests require Node.js 22 or newer. Detected ${process.version}. ` +
         'Use a supported Node version for deterministic Playwright execution.',
     );
     process.exit(1);

--- a/ext/js/extension/environment.js
+++ b/ext/js/extension/environment.js
@@ -140,13 +140,17 @@ export class Environment {
             if (this._isSafari()) {
                 return 'safari';
             }
-            if (os === 'android') {
-                return 'firefox-mobile';
+            // Chrome 148+ exposes the WebExtensions `browser` namespace too, so
+            // its mere presence no longer identifies Firefox. `runtime.getBrowserInfo`
+            // remains a Firefox-specific discriminator for the browsers supported here.
+            if (typeof browser.runtime?.getBrowserInfo === 'function') {
+                if (os === 'android') {
+                    return 'firefox-mobile';
+                }
+                return 'firefox';
             }
-            return 'firefox';
-        } else {
-            return 'chrome';
         }
+        return 'chrome';
     }
 
     /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
                 "@eslint/compat": "^1.2.4",
                 "@eslint/eslintrc": "^3.2.0",
                 "@eslint/js": "^9.17.0",
-                "@playwright/test": "^1.49.1",
+                "@playwright/test": "^1.63.0",
                 "@stylistic/eslint-plugin": "^2.12.1",
                 "@stylistic/stylelint-plugin": "^3.1.1",
                 "@types/assert": "^1.5.11",
@@ -2713,17 +2713,19 @@
             }
         },
         "node_modules/@playwright/test": {
-            "version": "1.49.1",
+            "version": "1.63.0",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0.tgz",
+            "integrity": "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright": "1.49.1"
+                "playwright": "1.63.0"
             },
             "bin": {
                 "playwright": "cli.js"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             }
         },
         "node_modules/@resvg/resvg-wasm": {
@@ -8235,31 +8237,32 @@
             }
         },
         "node_modules/playwright": {
-            "version": "1.49.1",
+            "version": "1.63.0",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+            "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "playwright-core": "1.49.1"
+                "playwright-core": "1.63.0"
             },
             "bin": {
                 "playwright": "cli.js"
             },
             "engines": {
-                "node": ">=18"
-            },
-            "optionalDependencies": {
-                "fsevents": "2.3.2"
+                "node": ">=20"
             }
         },
         "node_modules/playwright-core": {
-            "version": "1.49.1",
+            "version": "1.63.0",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+            "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
                 "playwright-core": "cli.js"
             },
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             }
         },
         "node_modules/pluralize": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
         "@eslint/compat": "^1.2.4",
         "@eslint/eslintrc": "^3.2.0",
         "@eslint/js": "^9.17.0",
-        "@playwright/test": "^1.49.1",
+        "@playwright/test": "^1.63.0",
         "@stylistic/eslint-plugin": "^2.12.1",
         "@stylistic/stylelint-plugin": "^3.1.1",
         "@types/assert": "^1.5.11",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -28,9 +28,9 @@ import 'dotenv/config';
 process.env.PW_EXPERIMENTAL_SERVICE_WORKER_NETWORK_EVENTS ??= '1';
 
 const nodeMajorVersion = Number.parseInt(process.versions.node.split('.')[0], 10);
-if (!Number.isFinite(nodeMajorVersion) || nodeMajorVersion < 18 || nodeMajorVersion > 22) {
+if (!Number.isFinite(nodeMajorVersion) || nodeMajorVersion < 22) {
     throw new Error(
-        `Playwright tests require Node.js 18-22. Detected ${process.version}. ` +
+        `Playwright tests require Node.js 22 or newer. Detected ${process.version}. ` +
         'Use a supported Node version for deterministic Playwright execution.',
     );
 }

--- a/test/chromium/extension-two-dictionary-import.e2e.js
+++ b/test/chromium/extension-two-dictionary-import.e2e.js
@@ -796,7 +796,9 @@ async function writeSlowZipResponse(response, body) {
         offset = nextOffset;
         if (offset < body.byteLength) {
             await new Promise((resolve) => {
-                setTimeout(resolve, 350);
+                // Keep the update download phase long enough for the concurrent
+                // lookup probe to complete before active import processing begins.
+                setTimeout(resolve, 1000);
             });
         }
     }
@@ -3387,13 +3389,19 @@ async function main() {
                     typeof startupDiagnosticsSnapshot.dictionaryOpenStorageDiagnostics === 'object' &&
                     startupDiagnosticsSnapshot.dictionaryOpenStorageDiagnostics !== null
                 ) ? startupDiagnosticsSnapshot.dictionaryOpenStorageDiagnostics : null;
+                const hasPageCreateSyncAccessHandle = !!(
+                    globalThis.FileSystemFileHandle &&
+                    globalThis.FileSystemFileHandle.prototype &&
+                    typeof globalThis.FileSystemFileHandle.prototype.createSyncAccessHandle === 'function'
+                );
+                const hasBackendCreateSyncAccessHandle = startupOpenStorageDiagnostics?.runtimeContext?.hasCreateSyncAccessHandle === true;
                 return {
                     hasStorageGetDirectory: !!(navigator.storage && typeof navigator.storage.getDirectory === 'function'),
-                    hasCreateSyncAccessHandle: !!(
-                        globalThis.FileSystemFileHandle &&
-                        globalThis.FileSystemFileHandle.prototype &&
-                        typeof globalThis.FileSystemFileHandle.prototype.createSyncAccessHandle === 'function'
-                    ),
+                    // The capability used by dictionary storage lives in the dedicated
+                    // backend worker on modern Chromium; page support alone is not authoritative.
+                    hasCreateSyncAccessHandle: hasPageCreateSyncAccessHandle || hasBackendCreateSyncAccessHandle,
+                    hasPageCreateSyncAccessHandle,
+                    hasBackendCreateSyncAccessHandle,
                     hasOpfsSahpoolVfs: (
                         startupOpenStorageDiagnostics &&
                         typeof startupOpenStorageDiagnostics.hasOpfsSahpoolVfs === 'boolean'

--- a/test/environment.test.js
+++ b/test/environment.test.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2026  Manabitan authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {afterEach, describe, expect, test, vi} from 'vitest';
+import {Environment} from '../ext/js/extension/environment.js';
+
+/**
+ * @param {object} options
+ * @param {string} options.userAgent
+ * @param {string} [options.vendor]
+ * @param {boolean} [options.exposeBrowser]
+ * @param {boolean} [options.exposeFirefoxBrowserInfo]
+ */
+function configureEnvironment({userAgent, vendor = '', exposeBrowser = false, exposeFirefoxBrowserInfo = false}) {
+    vi.stubGlobal('navigator', {userAgent, vendor});
+    vi.stubGlobal('chrome', {runtime: {getURL: () => 'chrome-extension://test/'}});
+    if (exposeBrowser) {
+        vi.stubGlobal('browser', {
+            runtime: exposeFirefoxBrowserInfo ? {getBrowserInfo: () => Promise.resolve({})} : {},
+        });
+    } else {
+        vi.stubGlobal('browser', void 0);
+    }
+}
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('Environment browser detection', () => {
+    test('treats the Chrome 148+ browser namespace as Chrome', async () => {
+        configureEnvironment({
+            userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/153.0.0.0 Safari/537.36',
+            exposeBrowser: true,
+        });
+
+        const environment = new Environment();
+        expect(await environment._getBrowser('linux')).toBe('chrome');
+    });
+
+    test('uses runtime.getBrowserInfo to identify Firefox', async () => {
+        configureEnvironment({
+            userAgent: 'Mozilla/5.0 (X11; Linux x86_64; rv:147.0) Gecko/20100101 Firefox/147.0',
+            exposeBrowser: true,
+            exposeFirefoxBrowserInfo: true,
+        });
+
+        const environment = new Environment();
+        expect(await environment._getBrowser('linux')).toBe('firefox');
+        expect(await environment._getBrowser('android')).toBe('firefox-mobile');
+    });
+
+    test('continues to identify Safari before the Firefox discriminator', async () => {
+        configureEnvironment({
+            userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Version/26.0 Safari/605.1.15',
+            vendor: 'Apple Computer, Inc.',
+            exposeBrowser: true,
+        });
+
+        const environment = new Environment();
+        expect(await environment._getBrowser('mac')).toBe('safari');
+    });
+});

--- a/test/playwright/playwright-util.js
+++ b/test/playwright/playwright-util.js
@@ -48,7 +48,11 @@ function getConfiguredExtensionId() {
     return [...hash].map((character) => String.fromCharCode('a'.charCodeAt(0) + Number.parseInt(character, 16))).join('');
 }
 
-export const test = base.extend({
+/** @typedef {import('@playwright/test').PlaywrightTestArgs & import('@playwright/test').PlaywrightTestOptions} BaseTestArgs */
+/** @typedef {import('@playwright/test').PlaywrightWorkerArgs & import('@playwright/test').PlaywrightWorkerOptions} BaseWorkerArgs */
+
+/** @type {import('@playwright/test').Fixtures<{extensionId: string}, {}, BaseTestArgs, BaseWorkerArgs>} */
+const fixtures = {
     // eslint-disable-next-line no-empty-pattern
     context: async ({}, /** @type {(r: import('playwright').BrowserContext) => Promise<void>} */ use) => {
         let createdManifest = false;
@@ -128,8 +132,9 @@ export const test = base.extend({
         }
         throw new Error('Unable to discover extension id');
     },
-});
+};
 
+export const test = base.extend(fixtures);
 export const expect = test.expect;
 
 /**


### PR DESCRIPTION
## Summary
- upgrade `@playwright/test` from 1.49.1 to 1.63.0 (bundled Chromium 153.0.8010.12)
- align Playwright Node guards with the repo's existing Node >=22 requirement
- fix browser detection for Chrome 148+, where Chrome now also exposes the WebExtensions `browser` namespace
- explicitly type the custom Playwright `extensionId` fixture for Playwright 1.63's stricter fixture typings
- add regression coverage for Chrome, Firefox, Firefox Android, and Safari detection
- stabilize the deliberately throttled Chromium update fixture so download-time and active-import lookup assertions remain distinct on faster Chromium
- report OPFS sync-access capability from the dictionary backend worker as well as the settings page, matching the E2E's existing OPFS availability logic

## Why the browser detection change is required
Chrome 148+ exposes extension APIs on both `chrome` and `browser`. The old `typeof browser !== 'undefined'` heuristic therefore misclassifies modern Chromium as Firefox. Use Firefox's `runtime.getBrowserInfo` capability as the discriminator instead, while preserving the existing Safari check.

## Validation
- `npx eslint dev/bin/run-playwright.js playwright.config.js ext/js/extension/environment.js test/environment.test.js test/playwright/playwright-util.js` — pass
- `npx vitest run test/environment.test.js` — 3/3 pass
- Playwright 1.63.0 installs Chrome for Testing 153.0.8010.12
- Chromium extension runtime reports `browser: 'chrome'` after the fix (it reported `firefox` before it)
- Playwright integration `search clipboard` test — 3/3 pass on Chromium 153 after the detection fix
- real headless Chromium extension/OPFS JMdict import smoke — pass
- `npm run test:ts:dev` — pass
- Playwright 1.63 initially introduced `extensionId` fixture type errors that were absent under 1.49; explicit fixture typing removes all Playwright-specific errors from `test:ts:test`
- full Chromium 153 extension E2E script passes end-to-end, including JMdict/Jitendex imports, concurrent lookup/database pressure, staged update crash recovery, active-import lookup, restart persistence, batch import, hover stress, and deletion

The repository still has unrelated pre-existing `test:ts:test` errors across generated zstd code and many tests. The Firefox extension E2E is also independently failing before dictionary work because current Firefox Developer Edition rejects Selenium script execution in a privileged browsing context; that lane does not use Playwright.