### PR TITLE
Hold: WASM parser experiment; original UI timing claims withdrawn

### DIFF
--- a/ext/js/dictionary/wasm/term-bank-parser.c
+++ b/ext/js/dictionary/wasm/term-bank-parser.c
@@ -16,6 +16,7 @@
  */
 
 #include <stdint.h>
+#include <wasm_simd128.h>
 
 #define WASM_PAGE_SIZE 65536u
 #define FNV1A_OFFSET 0x811c9dc5u
@@ -205,9 +206,9 @@ int32_t inflate_and_join_term_banks(
         if (nonempty_sources > 0u) {
             output[cursor++] = ',';
         }
-        for (uint32_t j = 0u; j < content_length; ++j) {
-            output[cursor + j] = inflated[start + j];
-        }
+        // Removing each source array wrapper shifts overlapping bytes left.
+        // Bulk memory copy handles overlap without a byte-at-a-time loop.
+        __builtin_memmove(output + cursor, inflated + start, content_length);
         cursor += content_length;
         ++nonempty_sources;
     }
@@ -359,14 +360,6 @@ static uint32_t skip_ws(const uint8_t* src, uint32_t len, uint32_t i) {
     return i;
 }
 
-static inline uint64_t has_zero_byte64(uint64_t value) {
-    return (value - UINT64_C(0x0101010101010101)) & ~value & UINT64_C(0x8080808080808080);
-}
-
-static inline uint64_t has_control_byte64(uint64_t value) {
-    return (value - UINT64_C(0x2020202020202020)) & ~value & UINT64_C(0x8080808080808080);
-}
-
 static int is_hex_digit(uint8_t value) {
     return (value >= '0' && value <= '9') ||
         (value >= 'a' && value <= 'f') ||
@@ -377,17 +370,24 @@ static int parse_string_span(const uint8_t* src, uint32_t len, uint32_t start, u
     if (start >= len || src[start] != '"') { return 0; }
     uint32_t i = start + 1u;
     while (i < len) {
-        while (i + 8u <= len) {
-            uint64_t word;
-            __builtin_memcpy(&word, src + i, sizeof(word));
-            if (
-                has_zero_byte64(word ^ UINT64_C(0x2222222222222222)) != 0u ||
-                has_zero_byte64(word ^ UINT64_C(0x5c5c5c5c5c5c5c5c)) != 0u ||
-                has_control_byte64(word) != 0u
-            ) {
+        // Skip ordinary UTF-8 bytes sixteen at a time. Only JSON quotes,
+        // backslashes and unescaped ASCII controls need scalar handling.
+        // Unsigned comparison keeps non-ASCII UTF-8 bytes out of the control mask.
+        while (len - i >= 16u) {
+            const v128_t bytes = wasm_v128_load(src + i);
+            const v128_t special = wasm_v128_or(
+                wasm_v128_or(
+                    wasm_i8x16_eq(bytes, wasm_i8x16_splat('"')),
+                    wasm_i8x16_eq(bytes, wasm_i8x16_splat('\\'))
+                ),
+                wasm_u8x16_lt(bytes, wasm_i8x16_splat(0x20))
+            );
+            const uint32_t mask = (uint32_t)wasm_i8x16_bitmask(special);
+            if (mask != 0u) {
+                i += (uint32_t)__builtin_ctz(mask);
                 break;
             }
-            i += 8u;
+            i += 16u;
         }
         if (i >= len) { break; }
         uint8_t c = src[i];

--- a/test/term-bank-parser-string-scan.test.js
+++ b/test/term-bank-parser-string-scan.test.js
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2026 Manabitan authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+/* eslint @stylistic/semi: ["error", "never"] */
+
+import {readFile} from 'node:fs/promises'
+import {crc32, deflateRawSync} from 'node:zlib'
+import {beforeAll, describe, expect, test} from 'vitest'
+
+/** @typedef {{memory: WebAssembly.Memory, wasm_reset_heap: () => void, wasm_alloc: (size: number) => number, parse_term_bank_with_media_hints: (...args: number[]) => number, inflate_and_join_term_banks: (...args: number[]) => number}} ParserExports */
+/** @type {ParserExports} */
+let wasm
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
+
+beforeAll(async () => {
+    const module = await WebAssembly.compile(await readFile(new URL('../ext/lib/term-bank-parser.wasm', import.meta.url)))
+    const instance = await WebAssembly.instantiate(module)
+    wasm = /** @type {ParserExports} */ (/** @type {unknown} */ (instance.exports))
+})
+
+/**
+ * The adjacent allocation deliberately contains quotes/brackets. A truncated
+ * input must not accidentally become valid by scanning beyond its logical end.
+ * @param {string} source
+ * @returns {{count: number, spans: number[], bytes: Uint8Array}}
+ */
+function parse(source) {
+    const bytes = encoder.encode(source)
+    wasm.wasm_reset_heap()
+    const input = wasm.wasm_alloc(bytes.length)
+    const adjacent = wasm.wasm_alloc(64)
+    const output = wasm.wasm_alloc(68)
+    const heap = new Uint8Array(wasm.memory.buffer)
+    heap.fill(0x22, input, adjacent + 64)
+    heap.set(bytes, input)
+    const count = wasm.parse_term_bank_with_media_hints(input, bytes.length, output, 1)
+    return {count, spans: [...new Uint32Array(wasm.memory.buffer, output, 17)], bytes}
+}
+
+/**
+ * @param {ReturnType<typeof parse>} result
+ * @param {number} offset
+ * @returns {unknown}
+ */
+function readSpan(result, offset) {
+    const start = result.spans[offset]
+    return JSON.parse(decoder.decode(result.bytes.subarray(start, start + result.spans[offset + 1])))
+}
+
+const alignments = Array.from({length: 64}, (_, index) => index)
+
+describe('term-bank string scanning', () => {
+    test.each(alignments)('preserves string spans at byte alignment %i', (padding) => {
+        const values = [
+            '',
+            'a',
+            'a'.repeat(15),
+            'a'.repeat(16),
+            'a'.repeat(17),
+            'a'.repeat(64),
+            '日本語と🙂',
+            '\\"/\b\f\n\r\t',
+            '\u0000\u001f',
+            'é\u0080\u07ff\u0800',
+        ]
+        for (const value of values) {
+            const word = `${'x'.repeat(padding)}${value}`
+            const row = [word, value, 'noun', '', -42, [value, {type: 'text', text: word}], 99, 'common']
+            const result = parse(`${' '.repeat(padding)}${JSON.stringify([row])}`)
+            expect(result.count).toBe(1)
+            expect(readSpan(result, 0)).toBe(word)
+            expect(readSpan(result, 2)).toBe(value)
+            expect(readSpan(result, 9)).toEqual(row[5])
+        }
+    })
+
+    test.each(alignments)('handles escaped Unicode and quotes across boundary %i', (padding) => {
+        const prefix = 'x'.repeat(padding)
+        const token = `"${prefix}\\u65e5\\u672c\\uD83D\\uDE42\\\\\\"end"`
+        const result = parse(`[[${token},"","","",0,[${token}],1,""]]`)
+        expect(result.count).toBe(1)
+        expect(readSpan(result, 0)).toBe(`${prefix}日本🙂\\"end`)
+        expect(readSpan(result, 9)).toEqual([`${prefix}日本🙂\\"end`])
+    })
+
+    test.each(alignments)('rejects unescaped controls at boundary %i', (padding) => {
+        for (let control = 0; control < 32; ++control) {
+            const source = `[["${'a'.repeat(padding)}${String.fromCharCode(control)}b","","","",0,["x"],1,""]]`
+            expect(parse(source).count).toBeLessThan(0)
+        }
+    })
+
+    test.each(alignments)('rejects truncated and invalid escapes at boundary %i', (padding) => {
+        const prefix = `[["${'x'.repeat(padding)}`
+        for (const ending of ['', '\\', '\\u', '\\u0', '\\u00', '\\u000']) {
+            expect(parse(prefix + ending).count).toBeLessThan(0)
+        }
+        for (const escape of ['\\q', '\\u00xz', '\\u-001', '\\u 000', '\\U0001']) {
+            expect(parse(`${prefix}${escape}","","","",0,[],1,""]]`).count).toBeLessThan(0)
+        }
+    })
+})
+
+/**
+ * @param {string[]} sources
+ * @param {number} method
+ * @returns {string}
+ */
+function inflateAndJoin(sources, method) {
+    const buffers = sources.map((source) => encoder.encode(source))
+    const payloads = buffers.map((bytes) => (method === 8 ? deflateRawSync(bytes) : bytes))
+    const inputLength = payloads.reduce((sum, bytes) => sum + bytes.length, 0)
+    const capacity = buffers.reduce((sum, bytes) => sum + bytes.length, 2)
+    wasm.wasm_reset_heap()
+    const input = wasm.wasm_alloc(inputLength)
+    const offsets = wasm.wasm_alloc(sources.length * 4)
+    const compressedLengths = wasm.wasm_alloc(sources.length * 4)
+    const uncompressedLengths = wasm.wasm_alloc(sources.length * 4)
+    const methods = wasm.wasm_alloc(sources.length * 4)
+    const checksums = wasm.wasm_alloc(sources.length * 4)
+    const output = wasm.wasm_alloc(capacity)
+    const heap = new Uint8Array(wasm.memory.buffer)
+    const words = new Uint32Array(wasm.memory.buffer)
+    let cursor = 0
+    for (let i = 0; i < sources.length; ++i) {
+        heap.set(payloads[i], input + cursor)
+        words[offsets / 4 + i] = cursor
+        words[compressedLengths / 4 + i] = payloads[i].length
+        words[uncompressedLengths / 4 + i] = buffers[i].length
+        words[methods / 4 + i] = method
+        words[checksums / 4 + i] = crc32(buffers[i])
+        cursor += payloads[i].length
+    }
+    const length = wasm.inflate_and_join_term_banks(
+        input,
+        inputLength,
+        offsets,
+        compressedLengths,
+        uncompressedLengths,
+        methods,
+        checksums,
+        sources.length,
+        output,
+        capacity,
+    )
+    expect(length).toBeGreaterThanOrEqual(2)
+    return decoder.decode(new Uint8Array(wasm.memory.buffer, output, length))
+}
+
+describe('overlapping term-bank join', () => {
+    test.each([0, 8])('preserves bytes and source order for compression method %i', (method) => {
+        for (const padding of alignments) {
+            const value = JSON.stringify(['x'.repeat(padding), '日本語', '\\"'])
+            const whitespace = ' '.repeat(padding)
+            const sources = ['[]', `${whitespace}[ ${value} ]\n`, '[ ]', `[${value}]`, '[]']
+            expect(inflateAndJoin(sources, method)).toBe(`[${value},${value}]`)
+        }
+    })
+
+    test.each([0, 8])('handles all-empty arrays for compression method %i', (method) => {
+        expect(inflateAndJoin(['[]', ' \n[ \t ]\r', '[]'], method)).toBe('[]')
+    })
+})


### PR DESCRIPTION
## Audit decision: do not merge this runtime experiment

Source remains `61588714864a58b22793dc8f17de4878ae29b315`, based on #18 `5c295fd17bed1aca2a5beae5963046574bcb2f36`. No source or branch history was deleted or rewritten.

**The original whole-import/UI percentages in this PR are withdrawn.** The old harness started timing after file dispatch. Those reports lack the timestamps needed to reconstruct valid whole-operation intervals. This withdrawal applies to the original favorable UI table and the separate low-memory UI claims; worker-RPC and isolated component measurements have different boundaries and must not be relabeled as end-to-end results.

The later [corrected review](https://github.com/ManabiIO/manabitan/blob/394d8eb799dd1eb5e194cee11472a4beab915080/dev/perf/pr20-review-validation.md) found JMdict slower in all three corrected pairs (median paired +10.94%) under variable load, with mixed Jitendex results and no JMnedict rerun. This is a regression concern requiring controlled remeasurement, not proof of universal slowdown or data corruption.

## Selected integration route

**#25** retains #17/#18 plus the subsequent timing, TypeScript, rendering, Anki and shared-string fixes, but restores only production `term-bank-parser.c` to the #18 baseline. All **260 compatibility tests from this PR remain enabled** and passed on the restored parser. Its final-head normal CI passes Chromium/Firefox, units/options, JSON, TypeScript and builds; repository-wide JavaScript lint remains a separate unresolved gate.

#22's independent miniz change is now reconciled on #25 without reintroducing this runtime experiment. #21's custom ZIP splitter is not included. Do not independently merge this old focused branch into the selected rollup.

## Historical source and correctness evidence retained

This experiment batches ordinary JSON bytes with WASM SIMD and uses overlap-safe compaction. It changes one production C file and adds the 260-test regression suite, without changing archive integrity validation, storage formats or worker defaults. The existing source, tests and original validation workflow/artifact (run 34095779682, wasm-parser-validation artifact 10008663358) remain the historical evidence surfaces; their old UI percentages are not accepted merge evidence.

Before reconsidering the runtime: produce a materially reworked or freshly justified candidate on the accepted baseline, use corrected browser change-to-current-operation-post-UI timing, retain A/A controls and all dictionary results, and repeat full supported-browser correctness checks. No new performance result or release approval is asserted by this metadata correction.