### PR TITLE
[Rejected current variant / retained evidence] Linear ZIP splitter

### DIFF
--- a/dev/build-libs.js
+++ b/dev/build-libs.js
@@ -26,6 +26,7 @@ import os from 'os';
 import path from 'path';
 import {fileURLToPath} from 'url';
 import {parseJson} from './json.js';
+import {zipChunkStreamPlugin} from './zip-chunk-stream-plugin.js'
 
 const require = createRequire(import.meta.url);
 
@@ -238,6 +239,7 @@ async function buildDictionaryWasm(out) {
  */
 async function buildLib(scriptPath) {
     await esbuild.build({
+        plugins: [zipChunkStreamPlugin],
         entryPoints: [scriptPath],
         bundle: true,
         minify: false,

--- a/dev/perf/zip-splitter-validation.md
+++ b/dev/perf/zip-splitter-validation.md
@@ -1,0 +1,112 @@
+# ZIP splitter import experiment - September 8, 2026
+
+## Decision: draft, not release-ready
+
+The isolated splitter improves Jitendex whole-import timing on this Linux host, but JMnedict shows a small, repeatable regression concern. Do not promote this candidate to release defaults on the Jitendex result alone. The exact-tail follow-up did not resolve the concern and was reverted. No change to `main`, `develop`, the benchmark vendor pin, PR #20, parser code, storage format, worker-count defaults, or import flags is included.
+
+Baseline: `394d8eb799dd1eb5e194cee11472a4beab915080`, the current PR #20 (`perf-render-overlap`) head, not release `main` or upstream Yomitan. The benchmark repository's `vendor/projects/manabitan` pin matches release main at `d3fc6795ccce4ba9b293c336898f3dcb32338128`; it is not the latest performance stack.
+
+## Scope and motivation
+
+A separate browser CPU trace identified recursive ZIP chunk splitting as a hotspot. The pinned zip.js 2.7.54 splitter repeatedly copies the shrinking remainder of a large input. The candidate iterates over bounded output chunks, retains one pending chunk, and gives each emitted chunk independent ownership so worker transfers do not detach the remaining data. A source-hash-checked esbuild adapter applies the helper to both the host ZIP and codec-worker bundles, preserves the upstream license, and fails closed if the dependency changes. No dependency files or generated binaries are committed.
+
+This is a narrow re-evaluation, not a claim that the old combined experiment was successful. Rejected branch `perf-import-linear-zip` (`15864af62dd1ee1e51cd87f3f6894a8a5df81041`) also changed Zstd and block-store code. None of those changes is included here. Upstream zip.js [v2.8.28 release notes](https://github.com/gildas-lormeau/zip.js/releases/tag/v2.8.28) independently describe the iterative splitter fix; this patch does not attempt the wider codec/worker API upgrade.
+
+## Method
+
+Forty complete browser imports for the reviewed candidate: five adjacent pairs each for JMdict and Jitendex, and ten for JMnedict. The first five pairs per dictionary were the initial comparison; five additional JMnedict pairs were explicitly exploratory confirmation after mixed results. Odd pairs are AB, even pairs BA. Every run uses a fresh browser profile, pinned ZIP fixtures, production import defaults, and the identical corrected PR #20 schema-3 harness.
+
+The authoritative boundary is the browser's monotonic file-input `change` event through the current session's post-UI import-complete event. It includes archive handoff, import, and UI completion; it is not a physical-paint measurement. Worker-RPC and automation-observed intervals are recorded separately. No tracing, screenshots, phase profiling, or process sampling is enabled in timed runs. Build/test work was separated from timed imports, including a pause only between completed dictionary pairs. There was no imported-artifact shortcut and no discarded failing timed run.
+
+Host: Linux x64, AMD EPYC 9V74, four-core cgroup CPU quota, 4 GiB cgroup memory limit; benchmark process affinity `[0,1,2,3]`. Node 24.20.0, V8 13.6.233.17-node.53, Playwright 1.63.0, Chromium 153.0.8010.12. Package lock, dictionary lock, timing harness, parser WASM, and Zstd WASM were held fixed. Tests exercise the ZIP-worker route selected by production policy on this host; other hardware, Firefox, and the higher-memory compressed-input WASM route have not been performance-validated by this experiment.
+
+## Whole-import results
+
+Negative paired change means faster. Percentages are the median of `(candidate / baseline - 1) * 100` for adjacent pairs, **not** the ratio of the independently computed column medians. Small sample counts and a shared host do not establish universal device gains.
+
+| Dictionary | Pairs | Baseline median ms | Candidate median ms | Median paired change | Faster pairs |
+| ---------- | ----: | -----------------: | ------------------: | -------------------: | -----------: |
+| JMdict     |     5 |             1859.5 |              1741.0 |               -1.92% |          4/5 |
+| JMnedict   |    10 |             1486.7 |              1505.4 |               +3.93% |         3/10 |
+| Jitendex   |     5 |             3871.9 |              3438.8 |               -9.27% |          5/5 |
+
+Jitendex improved in all five pairs. JMdict improved in four of five, but its paired median is modest. JMnedict was slower in seven of ten; that is an unresolved sign-off issue, not evidence of a general win. Worker-RPC median paired changes were -2.19%, +3.68%, and -9.72% for JMdict, JMnedict, and Jitendex, respectively.
+
+### All reviewed-candidate pairs
+
+A is baseline; B is candidate. Milliseconds below are rounded only for presentation; original browser values are retained in the JSON evidence.
+
+| Dictionary | Pair | Order |   A ms |   B ms |
+| ---------- | ---: | ----- | -----: | -----: |
+| JMdict     |    1 | AB    | 1866.0 | 1636.0 |
+| JMdict     |    2 | BA    | 1914.8 | 1892.0 |
+| JMdict     |    3 | AB    | 1713.8 | 1523.8 |
+| JMdict     |    4 | BA    | 1859.5 | 1876.9 |
+| JMdict     |    5 | AB    | 1775.0 | 1741.0 |
+| JMnedict   |    1 | AB    | 1525.7 | 1598.8 |
+| JMnedict   |    2 | BA    | 1440.4 | 1548.7 |
+| JMnedict   |    3 | AB    | 1585.8 | 1518.8 |
+| JMnedict   |    4 | BA    | 1735.3 | 1469.0 |
+| JMnedict   |    5 | AB    | 1355.2 | 1421.1 |
+| JMnedict   |    6 | BA    | 1373.3 | 1471.3 |
+| JMnedict   |    7 | AB    | 1447.7 | 1492.1 |
+| JMnedict   |    8 | BA    | 1551.9 | 1568.6 |
+| JMnedict   |    9 | AB    | 1428.6 | 1597.2 |
+| JMnedict   |   10 | BA    | 1567.3 | 1422.9 |
+| Jitendex   |    1 | AB    | 3654.6 | 3438.8 |
+| Jitendex   |    2 | BA    | 3975.3 | 3373.7 |
+| Jitendex   |    3 | AB    | 3871.9 | 3512.8 |
+| Jitendex   |    4 | BA    | 4178.0 | 3413.5 |
+| Jitendex   |    5 | AB    | 3783.6 | 3607.6 |
+
+## Rejected exact-tail follow-up
+
+A second version tried reducing small-tail allocations and avoiding the final partial-buffer copy. Five new JMnedict pairs produced a +6.25% median paired change, with only one faster pair. It was dropped, not folded into the reviewed source. These ten runs are separate from the forty above; do not pool the different candidates or hide the rejected results.
+
+| Pair | Order | Baseline ms | Rejected variant ms |
+| ---- | ----- | ----------: | ------------------: |
+| 1    | AB    |      1426.1 |              1535.2 |
+| 2    | BA    |      1393.0 |              1459.9 |
+| 3    | AB    |      1454.6 |              1545.5 |
+| 4    | BA    |      1454.3 |              1561.2 |
+| 5    | AB    |      1454.5 |              1433.0 |
+
+## Correctness and integration
+
+- All 50 timed imports (40 reviewed-candidate comparison runs plus 10 rejected-variant comparison runs) passed exact persisted title, revision, and term-row-count checks, with 12 readable-content probes after timing. Counts are 526,942 JMdict, 667,942 JMnedict, and 435,448 Jitendex. These are sampled persisted-content checks, not exhaustive database equality.
+- Independently compared all 595 non-directory ZIP entries across the three fixtures: 759,119,664 decompressed bytes identical, with explicit CRC verification on both generated libraries. Both rejected deliberate CRC corruption and a truncated central directory. This verifier uses the main-thread codec; real worker integration is covered by browser imports and E2E. The verifier first had a Node Buffer-versus-Uint8Array fixture error; correcting the test input to a true Uint8Array resolved it without product changes.
+- 21 new regression tests cover fragmented inputs, boundaries, empty streams, nonzero offsets, immediate transfer/detachment, an 8 MiB input, 100 deterministic fragmentation cases, invalid internal chunk sizes, both generated ZIP bundles, and the dependency hash guard.
+- Full unit suite: 153 files, 5,410 passed, 46 skipped, including those 21 new tests. Separate options suite: 25 passed.
+- All four TypeScript projects pass: main, dev, test, and bench. All-target build dry run passes. Focused new-file lint passes with `@stylistic/semi: [error, never]`; repository-wide lint is not claimed green.
+- Strict full Chromium extension E2E passes all 83 phases without skips: import, concurrent lookup, interrupted-update recovery, updates, restart persistence, batch import, hover/search stress, and deletion. Firefox was not rerun; PR #20's existing Firefox and earlier parser-performance sign-off concerns remain separate and unresolved.
+
+## Provenance
+
+Exact five-file reviewed source tree, before this documentation: `68c698900943ab62e8f803bca8a0353b74938a0a`. The GitHub-created tree was required to equal the locally tested Git tree before publication. The experimental exact-tail version is absent from that tree.
+
+Each arm used a single unchanged packaged extension across its 40-run comparison. SHA-256 values:
+
+| Artifact                      | SHA-256                                                            |
+| ----------------------------- | ------------------------------------------------------------------ |
+| Baseline measured Chrome ZIP  | `be86a580e3a29dd46e3b0b4f8bc2ee2717604085c5c3287aac8e1af0ac1e6dd9` |
+| Candidate measured Chrome ZIP | `f44ad0376cafaf08623e2a16eff3655919e6cc660f6c4589a839036be023d391` |
+| Shared parser WASM            | `f734104d5933719059406387dd07de2148c8612a7ae02f2bd5bb92eef80cfc56` |
+| Shared Zstd WASM              | `ad3a18c197d72167262d01fd202976325f57a6697bca627f4527c96d4dbbcfcc` |
+| Candidate ZIP library         | `677c046f58f6c9648b240e68df3a9fddaa2ba606ad44f007fc29bc6852504ec7` |
+| Candidate ZIP worker          | `3a1fa9912be59b7ea81abd9b8ee62f91f9de6e8aadb08fa9f44dd68aa3f3fe5d` |
+
+After reverting the rejected variant, rebuilding reproduced all 546 packaged file payloads byte-for-byte. The ZIP container hash changed solely because all entry timestamps changed; the measured package hashes above identify the actual timing inputs. Node dependencies were shared through a symlink between worktrees; source and package provenance, including dirty-state flags, are retained in every report.
+
+Fixtures use the unmodified `test/perf/dictionaries.lock.json`: JMdict/JMnedict 2026-09-06 and Jitendex 2026.08.11.0, with exact SHA-256/size/title/revision/row-count verification. Full reports, logs, source-comparison driver, per-entry byte hashes, trace, and rejected experiment are retained in the accompanying evidence archive, excluding dictionaries, fonts, dependencies, and browser/runtime binaries.
+
+## Reproduction
+
+The current performance tasks live in Manabitan itself: `mise run perf:import`, `perf:import:trace`, `perf:import:ab`, and `perf:dictionaries`. The parent benchmark repository also has the older supported-knob task `manabitan-import-flags-ab`. Its flags A/B is not a substitute for comparing two different source builds.
+
+Prepare independent worktrees at baseline and this candidate, install the locked dependencies, build their libraries and `chrome-dev` packages, and verify pinned dictionaries. Alternate the following command between those worktrees, selecting `jmdict`, `jmnedict`, or `jitendex` and a distinct output directory per run:
+
+```sh
+node dev/perf/import-benchmark.js jitendex --runs 1 --no-build --output /absolute/output/run
+```
+
+`mise` is optional: the tasks invoke these same Node entrypoints. Keep both builds' harness and fixture hashes equal, verify each report's schema/acceptance fields, and report per-dictionary paired ratios. Run traces separately. Before promotion, resolve the JMnedict regression and repeat on another representative runtime; do not revive the old withdrawn whole-import percentages.

--- a/dev/zip-chunk-stream-plugin.js
+++ b/dev/zip-chunk-stream-plugin.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2023-2026  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {createHash} from 'node:crypto'
+import {readFile} from 'node:fs/promises'
+import path from 'node:path'
+import {fileURLToPath} from 'node:url'
+
+const codecSourceSha256 = '1c0d9de91141bf89f49dc1e239dd22d75a3e46d38dd153aca1a6d48c231d4d85'
+const replacementPath = fileURLToPath(new URL('zip-chunk-stream.js', import.meta.url))
+
+/**
+ * Replace only the pinned splitter, in both ZIP host and worker bundles.
+ * Keep the dependency's codecs and license intact; fail closed on any source
+ * change so dependency upgrades require an explicit backport review/removal.
+ * @type {import('esbuild').Plugin}
+ */
+export const zipChunkStreamPlugin = {
+    name: 'zip-chunk-stream-backport',
+    setup(build) {
+        build.onLoad({filter: /[/\\]@zip\.js[/\\]zip\.js[/\\]lib[/\\]core[/\\]streams[/\\]codec-stream\.js$/}, async ({path: sourcePath}) => {
+            const source = await readFile(sourcePath, 'utf8')
+            if (createHash('sha256').update(source).digest('hex') !== codecSourceSha256) {
+                throw new Error('zip.js codec-stream source changed: review/remove the ChunkStream backport before rebuilding')
+            }
+            const start = source.indexOf('\nclass ChunkStream extends TransformStream {')
+            if (start < 0) { throw new Error('zip.js ChunkStream backport anchor missing') }
+            return {
+                contents: `${source.slice(0, start).replace(/^\/\*/, '/*!')}\nimport {ChunkStream} from ${JSON.stringify(replacementPath)};\n`,
+                loader: 'js',
+                resolveDir: path.dirname(sourcePath),
+                watchFiles: [sourcePath, replacementPath],
+            }
+        })
+    },
+}

--- a/dev/zip-chunk-stream.js
+++ b/dev/zip-chunk-stream.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2023-2026  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Linear-time splitting for the pinned zip.js worker protocol. Every emitted
+ * chunk owns its buffer, so transfer cannot detach another chunk or the input.
+ * Retain one pending chunk, including a full chunk, until more input or flush;
+ * this preserves the original splitter's chunk boundaries and delivery order.
+ * @augments {TransformStream<Uint8Array, Uint8Array>}
+ */
+export class ChunkStream extends TransformStream {
+    /** @param {number} chunkSize */
+    constructor(chunkSize) {
+        if (!Number.isSafeInteger(chunkSize) || chunkSize <= 0) {
+            throw new RangeError('ZIP chunk size must be a positive safe integer')
+        }
+        /** @type {Uint8Array|null} */
+        let pending = null
+        let pendingLength = 0
+        super({
+            transform(chunk, controller) {
+                let offset = 0
+                if (pending !== null) {
+                    const length = Math.min(chunkSize - pendingLength, chunk.length)
+                    pending.set(chunk.subarray(0, length), pendingLength)
+                    pendingLength += length
+                    offset = length
+                    if (pendingLength === chunkSize && offset < chunk.length) {
+                        controller.enqueue(pending)
+                        pending = null
+                        pendingLength = 0
+                    }
+                }
+                // Copy bounded outputs, never the successively shrinking tail.
+                while (chunk.length - offset > chunkSize) {
+                    controller.enqueue(new Uint8Array(chunk.subarray(offset, offset + chunkSize)))
+                    offset += chunkSize
+                }
+                if (offset < chunk.length) {
+                    pending ??= new Uint8Array(chunkSize)
+                    pending.set(chunk.subarray(offset), pendingLength)
+                    pendingLength += chunk.length - offset
+                }
+            },
+            flush(controller) {
+                if (pending !== null && pendingLength > 0) {
+                    controller.enqueue(pendingLength === chunkSize ? pending : pending.slice(0, pendingLength))
+                }
+                pending = null
+                pendingLength = 0
+            },
+        })
+    }
+}

--- a/test/zip-chunk-stream-build.test.js
+++ b/test/zip-chunk-stream-build.test.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2023-2026  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {build} from 'esbuild'
+import {mkdtemp, mkdir, readFile, rm, writeFile} from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import {describe, expect, test} from 'vitest'
+import {zipChunkStreamPlugin} from '../dev/zip-chunk-stream-plugin.js'
+
+describe('ZIP splitter build integration', () => {
+    test.each(['zip.js', 'z-worker.js'])('patches the pinned codec in %s', async (entry) => {
+        const result = await build({
+            entryPoints: [`dev/lib/${entry}`],
+            bundle: true,
+            format: 'esm',
+            write: false,
+            plugins: [zipChunkStreamPlugin],
+        })
+        expect(result.outputFiles[0].text).toContain('ZIP chunk size must be a positive safe integer')
+        expect(result.outputFiles[0].text).toContain('Redistribution and use in source and binary forms')
+        expect(result.outputFiles[0].text).not.toContain('transform(chunk.slice(chunkSize), controller)')
+    })
+
+    test('fails closed if the pinned dependency source changes', async () => {
+        const temporary = await mkdtemp(path.join(os.tmpdir(), 'manabitan-zip-splitter-'))
+        try {
+            const fixture = path.join(temporary, '@zip.js/zip.js/lib/core/streams/codec-stream.js')
+            await mkdir(path.dirname(fixture), {recursive: true})
+            const original = await readFile('node_modules/@zip.js/zip.js/lib/core/streams/codec-stream.js', 'utf8')
+            await writeFile(fixture, `${original}\n`)
+            await expect(build({entryPoints: [fixture], bundle: true, write: false, logLevel: 'silent', plugins: [zipChunkStreamPlugin]}))
+                .rejects.toThrow('zip.js codec-stream source changed')
+        } finally {
+            await rm(temporary, {recursive: true, force: true})
+        }
+    })
+})

--- a/test/zip-chunk-stream.test.js
+++ b/test/zip-chunk-stream.test.js
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2023-2026  Yomitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {describe, expect, test} from 'vitest'
+import {ChunkStream} from '../dev/zip-chunk-stream.js'
+
+/**
+ * @param {Uint8Array[]} inputs
+ * @param {number} chunkSize
+ * @returns {Promise<Uint8Array[]>}
+ */
+async function collectTransferredChunks(inputs, chunkSize) {
+    /** @type {Uint8Array[]} */
+    const outputs = []
+    const source = new ReadableStream({
+        start(controller) {
+            for (const input of inputs) { controller.enqueue(input) }
+            controller.close()
+        },
+    })
+    await source.pipeThrough(new ChunkStream(chunkSize)).pipeTo(new WritableStream({
+        write(chunk) {
+            // Exercise the worker protocol: each output is detached immediately.
+            outputs.push(structuredClone(chunk, {transfer: [chunk.buffer]}))
+            expect(chunk.byteLength).toBe(0)
+        },
+    }))
+    return outputs
+}
+
+/**
+ * @param {number} length
+ * @returns {Uint8Array}
+ */
+function bytes(length) {
+    return Uint8Array.from({length}, (_, i) => (i * 31 + (i >>> 8)) & 255)
+}
+
+describe('ZIP output splitting', () => {
+    test.each([1, 2, 3, 7, 64, 1024, 65536])('preserves bytes, boundaries, and ownership at size %i', async (size) => {
+        const source = bytes(size * 4 + 13)
+        // Nonzero byte offsets and empty inputs exercise both seam paths.
+        const backing = new Uint8Array(source.length + 14)
+        backing.set(source, 7)
+        const view = backing.subarray(7, 7 + source.length)
+        const splits = [0, 1, Math.min(size + 1, view.length), Math.min(size * 2 + 2, view.length), view.length]
+        const inputs = [new Uint8Array(0)]
+        for (let i = 1; i < splits.length; i++) {
+            inputs.push(view.subarray(splits[i - 1], splits[i]), new Uint8Array(0))
+        }
+        const outputs = await collectTransferredChunks(inputs, size)
+        const flattened = Buffer.concat(outputs)
+        expect(flattened.equals(Buffer.from(source))).toBe(true)
+        expect(outputs.map((chunk) => chunk.length)).toEqual(
+            Array.from({length: Math.ceil(source.length / size)}, (_, i) => Math.min(size, source.length - i * size)),
+        )
+        expect(backing.byteLength).toBe(source.length + 14)
+        expect(Buffer.from(view).equals(Buffer.from(source))).toBe(true)
+        expect(new Set(outputs.map((chunk) => chunk.buffer)).size).toBe(outputs.length)
+    })
+
+    test.each([[], [new Uint8Array(0)], [new Uint8Array(0), new Uint8Array(0)]])('does not emit empty chunks: %j', async (...inputs) => {
+        // Vitest spreads each table row into arguments.
+        const outputs = await collectTransferredChunks(inputs, 8)
+        expect(outputs).toEqual([])
+    })
+
+    test('keeps the full pending chunk until further data or flush', async () => {
+        const stream = new ChunkStream(4)
+        const reader = stream.readable.getReader()
+        const writer = stream.writable.getWriter()
+        let delivered = false
+        const first = reader.read().then((result) => {
+            delivered = true
+            return result
+        })
+        await writer.write(new Uint8Array([1, 2, 3, 4]))
+        await writer.write(new Uint8Array(0))
+        expect(delivered).toBe(false)
+        await writer.write(new Uint8Array([5]))
+        expect((await first).value).toEqual(new Uint8Array([1, 2, 3, 4]))
+        const last = reader.read()
+        await writer.close()
+        expect((await last).value).toEqual(new Uint8Array([5]))
+        expect((await reader.read()).done).toBe(true)
+    })
+
+    test('splits a large single input without recursive tail copies', async () => {
+        const input = bytes(8 * 1024 * 1024 + 3)
+        const output = await collectTransferredChunks([input], 1024)
+        expect(Buffer.concat(output).equals(Buffer.from(input))).toBe(true)
+        expect(output).toHaveLength(8193)
+        expect(output.at(-1)?.length).toBe(3)
+    })
+
+    test('handles deterministic fragmented input across many seams', async () => {
+        let seed = 0x5f3759df
+        const random = () => {
+            seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0
+            return seed
+        }
+        for (let caseIndex = 0; caseIndex < 100; caseIndex++) {
+            const size = 1 + random() % 257
+            const input = bytes(random() % 8192)
+            const chunks = []
+            for (let offset = 0; offset < input.length;) {
+                const length = 1 + random() % 513
+                chunks.push(input.subarray(offset, offset + length))
+                if (random() % 3 === 0) { chunks.push(new Uint8Array(0)) }
+                offset += length
+            }
+            const output = await collectTransferredChunks(chunks, size)
+            expect(Buffer.concat(output).equals(Buffer.from(input))).toBe(true)
+            expect(output.map((chunk) => chunk.length)).toEqual(
+                Array.from({length: Math.ceil(input.length / size)}, (_, i) => Math.min(size, input.length - i * size)),
+            )
+        }
+    })
+
+    test.each([0, -1, 1.5, Number.NaN, Infinity])('rejects invalid internal chunk size %s', (size) => {
+        expect(() => new ChunkStream(size)).toThrow(RangeError)
+    })
+})


### PR DESCRIPTION
## Draft: do not promote to release defaults yet

Source commit: `308123e7547dba95dea74eb8929ea4a237df5c50`.
Base: PR #20 at `394d8eb799dd1eb5e194cee11472a4beab915080`.
This is one commit and six files on top of the current performance stack. No changes to `main`, `develop`, the benchmark vendor pin, or PR #20 itself.

[Full validation, every paired timing, rejected follow-up, and provenance](https://github.com/ManabiIO/manabitan/blob/perf-import-zip-splitter-20260908/dev/perf/zip-splitter-validation.md)

## Change

Replace the pinned zip.js 2.7.54 recursive shrinking-tail splitter with a linear bounded-copy splitter. A hash-checked esbuild adapter applies only this helper to both ZIP host and worker bundles; it retains the upstream license and fails closed on dependency source changes. Output buffers remain independently transferable, with the existing pending-chunk boundaries and delivery order.

No parser, Zstd, OPFS/storage format, import flags, worker-count default, or dependency-lock changes. No generated binaries or transport workflows are included.

This revisits **only the ZIP portion** of previously rejected `perf-import-linear-zip`; its Zstd/block-store changes are excluded. The current trace identified the splitter hotspot, and these measurements use the corrected PR #20 timing harness. This does not revive the old withdrawn whole-import percentages.

## Corrected whole-import A/B

Linux x64, AMD EPYC 9V74; four-core cgroup quota and 4 GiB cgroup memory limit. Node 24.20.0, Playwright 1.63.0, Chromium 153.0.8010.12. Fresh browser profiles, pinned dictionary ZIPs, production defaults, alternating adjacent AB/BA pairs. Timing is browser file-input change through post-UI import completion; tracing/profiling is separate.

| Dictionary | Pairs | Baseline median | Candidate median | Median paired change | Faster pairs |
|---|---:|---:|---:|---:|---:|
| JMdict | 5 | 1859.5 ms | 1741.0 ms | -1.92% | 4/5 |
| JMnedict | 10 | 1486.7 ms | 1505.4 ms | +3.93% | 3/10 |
| Jitendex | 5 | 3871.9 ms | 3438.8 ms | -9.27% | 5/5 |

Negative paired change means faster. Percentages are medians of per-pair ratios, not the ratio of the separate column medians. **JMnedict is an unresolved regression concern**, not a general win. Its second five pairs were exploratory confirmation after the initial mixed result. Another exact-tail allocation variant was tried in five new JMnedict pairs, regressed +6.25%, and was reverted; its ten runs are recorded separately, not pooled with the reviewed candidate.

## Validation

- All 50 timed imports (40 reviewed-candidate comparison runs plus 10 rejected-follow-up comparison runs) pass exact persisted title/revision/row counts and 12 post-timing readable-content probes each. These are sampled persisted-content checks, not exhaustive database equivalence.
- All 595 non-directory archive entries, 759,119,664 decompressed bytes, are identical between generated libraries, with explicit CRC checks. Both reject deliberately corrupt CRC and truncated central-directory fixtures. Main-thread codec byte parity and real browser worker integration are separate checks.
- 21 new tests: chunk seams, empty/full/tail inputs, nonzero offsets, immediate transferable-buffer detachment, large non-recursive input, deterministic fragmentation, invalid internal sizes, host/worker build integration, and dependency hash guard.
- Full unit suite: **5,410 passed, 46 skipped, 153 files**. Separate options: **25 passed**.
- Strict TypeScript main/dev/test/bench projects pass; all-target build dry run passes. Focused new-file lint passes with the semicolon-free style override. Repository-wide lint/CI is not claimed green.
- Strict Chromium full extension E2E: **83 phases pass without skips**, including concurrent lookup, interrupted-update recovery, updates, restart, batch import, hover/search stress, and deletion.
- Rebuilding the restored reviewed candidate reproduced all 546 packaged file payloads byte-for-byte; ZIP timestamps change the archive hash. Actual measured package hashes are in the report.

## Publication integrity and limits

The remote code tree was checked against local tested tree `68c698900943ab62e8f803bca8a0353b74938a0a`; final tree including documentation is `e8cb7ac21c23b2ffe0c9418881d595ac4d8ebe52`. The rejected tail variant is not in this commit.

Only this Linux Chromium production-selected ZIP-worker path was performance-validated. Firefox and the higher-memory compressed-input WASM route are not covered by these performance results. PR #20's pre-existing Firefox and parser-performance sign-off concerns remain separate. Resolve the JMnedict regression and repeat on another representative runtime before release promotion.