### PR TITLE
Reconcile WASM inflater optimization onto reviewed no-SIMD rollup

### DIFF
--- a/dev/perf/inflate-core-validation.md
+++ b/dev/perf/inflate-core-validation.md
@@ -1,0 +1,95 @@
+# WASM inflater validation — September 8, 2026
+
+## Decision
+
+**Draft: a repeatable component improvement, but only a modest whole-import signal.** Jitendex's median paired improvement is approximately 1.15% on both independent runners. The second run is noisier and its interval includes zero. The first JMdict improvement did not repeat. Do not advertise the component's double-digit improvement as an equivalent import speedup or merge this as a general cross-device win.
+
+Baseline: PR #20 commit `394d8eb799dd1eb5e194cee11472a4beab915080`, not release main or upstream Yomitan.
+
+Exact tested source commit: `1a48eb3ef7da950a1ab55716c2ac2f725741b9ba`.
+
+Exact tested source/test tree: `0bd78b4f115919a4e984c929faff2af67f3881e1`. This documentation follows that commit and does not change executable code.
+
+## Change
+
+- Select miniz's existing 64-bit bit buffer for WebAssembly. Its architecture heuristic previously selected 32-bit buffering for wasm32, despite WebAssembly's i64 arithmetic. No new build feature is enabled.
+- Use overlap-safe bulk copying for history matches of at least nine bytes with length no greater than distance, after the existing bounds checks. Those source bytes already exist. Preserve the original forward expansion for short-distance self-repeating matches.
+- Add 33 regression tests, including 1,792 controlled fixed-Huffman distance/length/alignment cases.
+
+No parser API, JSON rules, storage format, cache limits, deduplication policy, worker-count default, compression level, progress event, or UI behavior changes. Input/output bounds, CRC, exact-size, and trailing-input checks remain enabled. The older ZIP splitter, scanner, dense-rehash, cache-copy, and descriptor/string-copy experiments are excluded.
+
+## Completed whole-import comparisons
+
+Each run uses 12 adjacent AB/BA pairs per dictionary: **72 measured fresh-profile imports plus six separately excluded warmup imports**. Dictionary order rotates. Both builds use the same pinned dependencies, dictionaries, corrected PR #20 schema-3 timing harness, and production import defaults. No traces, screenshots, or process sampling run during timing. No outliers are removed and different runners are not pooled.
+
+Timing: browser file-input change through the current operation's post-UI import-complete event. This is not a physical-paint measurement. Worker-RPC and automation-observed intervals remain separate.
+
+Percentages below are medians of within-pair `(candidate / baseline - 1) * 100`, not ratios of the two independent time medians. Negative means less time. Intervals are exploratory, unadjusted 20,000-resample percentile bootstrap intervals for paired medians.
+
+### First runner
+
+[Completed run 34280922194](https://github.com/ManabiIO/manabitan/actions/runs/34280922194): AMD EPYC 7763, four logical CPUs, approximately 16 GiB RAM, Ubuntu 24.04, Node 24.20.0, Playwright 1.63.0, Chromium 153.0.8010.12, clang 18.1.3.
+
+| Dictionary | Baseline median ms | Candidate median ms | Paired change | Faster pairs | Exploratory 95% interval |
+| ---------- | -----------------: | ------------------: | ------------: | -----------: | ----------------------: |
+| JMdict | 1554.9 | 1532.7 | -0.83% | 10/12 | -3.19% to -0.42% |
+| JMnedict | 1393.6 | 1389.8 | +0.29% | 6/12 | -1.47% to +2.80% |
+| Jitendex | 2777.7 | 2737.2 | -1.15% | 11/12 | -2.38% to -0.26% |
+
+### Fresh-runner confirmation
+
+[Completed run 34282494230](https://github.com/ManabiIO/manabitan/actions/runs/34282494230): Intel Xeon Platinum 8573C, four logical CPUs, approximately 16 GiB RAM; same runtime/compiler versions. This comparison uses immutable baseline and published candidate commits. Each resulting WASM binary is byte-identical to the corresponding binary from the first runner.
+
+| Dictionary | Baseline median ms | Candidate median ms | Paired change | Faster pairs | Exploratory 95% interval |
+| ---------- | -----------------: | ------------------: | ------------: | -----------: | ----------------------: |
+| JMdict | 1446.7 | 1450.4 | -0.03% | 6/12 | -2.55% to +3.20% |
+| JMnedict | 1308.8 | 1299.6 | -1.46% | 7/12 | -3.96% to +1.75% |
+| Jitendex | 2526.3 | 2502.8 | -1.14% | 7/12 | -3.45% to +0.26% |
+
+Every one of the 156 measured/warmup import reports passes exact title/revision/row-count checks, 12 readable-content probes, no import/settings errors, and no fallback/skipped verification. Every run's harness/lock/package fingerprints are re-audited. Compressed-input counters prove that the modified WASM inflation route ran, with identical per-dictionary compressed/uncompressed byte totals on both sides.
+
+These persisted-content probes are sampled checks, not exhaustive database equality.
+
+## Component results — not import speedups
+
+A separate preloaded single-WASM benchmark measures inflation, CRC, and bank-wrapper compaction only. Local Linux x64 Intel Xeon Platinum 8370C, four-core quota, 4 GiB limit, one-CPU affinity, Node 24.20.0, clang 17. All bytes are checked outside timing.
+
+After initial isolated four-pair trials of each change and the combination, the frozen combined candidate completed 12 new pairs per dictionary:
+
+| Dictionary | Baseline component median ms | Candidate component median ms | Paired change | Faster pairs |
+| ---------- | ---------------------------: | ----------------------------: | ------------: | -----------: |
+| JMdict | 566.4 | 505.4 | -10.31% | 12/12 |
+| JMnedict | 279.7 | 240.2 | -12.98% | 12/12 |
+| Jitendex | 1436.5 | 1328.6 | -8.96% | 12/12 |
+
+An exploratory six-pair Chromium 153 component check using the actual CI-built binaries also had lower paired medians: -11.91%, -13.66%, and -6.14%, respectively, with 5/6, 6/6, and 5/6 faster pairs. Its first launch failed before timing because the offline bundle lacked the optional headless shell; the completed run used the pinned full Chromium executable.
+
+## Correctness
+
+- Local and independent CI full unit suites: **5,422 passed, 46 existing skips, 152 files**. Separate options: **25 passed**. All four TypeScript projects, new-test focused lint, and all-target build dry run pass. Repository-wide lint/CI is not claimed green.
+- Strict full Chromium E2E from the first verification run: **82 phases pass without skipped verification**, including concurrent lookup, interrupted-update recovery, updates, restart persistence, batch import, hover/search, and deletion. The confirmation run repeats boundary tests and measurements, not the full E2E suite.
+- All **338 term banks / 754,052,959 decompressed bytes** match independent ZIP decompression and both implementations byte-for-byte. Repeated using local clang-17 modules and the actual downloaded clang-18 CI modules.
+- **1,280 valid generated inputs plus 11,520 modified/truncated/trailing-input cases** produce zero status, output-byte, or output-guard differences. Repeated on the actual CI binaries. Some modified inputs may remain valid.
+- A supplementary test-only streaming wrapper passes **384 cases per arm**: fragmented input down to one byte, wrapping/nonwrapping output, raw DEFLATE/zlib streams, repeated 32 KiB history, four compression levels, and output guards. It is separate from the committed 33-test suite.
+- The saved three-file product patch reconstructs the tested Git tree exactly. No generated bundle or verification workflow is part of the product diff.
+
+## Provenance and retained evidence
+
+Actual first-run and confirmation WASM SHA-256:
+
+- Baseline: `3f9e47b17109cdcada5c9c4c6bcd584bab9d8263a3add46e6bf8c772b0cd1f56`.
+- Candidate: `da170cae914093e14d27b74944b68ac041f041342bf26368934a7d090b25fdd4`.
+
+Local clang-17 candidate: `e2fa243a8754b45729997550f885de180708d6226e0ef7b74ee6c068ed105ebd`. Compiler-specific binaries are identified separately.
+
+Raw GitHub artifact `inflate-core-verification` (10078040841), SHA-256 `6185e4a1ac95529b53ee379cf7db6e2aa3bc09201fbd62e93b2ff8894d737a8f`, retains every first-run report, source diff, build/test log, and both measured WASM binaries. `inflate-core-confirmation` (10078474070), SHA-256 `918fb52951fdb853e2d6304e99182857ddbbf8c4210c9fb48ef4bdac5cf4a5ca`, retains every confirmation report and binary. Both were retrieved and independently audited; they are not merely submitted jobs. Actions retention is 14 days; the delivered evidence bundle also preserves these complete archives, all paired values, local validation, and rejected experiments without fonts, dictionaries, dependencies, or browser binaries.
+
+## Limits and exclusions
+
+Only Linux x64 Chromium is performance-tested. Firefox, ARM, and 32-bit host devices are unvalidated. Lower-memory configurations selecting ZIP-worker inflation do not use this modified decoder; no whole-import benefit is claimed for that route. PR #20's pre-existing Firefox/parser sign-off concerns are separate and unresolved.
+
+The earlier scanner and dense comparisons were recovered and remain mixed. The new owned-cache-copy experiment had approximately -1.09% / -1.19% / +0.32% paired changes and was not combined or promoted. A local whole-browser cache-copy run was interrupted after severe 4 GiB memory pressure; its partial evidence and stop reason are retained, but no effect estimate is used. Failed preflight attempts and diagnostic traces are explicitly excluded from authoritative timing.
+
+No release branch or previous PR was merged. Reproduce with independent source worktrees and the repository's corrected `dev/perf/import-benchmark.js` / `mise run perf:import` entrypoint, pinned fixtures, identical builds except the candidate, and adjacent counterbalanced runs. Run traces separately.
+
+Semantic references: [DEFLATE RFC 1951](https://www.rfc-editor.org/rfc/rfc1951.html) and [WebAssembly memory.copy](https://webassembly.github.io/spec/core/exec/instructions.html#exec-memory-copy). These constrain correctness; they do not establish performance.

--- a/dev/perf/inflate-core-validation.md
+++ b/dev/perf/inflate-core-validation.md
@@ -1,95 +1,59 @@
 # WASM inflater validation — September 8, 2026
 
-## Decision
+## Decision and source
 
-**Draft: a repeatable component improvement, but only a modest whole-import signal.** Jitendex's median paired improvement is approximately 1.15% on both independent runners. The second run is noisier and its interval includes zero. The first JMdict improvement did not repeat. Do not advertise the component's double-digit improvement as an equivalent import speedup or merge this as a general cross-device win.
+**Draft: a repeatable component improvement, but only a modest whole-import signal.** Jitendex's paired median is about 1.15% lower on both runners; the second interval includes zero. JMdict's first improvement did not repeat. Do not advertise the component result as an equal import speedup or a general cross-device win.
 
-Baseline: PR #20 commit `394d8eb799dd1eb5e194cee11472a4beab915080`, not release main or upstream Yomitan.
+Baseline: PR #20 `394d8eb799dd1eb5e194cee11472a4beab915080`, not release main or upstream Yomitan. Tested source: `1a48eb3ef7da950a1ab55716c2ac2f725741b9ba`, tree `0bd78b4f115919a4e984c929faff2af67f3881e1`. Later documentation commits do not change executable code.
 
-Exact tested source commit: `1a48eb3ef7da950a1ab55716c2ac2f725741b9ba`.
+The two miniz changes select its existing 64-bit bit buffer for WebAssembly and use overlap-safe bulk copying for history matches of at least nine bytes whose length is no greater than distance. Existing bounds checks precede copying. Short-distance self-repeating matches retain forward expansion. A new test file adds 33 tests, including 1,792 controlled fixed-Huffman distance/length/alignment cases.
 
-Exact tested source/test tree: `0bd78b4f115919a4e984c929faff2af67f3881e1`. This documentation follows that commit and does not change executable code.
+No API, JSON rules, storage format, compression level, cache limit, deduplication policy, worker default, progress event, or UI changes. CRC, exact-size, and trailing-input checks remain enabled. No older ZIP, scanner, dense-rehash, cache-copy, or descriptor/string-copy experiment is included.
 
-## Change
+## Whole imports
 
-- Select miniz's existing 64-bit bit buffer for WebAssembly. Its architecture heuristic previously selected 32-bit buffering for wasm32, despite WebAssembly's i64 arithmetic. No new build feature is enabled.
-- Use overlap-safe bulk copying for history matches of at least nine bytes with length no greater than distance, after the existing bounds checks. Those source bytes already exist. Preserve the original forward expansion for short-distance self-repeating matches.
-- Add 33 regression tests, including 1,792 controlled fixed-Huffman distance/length/alignment cases.
+Each comparison uses 12 adjacent AB/BA pairs per dictionary: 72 measured fresh-profile imports plus six excluded warmup imports. Dictionary order rotates. Dependencies, pinned fixtures, corrected PR #20 schema-3 harness, and production defaults match. No traces/screenshots/process sampling during timing, no outlier removal, no optional stopping, and no pooling runners.
 
-No parser API, JSON rules, storage format, cache limits, deduplication policy, worker-count default, compression level, progress event, or UI behavior changes. Input/output bounds, CRC, exact-size, and trailing-input checks remain enabled. The older ZIP splitter, scanner, dense-rehash, cache-copy, and descriptor/string-copy experiments are excluded.
+Boundary: browser file-input change to current-operation post-UI completion, not physical paint. Worker-RPC and automation-observed intervals remain separate. Percentages are medians of within-pair ratios, not ratios of the two time medians. Negative means faster. Intervals are exploratory, unadjusted 20,000-resample percentile bootstrap intervals for paired medians.
 
-## Completed whole-import comparisons
+Both runners use four logical CPUs, approximately 16 GiB RAM, Ubuntu 24.04, Node 24.20.0, Playwright 1.63.0, Chromium 153.0.8010.12, and clang 18.1.3. First runner: AMD EPYC 7763. Confirmation: Intel Xeon Platinum 8573C. Confirmation uses immutable source commits; its corresponding WASM binaries match the first run byte-for-byte.
 
-Each run uses 12 adjacent AB/BA pairs per dictionary: **72 measured fresh-profile imports plus six separately excluded warmup imports**. Dictionary order rotates. Both builds use the same pinned dependencies, dictionaries, corrected PR #20 schema-3 timing harness, and production import defaults. No traces, screenshots, or process sampling run during timing. No outliers are removed and different runners are not pooled.
+| Run          | Dictionary | Baseline ms | Candidate ms | Paired change | Faster |     95% interval |
+| ------------ | ---------- | ----------: | -----------: | ------------: | -----: | ---------------: |
+| First        | JMdict     |      1554.9 |       1532.7 |        -0.83% |  10/12 | -3.19% to -0.42% |
+| First        | JMnedict   |      1393.6 |       1389.8 |        +0.29% |   6/12 | -1.47% to +2.80% |
+| First        | Jitendex   |      2777.7 |       2737.2 |        -1.15% |  11/12 | -2.38% to -0.26% |
+| Confirmation | JMdict     |      1446.7 |       1450.4 |        -0.03% |   6/12 | -2.55% to +3.20% |
+| Confirmation | JMnedict   |      1308.8 |       1299.6 |        -1.46% |   7/12 | -3.96% to +1.75% |
+| Confirmation | Jitendex   |      2526.3 |       2502.8 |        -1.14% |   7/12 | -3.45% to +0.26% |
 
-Timing: browser file-input change through the current operation's post-UI import-complete event. This is not a physical-paint measurement. Worker-RPC and automation-observed intervals remain separate.
+All 156 measured/warmup reports pass exact title/revision/row counts, 12 readable-content probes, and no errors/fallback/skipped verification. Every run's harness/lock/package hashes are audited. Equal compressed-input counters prove both sides exercised the modified inflater. These are sampled persisted-content checks, not exhaustive database equality.
 
-Percentages below are medians of within-pair `(candidate / baseline - 1) * 100`, not ratios of the two independent time medians. Negative means less time. Intervals are exploratory, unadjusted 20,000-resample percentile bootstrap intervals for paired medians.
+## Component evidence and correctness
 
-### First runner
+Preloaded single-WASM inflation, CRC, and wrapper compaction on a local Xeon Platinum 8370C, one-CPU affinity, four-core quota, 4 GiB limit, Node 24.20.0, clang 17: twelve confirmation pairs each gave JMdict **-10.31%**, JMnedict **-12.98%**, Jitendex **-8.96%**, all 12/12 faster. Initial isolated four-pair experiments are retained separately. This excludes startup, storage, and UI.
 
-[Completed run 34280922194](https://github.com/ManabiIO/manabitan/actions/runs/34280922194): AMD EPYC 7763, four logical CPUs, approximately 16 GiB RAM, Ubuntu 24.04, Node 24.20.0, Playwright 1.63.0, Chromium 153.0.8010.12, clang 18.1.3.
+An exploratory Chromium component check using actual CI-built binaries gave **-11.91% / -13.66% / -6.14%**, with 5/6, 6/6, and 5/6 faster pairs. A missing optional headless-shell executable caused a pre-timing launch failure; the completed run used the pinned full Chromium executable.
 
-| Dictionary | Baseline median ms | Candidate median ms | Paired change | Faster pairs | Exploratory 95% interval |
-| ---------- | -----------------: | ------------------: | ------------: | -----------: | ----------------------: |
-| JMdict | 1554.9 | 1532.7 | -0.83% | 10/12 | -3.19% to -0.42% |
-| JMnedict | 1393.6 | 1389.8 | +0.29% | 6/12 | -1.47% to +2.80% |
-| Jitendex | 2777.7 | 2737.2 | -1.15% | 11/12 | -2.38% to -0.26% |
+- Local and CI full suites: **5,422 passed, 46 existing skips, 152 files**; options **25 passed**. All four TypeScript projects, focused new-test lint, and all-target build dry run pass. Repository-wide lint/CI is not claimed green.
+- First verification's strict full Chromium E2E: **82 phases pass without skips**, including concurrent lookup, interrupted updates, restart persistence, batch import, hover/search, and deletion. Confirmation repeats boundary tests and timing, not full E2E.
+- All **338 term banks / 754,052,959 raw decompressed bytes** match independent ZIP decompression and both implementations. Repeated on local clang-17 and actual CI clang-18 modules.
+- **1,280 valid generated plus 11,520 modified/truncated/trailing-input cases**: zero status/byte/guard differences, repeated on CI binaries. Some modified inputs may remain valid.
+- A separate test-only streaming wrapper passes **384 cases per arm**, covering fragmented input, wrapping/nonwrapping output, raw/zlib streams, repeated 32 KiB history, four levels, and guards. It is not part of the committed 33-test suite.
+- The saved three-file product patch reconstructs the tested tree exactly. No generated bundle or verification workflow is in the product diff.
 
-### Fresh-runner confirmation
+## Evidence and limits
 
-[Completed run 34282494230](https://github.com/ManabiIO/manabitan/actions/runs/34282494230): Intel Xeon Platinum 8573C, four logical CPUs, approximately 16 GiB RAM; same runtime/compiler versions. This comparison uses immutable baseline and published candidate commits. Each resulting WASM binary is byte-identical to the corresponding binary from the first runner.
+[First completed run 34280922194](https://github.com/ManabiIO/manabitan/actions/runs/34280922194): artifact `inflate-core-verification` (10078040841), SHA-256 `6185e4a1ac95529b53ee379cf7db6e2aa3bc09201fbd62e93b2ff8894d737a8f`.
 
-| Dictionary | Baseline median ms | Candidate median ms | Paired change | Faster pairs | Exploratory 95% interval |
-| ---------- | -----------------: | ------------------: | ------------: | -----------: | ----------------------: |
-| JMdict | 1446.7 | 1450.4 | -0.03% | 6/12 | -2.55% to +3.20% |
-| JMnedict | 1308.8 | 1299.6 | -1.46% | 7/12 | -3.96% to +1.75% |
-| Jitendex | 2526.3 | 2502.8 | -1.14% | 7/12 | -3.45% to +0.26% |
+[Completed confirmation 34282494230](https://github.com/ManabiIO/manabitan/actions/runs/34282494230): artifact `inflate-core-confirmation` (10078474070), SHA-256 `918fb52951fdb853e2d6304e99182857ddbbf8c4210c9fb48ef4bdac5cf4a5ca`.
 
-Every one of the 156 measured/warmup import reports passes exact title/revision/row-count checks, 12 readable-content probes, no import/settings errors, and no fallback/skipped verification. Every run's harness/lock/package fingerprints are re-audited. Compressed-input counters prove that the modified WASM inflation route ran, with identical per-dictionary compressed/uncompressed byte totals on both sides.
+Both archives were downloaded and audited. They retain every pair/report, source/build fingerprints, and measured WASM binaries; the first also retains full validation logs. Actions retention is 14 days. The delivered `manabitan-inflater-source-and-evidence.zip` preserves those archives, all paired values, local validation, and rejected experiments without fonts, dictionaries, dependencies, or browser binaries.
 
-These persisted-content probes are sampled checks, not exhaustive database equality.
+Actual CI WASM SHA-256: baseline `3f9e47b17109cdcada5c9c4c6bcd584bab9d8263a3add46e6bf8c772b0cd1f56`; candidate `da170cae914093e14d27b74944b68ac041f041342bf26368934a7d090b25fdd4`. Local clang-17 candidate: `e2fa243a8754b45729997550f885de180708d6226e0ef7b74ee6c068ed105ebd`.
 
-## Component results — not import speedups
+Firefox, ARM, and 32-bit hosts are unvalidated. Lower-memory configurations selecting ZIP-worker inflation do not use this modified decoder; no benefit is claimed there. PR #20's earlier Firefox/parser sign-off concerns remain separate. No release branch or previous PR was merged.
 
-A separate preloaded single-WASM benchmark measures inflation, CRC, and bank-wrapper compaction only. Local Linux x64 Intel Xeon Platinum 8370C, four-core quota, 4 GiB limit, one-CPU affinity, Node 24.20.0, clang 17. All bytes are checked outside timing.
+Recovered scanner/dense results remain mixed. The new owned-cache-copy experiment had -1.09% / -1.19% / +0.32% paired changes and was not promoted or combined. A local cache-copy browser run was interrupted after severe memory pressure; its partial evidence and stop reason are retained, with no effect estimate used. Failed preflights and diagnostic traces are excluded from authoritative timing.
 
-After initial isolated four-pair trials of each change and the combination, the frozen combined candidate completed 12 new pairs per dictionary:
-
-| Dictionary | Baseline component median ms | Candidate component median ms | Paired change | Faster pairs |
-| ---------- | ---------------------------: | ----------------------------: | ------------: | -----------: |
-| JMdict | 566.4 | 505.4 | -10.31% | 12/12 |
-| JMnedict | 279.7 | 240.2 | -12.98% | 12/12 |
-| Jitendex | 1436.5 | 1328.6 | -8.96% | 12/12 |
-
-An exploratory six-pair Chromium 153 component check using the actual CI-built binaries also had lower paired medians: -11.91%, -13.66%, and -6.14%, respectively, with 5/6, 6/6, and 5/6 faster pairs. Its first launch failed before timing because the offline bundle lacked the optional headless shell; the completed run used the pinned full Chromium executable.
-
-## Correctness
-
-- Local and independent CI full unit suites: **5,422 passed, 46 existing skips, 152 files**. Separate options: **25 passed**. All four TypeScript projects, new-test focused lint, and all-target build dry run pass. Repository-wide lint/CI is not claimed green.
-- Strict full Chromium E2E from the first verification run: **82 phases pass without skipped verification**, including concurrent lookup, interrupted-update recovery, updates, restart persistence, batch import, hover/search, and deletion. The confirmation run repeats boundary tests and measurements, not the full E2E suite.
-- All **338 term banks / 754,052,959 decompressed bytes** match independent ZIP decompression and both implementations byte-for-byte. Repeated using local clang-17 modules and the actual downloaded clang-18 CI modules.
-- **1,280 valid generated inputs plus 11,520 modified/truncated/trailing-input cases** produce zero status, output-byte, or output-guard differences. Repeated on the actual CI binaries. Some modified inputs may remain valid.
-- A supplementary test-only streaming wrapper passes **384 cases per arm**: fragmented input down to one byte, wrapping/nonwrapping output, raw DEFLATE/zlib streams, repeated 32 KiB history, four compression levels, and output guards. It is separate from the committed 33-test suite.
-- The saved three-file product patch reconstructs the tested Git tree exactly. No generated bundle or verification workflow is part of the product diff.
-
-## Provenance and retained evidence
-
-Actual first-run and confirmation WASM SHA-256:
-
-- Baseline: `3f9e47b17109cdcada5c9c4c6bcd584bab9d8263a3add46e6bf8c772b0cd1f56`.
-- Candidate: `da170cae914093e14d27b74944b68ac041f041342bf26368934a7d090b25fdd4`.
-
-Local clang-17 candidate: `e2fa243a8754b45729997550f885de180708d6226e0ef7b74ee6c068ed105ebd`. Compiler-specific binaries are identified separately.
-
-Raw GitHub artifact `inflate-core-verification` (10078040841), SHA-256 `6185e4a1ac95529b53ee379cf7db6e2aa3bc09201fbd62e93b2ff8894d737a8f`, retains every first-run report, source diff, build/test log, and both measured WASM binaries. `inflate-core-confirmation` (10078474070), SHA-256 `918fb52951fdb853e2d6304e99182857ddbbf8c4210c9fb48ef4bdac5cf4a5ca`, retains every confirmation report and binary. Both were retrieved and independently audited; they are not merely submitted jobs. Actions retention is 14 days; the delivered evidence bundle also preserves these complete archives, all paired values, local validation, and rejected experiments without fonts, dictionaries, dependencies, or browser binaries.
-
-## Limits and exclusions
-
-Only Linux x64 Chromium is performance-tested. Firefox, ARM, and 32-bit host devices are unvalidated. Lower-memory configurations selecting ZIP-worker inflation do not use this modified decoder; no whole-import benefit is claimed for that route. PR #20's pre-existing Firefox/parser sign-off concerns are separate and unresolved.
-
-The earlier scanner and dense comparisons were recovered and remain mixed. The new owned-cache-copy experiment had approximately -1.09% / -1.19% / +0.32% paired changes and was not combined or promoted. A local whole-browser cache-copy run was interrupted after severe 4 GiB memory pressure; its partial evidence and stop reason are retained, but no effect estimate is used. Failed preflight attempts and diagnostic traces are explicitly excluded from authoritative timing.
-
-No release branch or previous PR was merged. Reproduce with independent source worktrees and the repository's corrected `dev/perf/import-benchmark.js` / `mise run perf:import` entrypoint, pinned fixtures, identical builds except the candidate, and adjacent counterbalanced runs. Run traces separately.
-
-Semantic references: [DEFLATE RFC 1951](https://www.rfc-editor.org/rfc/rfc1951.html) and [WebAssembly memory.copy](https://webassembly.github.io/spec/core/exec/instructions.html#exec-memory-copy). These constrain correctness; they do not establish performance.
+Reproduce with independent source worktrees, locked fixtures, and the corrected `dev/perf/import-benchmark.js` / `mise run perf:import` entrypoint. Run traces separately. [RFC 1951](https://www.rfc-editor.org/rfc/rfc1951.html) and [WebAssembly memory.copy](https://webassembly.github.io/spec/core/exec/instructions.html#exec-memory-copy) establish semantic constraints, not performance expectations.

--- a/ext/js/dictionary/wasm/vendor/miniz/miniz.h
+++ b/ext/js/dictionary/wasm/vendor/miniz/miniz.h
@@ -225,7 +225,8 @@
 #endif
 #endif
 
-#if defined(_M_X64) || defined(_WIN64) || defined(__MINGW64__) || defined(_LP64) || defined(__LP64__) || defined(__ia64__) || defined(__x86_64__)
+/* WebAssembly has i64 arithmetic independently of its pointer width. */
+#if defined(_M_X64) || defined(_WIN64) || defined(__MINGW64__) || defined(_LP64) || defined(__LP64__) || defined(__ia64__) || defined(__x86_64__) || defined(__wasm__)
 /* Set MINIZ_HAS_64BIT_REGISTERS to 1 if operations on 64-bit integers are reasonably fast (and don't involve compiler generated calls to helper functions). */
 #define MINIZ_HAS_64BIT_REGISTERS 1
 #else

--- a/ext/js/dictionary/wasm/vendor/miniz/miniz_tinfl.c
+++ b/ext/js/dictionary/wasm/vendor/miniz/miniz_tinfl.c
@@ -552,7 +552,18 @@ extern "C"
                         }
                         continue;
                     }
-#if MINIZ_USE_UNALIGNED_LOADS_AND_STORES
+#if defined(__wasm_bulk_memory__)
+                    else if ((counter >= 9) && (counter <= dist))
+                    {
+                        /* Manabitan: these match bytes already exist in the history.
+                           Short-distance matches must keep forward expansion below.
+                           memmove also preserves wrapped-buffer aliasing semantics. */
+                        __builtin_memmove(pOut_buf_cur, pSrc, counter);
+                        pOut_buf_cur += counter;
+                        counter = 0;
+                        continue;
+                    }
+#elif MINIZ_USE_UNALIGNED_LOADS_AND_STORES
                     else if ((counter >= 9) && (counter <= dist))
                     {
                         const mz_uint8 *pSrc_end = pSrc + (counter & ~7);

--- a/test/term-bank-inflate-matches.test.js
+++ b/test/term-bank-inflate-matches.test.js
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2026 Manabitan authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+/* eslint @stylistic/semi: ["error", "never"] */
+
+import {readFile} from 'node:fs/promises'
+import {crc32, deflateRawSync, inflateRawSync} from 'node:zlib'
+import {beforeAll, describe, expect, test} from 'vitest'
+
+/** @typedef {{memory: WebAssembly.Memory, wasm_reset_heap: () => void, wasm_alloc: (size: number) => number, inflate_and_join_term_banks: (...args: number[]) => number}} InflateExports */
+/** @type {InflateExports} */
+let wasm
+beforeAll(async () => {
+    const module = await WebAssembly.compile(await readFile(new URL('../ext/lib/term-bank-parser.wasm', import.meta.url)))
+    wasm = /** @type {InflateExports} */ (/** @type {unknown} */ ((await WebAssembly.instantiate(module)).exports))
+})
+
+/**
+ * Hand-build a fixed-Huffman block so the match distance/length, including
+ * self-overlapping expansion, are known rather than chosen by a compressor.
+ * @param {number} distance
+ * @param {number} length
+ * @param {number} padding
+ * @returns {{compressed: Uint8Array, expected: Uint8Array}}
+ */
+function fixedMatch(distance, length, padding) {
+    /** @type {number[]} */
+    const output = []
+    /** @type {number[]} */
+    const compressed = []
+    let byte = 0
+    let bitCount = 0
+    /**
+     * @param {number} value
+     * @param {number} count
+     */
+    const bits = (value, count) => {
+        for (let i = 0; i < count; ++i) {
+            byte |= ((value >>> i) & 1) << bitCount
+            if (++bitCount === 8) {
+                compressed.push(byte)
+                byte = bitCount = 0
+            }
+        }
+    }
+    /**
+     * @param {number} code
+     * @param {number} count
+     */
+    const codeBits = (code, count) => {
+        for (let i = count - 1; i >= 0; --i) { bits(code >>> i, 1) }
+    }
+    /** @param {number} symbol */
+    const symbol = (symbol) => {
+        if (symbol <= 143) {
+            codeBits(0x30 + symbol, 8)
+        } else if (symbol <= 255) {
+            codeBits(0x190 + symbol - 144, 9)
+        } else if (symbol <= 279) {
+            codeBits(symbol - 256, 7)
+        } else {
+            codeBits(0xc0 + symbol - 280, 8)
+        }
+    }
+    /** @param {number} value */
+    const literal = (value) => {
+        output.push(value)
+        symbol(value)
+    }
+    bits(3, 3) // Final block, fixed Huffman coding.
+    literal(91)
+    literal(34)
+    for (let i = 0; i < distance + padding; ++i) { literal(97 + i % 26) }
+    const bases = [3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 17, 19, 23, 27, 31, 35, 43, 51, 59, 67, 83, 99, 115, 131, 163, 195, 227, 258]
+    const extras = [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 0]
+    let code = bases.length - 1
+    while (length < bases[code]) { --code }
+    symbol(257 + code)
+    bits(length - bases[code], extras[code])
+    code = 29
+    const distanceBase = (/** @type {number} */ value) => (value < 4 ? value + 1 : ((2 + (value & 1)) << ((value >>> 1) - 1)) + 1)
+    while (distance < distanceBase(code)) { --code }
+    codeBits(code, 5)
+    bits(distance - distanceBase(code), code < 4 ? 0 : (code >>> 1) - 1)
+    for (let i = 0; i < length; ++i) { output.push(output[output.length - distance]) }
+    literal(34)
+    literal(93)
+    symbol(256)
+    if (bitCount !== 0) { compressed.push(byte) }
+    return {compressed: Uint8Array.from(compressed), expected: Uint8Array.from(output)}
+}
+
+/**
+ * @param {Uint8Array} compressed
+ * @param {Uint8Array} expected
+ * @param {{crc?: number, capacity?: number}} [options]
+ * @returns {{status: number, output: Uint8Array}}
+ */
+function inflate(compressed, expected, options = {}) {
+    wasm.wasm_reset_heap()
+    const input = wasm.wasm_alloc(compressed.length)
+    const metadata = wasm.wasm_alloc(24)
+    const capacity = options.capacity ?? expected.length + 2
+    const output = wasm.wasm_alloc(capacity + 32)
+    const heap = new Uint8Array(wasm.memory.buffer)
+    heap.set(compressed, input)
+    heap.fill(0xa5, output, output + capacity + 32)
+    new Uint32Array(wasm.memory.buffer, metadata, 6).set([
+        0, compressed.length, expected.length, 8, options.crc ?? crc32(expected),
+    ])
+    const status = wasm.inflate_and_join_term_banks(
+        input,
+        compressed.length,
+        metadata,
+        metadata + 4,
+        metadata + 8,
+        metadata + 12,
+        metadata + 16,
+        1,
+        output,
+        capacity,
+    )
+    expect([...heap.subarray(output + capacity, output + capacity + 32)]).toEqual(new Array(32).fill(0xa5))
+    return {status, output: heap.slice(output, output + Math.max(0, status))}
+}
+
+const distances = [1, 2, 3, 4, 7, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 65, 127, 128, 129, 255, 256, 257, 258, 259, 512, 1024, 4096, 32768]
+const lengths = [3, 8, 9, 15, 16, 17, 31, 32, 63, 64, 127, 128, 255, 256, 257, 258]
+describe('WASM DEFLATE history and bit buffers', () => {
+    test.each(distances)('preserves known match distance %i across lengths and alignments', (distance) => {
+        for (const length of lengths) {
+            for (const padding of [0, 1, 7, 15]) {
+                const fixture = fixedMatch(distance, length, padding)
+                expect(inflateRawSync(fixture.compressed).equals(Buffer.from(fixture.expected))).toBe(true)
+                const result = inflate(fixture.compressed, fixture.expected)
+                expect(result.status).toBe(fixture.expected.length)
+                expect(Buffer.from(result.output).equals(Buffer.from(fixture.expected))).toBe(true)
+            }
+        }
+    })
+
+    test.each([0, 1, 6, 9])('preserves compressor-produced blocks at level %i', (level) => {
+        const text = JSON.stringify([Array.from({length: 4096}, (_, i) => `${i % 37}:日本語と🙂:${'abc'.repeat(i % 19)}`)])
+        const expected = new TextEncoder().encode(text)
+        const compressed = deflateRawSync(expected, {level})
+        const result = inflate(compressed, expected)
+        expect(result.status).toBe(expected.length)
+        expect(Buffer.from(result.output).equals(Buffer.from(expected))).toBe(true)
+    })
+
+    test('still rejects CRC errors, truncated data, and insufficient capacity', () => {
+        const {compressed, expected} = fixedMatch(257, 258, 7)
+        expect(inflate(compressed, expected, {crc: crc32(expected) ^ 1}).status).toBeLessThan(0)
+        expect(inflate(compressed.subarray(0, -2), expected).status).toBeLessThan(0)
+        expect(inflate(compressed, expected, {capacity: expected.length}).status).toBeLessThan(0)
+    })
+})


### PR DESCRIPTION
## Ready for development integration: final source, CI and fresh imports verified

Head **`6b6397544610d285fec07c826462cd08683eb391`**, complete tree **`b217181dee356a8a8f9836cffe5c5b382c27da69`**. Normal history-preserving merge of the earlier inflater head `b6d4c3...` and lint-qualified #25 head `d7ba330...`. #25 is merged into develop as `faa33eb...`; this PR now targets develop. No force push, release deployment or Reader pin change.

Exactly four incremental files: the two miniz runtime files, the 33-test inflater suite and its historical report. Production term-bank parser remains the #18 baseline (Git blob `836cb10f5aa52177bd82d6fbccb44dd5f3811e2b`); the disputed #19 parser and #21 custom ZIP splitter are excluded.

## Runtime scope and review decision

Use miniz's existing 64-bit bit buffer for WebAssembly and bounded bulk copies for eligible DEFLATE history matches. Short-distance self-repeating matches retain forward expansion. CRC/archive validation, formats, compression level, worker defaults, caches and UI are unchanged.

Accept as a small, functionally verified decoder-component change, with historical targeted component evidence and fresh approximately flat whole-import results. **This is not acceptance of a new general whole-import speedup, an equivalence bound, or a cross-device guarantee.** The noisy same-binary controls below explicitly limit performance inference.

## Final correctness and normal CI

Local exact integrated tree: **5,434 unit tests passed, 46 existing skips, 154 files; options 25 passed**, after a fresh library build. The independent source preparation job in **34344263974** checked the exact tree and four-file scope, preserved the parser blob, passed the focused inflater/runtime/lint-boundary suites, verified a clean checkout and published only source history.

Final-head normal [CI 34345036822](https://github.com/ManabiIO/manabitan/actions/runs/34345036822) passes **JavaScript lint, Chromium/Firefox full extension E2E, all four TypeScript projects, units/options, JSON/HTML/CSS/Markdown, full builds and manifest validation**. Dependency review, actionlint and links also pass. Edge/Firefox Android are skipped, not qualified.

## Fresh complete fixed-fixture comparison on the actual new baseline

[Read-only run 34345116632](https://github.com/ManabiIO/manabitan/actions/runs/34345116632) builds immutable baseline `d7ba330...` and candidate `6b639754...` before timing. Each dictionary/job has six fixed adjacent alternating A/B pairs, one excluded warmup pair, two baseline same-binary pairs before, and two candidate same-binary pairs after. Fresh browser profiles; unchanged schema-3 file-input change to current-operation post-UI completion timing; no tracing, optional stopping or discarded observations.

**All 66 completed import reports were independently re-audited:** 36 measured A/B imports, six excluded warmups and 24 same-binary controls. Exact fixture title/revision/row counts, twelve readable persisted-content probes each, no import/settings errors or fallback storage, clean source identities, matching harness/lock/ZIP/Zstd fingerprints and complete intended compressed-source accounting all pass. These are sampled persisted-content checks, not exhaustive database equivalence. Both sides actually use the WASM compressed-input path.

| Dictionary | Median within-pair change | Total equal-work time change | Candidate faster pairs |
|---|---:|---:|---:|
| JMdict | -1.61% | -1.86% | 6/6 |
| JMnedict | +0.56% | +0.04% | 2/6 |
| Jitendex | +0.37% | -0.18% | 3/6 |

Positive is slower. Do not substitute separate medians or component timings for these values. Before-run A/A medians were **-8.71%, +23.15%, +23.50%** respectively; after-run medians **-2.02%, +1.01%, -0.70%**. Controls show substantial startup/host drift. The fresh results do not support a broad speed claim or a tight non-regression bound; JMnedict/Jitendex are effectively flat at this evidence level. No pooled-host or discarded-outlier analysis is used.

Node 22.16.0, Chromium 153.0.8010.12, Linux x64, four logical CPUs and about 16 GiB host RAM. JMdict uses an AMD EPYC 7763 host, the other two jobs EPYC 9V74 hosts. Firefox is functionally tested by normal CI, not performance-tested here. ARM/Android/smaller-memory performance remains unqualified.

The first comparison setup failed before timing because node_modules was a symlink not covered by the directory-only gitignore rule. The repeat uses actual dependency directories and retains the clean-tree assertion; it changes no product source and splices no incomplete measurements. Original failed attempt and all final raw reports are retained.

## Historical evidence remains distinct

The retained report records original `1a48eb3...` versus old #20 `394d8eb...`: component improvements, 338-bank parity, generated differential cases and the original small/uncertain Jitendex whole-import signal. Those are historical results, not re-labelled new-baseline gains.

Final artifacts: `final-inflater-recheck-jmdict` 10101483719, `...-jmnedict` 10101482437, `...-jitendex` 10101502685. Downloaded ZIP SHA-256 digests were verified, all 66 summaries were checked, and paired/total values independently recomputed. Raw results, complete audit script and manifests are retained in the delivery. All publication/benchmark helpers remain on the audit branch outside product ancestry.