### PR TITLE
Bounded compressed imports: measured JMdict/Jitendex gains and broader safety coverage

### DIFF
--- a/dev/perf/bounded-import-followup-20260909.md
+++ b/dev/perf/bounded-import-followup-20260909.md
@@ -1,0 +1,70 @@
+# Bounded compressed import follow-up — September 9, 2026
+
+## Decision and source
+
+**Material JMdict/Jitendex gains on the tested constrained Chromium runtimes; JMnedict is not signed off. Draft review only, not release approval.**
+
+Baseline: PR #23 `b8d68458cde8788b5d5301ceaf36beae7a1363f9`, not upstream Yomitan or release main. This pass reuses the existing bounded implementation `29eb2f1e322847566b724934cbd7ac9a9b81ed2b` rather than maintaining a duplicate, adds 20 independent tests, and supplies new comparisons. Source/test commit: `000dbe4decb6159b8cae323312088a79dd10cd5a`; exact tested tree: `e6d11144e19efb196ffa17480eaa539e3596746b`. Later documentation does not change measured code.
+
+Compressed payloads go directly to the existing WASM parser workers for inflation, validation and parsing, instead of first inflating in the ZIP layer and transferring expanded JSON. Low-memory plans retain the existing 64 MiB decoded-source budget and 80-file cap, independently cap compressed input at 64 MiB, and re-plan after releasing each batch. Ordinary fallback remains for unsupported metadata, oversized banks, fewer than four banks or unavailable raw reads. High/unknown-memory import-wide behavior remains unchanged.
+
+These are source-batch limits, **not total process/RSS/WASM-heap limits**. Parser, ZIP, Zstd, database, preinterned-plan, compression level, persistent format, cache limits, global worker settings and UI behavior remain unchanged. The direct-fill ZIP adapter and earlier rejected experiments are excluded.
+
+## Whole-import comparisons
+
+Every row has four adjacent AB/BA pairs plus one separately retained warmup pair, fresh browser profiles, locked dictionaries and unchanged schema-3 browser file-input-change-to-post-UI-completion timing. Negative means faster. Percentages are medians of within-pair ratios, not ratios of the independent time medians. No outliers are removed or independent runners pooled. No profiling, screenshots or process sampling runs during timing.
+
+| Environment | Dictionary | Baseline ms | Candidate ms | Paired change | Faster pairs |
+| --- | --- | ---: | ---: | ---: | ---: |
+| Local 4 GiB | JMdict | 3882.0 | 3080.6 | -20.78% | 3/4 |
+| Local 4 GiB | JMnedict | 2492.8 | 2885.8 | -4.52% | 3/4 |
+| Local 4 GiB | Jitendex | 8779.6 | 6132.4 | -30.19% | 4/4 |
+| Constrained runner, first run | JMdict | 6739.8 | 5269.9 | -20.76% | 4/4 |
+| Constrained runner, first run | JMnedict | 4490.1 | 4031.1 | -7.06% | 3/4 |
+| Constrained runner, confirmation | Jitendex | 20566.4 | 11957.6 | -41.37% | 4/4 |
+
+Local: Node 24.20.0, Chromium 153.0.8010.12, clang 17, four-core quota, 4 GiB cgroup limit, Xeon Platinum 8573C. Constrained GitHub runners: one logical CPU, clang 18.1.3, native page/worker `navigator.deviceMemory=4`; runtime, compiler, source and package fingerprints are retained. No browser memory value was overridden. Timing remains variable on shared hosts, and four pairs per cell are exploratory.
+
+Unadjusted 20,000-resample percentile intervals for paired medians: local JMdict -40.59% to +13.16%; local JMnedict -9.77% to +78.19%; local Jitendex -40.07% to -2.67%; constrained JMdict -33.51% to -9.16%; constrained JMnedict -25.77% to +3.92%; constrained Jitendex -58.77% to -22.88%. These are not universal non-regression bounds.
+
+**JMnedict caveat:** one local candidate pair is 78.19% slower. Although the paired median is lower, the candidate's independent median is higher and total time across four equal-work imports is **11.73% higher**. Retain that observation. No reliable JMnedict speedup or regression-free claim is established.
+
+## Accounting and correctness
+
+All 60 measured/warmup reports from the complete bounded comparisons pass exact title/revision/row-count checks, 12 persisted-content readability probes each, no import/settings errors or fallback storage, frozen package/source checks, complete source-bank accounting, and identical pending/persisted/unique-content deduplication totals. These are sampled persisted-content and accounting checks, not exhaustive database byte equality.
+
+| Fixture | Banks | Baseline expanded bytes transferred | Candidate compressed bytes transferred | Candidate batches |
+| --- | ---: | ---: | ---: | ---: |
+| JMdict | 53 | 171092992 | 15574114 | 3 |
+| JMnedict | 67 | 45421175 | 11419584 | 1 |
+| Jitendex | 218 | 537538792 | 33696215 | 9 |
+
+Every candidate batch stays within both source-byte limits and the file cap. Jitendex transfers approximately 93.7% fewer source bytes; that is not an equal elapsed-time or total-memory reduction.
+
+Two independent full validations of the exact source/test tree pass **5,478 tests**, with 46 existing skips; options **25 passed**; all four strict TypeScript projects and all-target dry builds pass. Strict higher-memory Chromium integration controls pass **84 and 85 phases** without skipped verification. Historical constrained integration of the same runtime code, before test-only cleanup/additions, passed 89 phases; that evidence is retained as historical, not a new run.
+
+The 20 new tests cover lazy byte budgets, adversarial compressed sizes, subsequent batches, file caps, invalid metadata, released reads, disposal and cancellation joined before fallback. The randomized test checks 100 uneven source plans over 20,000 synthetic metadata entries, not 20,000 parsed dictionary rows. Local focused validation passes 79 tests and new-file ESLint.
+
+## Failures remain visible
+
+[First verification 34319896500](https://github.com/ManabiIO/manabitan/actions/runs/34319896500) completed JMdict/JMnedict, but Jitendex stopped after one pair at a zero-phase settings-input startup timeout. The retry classifier expected `failed` instead of the actual `failure` report status and therefore retried nothing.
+
+[Full-plan repeat 34321582663](https://github.com/ManabiIO/manabitan/actions/runs/34321582663) completed Jitendex with **zero retries**. JMnedict stopped after one baseline observation and two pre-import startup failures; JMdict reached the runner job limit after five measured observations. Those incomplete lanes receive no effect estimates, and observations are not spliced between runs. Neither complete workflow matrix is claimed green.
+
+The corrected retry predicate is checked against the actual report and 11 rejecting mutations. At most one recorded retry is allowed only for the precise settings-selector timeout before any phase or import dispatch, never for import, acceptance or slow-timing failures. This does not fix product startup reliability.
+
+A preliminary 4 GiB Docker container still reported browser device memory 16 and was rejected as a low-memory measurement. Dependency-path comment differences also caused a local preflight rejection; both arms were rebuilt from one shared dependency location and byte-checked before timing.
+
+## Excluded ZIP candidate and trace
+
+[Direct-fill verification 34317754128](https://github.com/ManabiIO/manabitan/actions/runs/34317754128) passed 5,470 tests, all types, options, focused lint, dry builds and 81 strict Chromium phases. Its 12-pair independent comparison gave -0.10% JMdict, **+2.16% JMnedict**, and -0.45% Jitendex; local results were highly variable. It is not a general win and is not included here.
+
+A separate candidate-only browser trace completed after local timing. It is non-authoritative. Visible remaining work includes recent-content copies, compression and message transfer. SQLite's heavily sampled async-proxy `waitLoop` calls `Atomics.wait`; its samples are not equivalent active SQLite CPU work. No further cache/compression experiment was combined.
+
+## Evidence and limits
+
+Workflow artifacts retain all reports, patches and fingerprints. Key artifacts: first correctness 10091557162; first JMdict 10091961434; first JMnedict 10091746951; Jitendex confirmation 10092655856; repeated correctness 10092179979; direct-fill 10091040276. Their original ZIPs were downloaded, checked against GitHub SHA-256 digests and preserved, including incomplete lanes, in the delivered `manabitan-import-pass-20260909.zip` alongside full local reports, the separate trace and audit scripts. No fonts, dictionaries, dependencies or browser runtimes are included.
+
+Apply `bounded-complete-source.patch` to PR #23, or only `bounded-test-followup.patch` to existing `29eb2f1`; do not apply both. Each reconstructs the exact tested tree. Rebuild with locked dependencies and verify native browser memory selection before repeating the source A/B.
+
+JMnedict non-regression, startup reliability, larger samples, Firefox, ARM/Android and smaller-memory runtime checks remain open. Do not invent dictionary-specific exceptions from three fixtures. PR #23/PR #20's own limitations remain separate. No release branch, vendor pin or earlier PR was merged or updated.

--- a/ext/js/dictionary/dictionary-importer.js
+++ b/ext/js/dictionary/dictionary-importer.js
@@ -1727,9 +1727,15 @@ export class DictionaryImporter {
                 } else if (!this._disableTermBankWasmFastPath) {
                     try {
                         const termFileEntry = /** @type {import('@zip.js/zip.js').Entry} */ (termFile);
+                        // Constrained devices use the same compressed parser, but only
+                        // for one bounded source batch at a time. Re-plan after each
+                        // batch is released; never pin an import-wide low-memory slab.
+                        const compressedSourcePlan = importWideSourceRunEnabled ?
+                            (termFileIndex === 0 ? compressedImportRunPlan : termBankSourcePipeline.createCompressedImportRunPlan(termFileIndex)) :
+                            null
                         const importRunPlan = importWideSourceRunEnabled ?
-                            (termFileIndex === 0 ? compressedImportRunPlan ?? uncompressedImportRunPlan : null) ?? termBankSourcePipeline.createImportRunPlan(termFileIndex) :
-                            null;
+                            compressedSourcePlan ?? (termFileIndex === 0 ? uncompressedImportRunPlan : null) ?? termBankSourcePipeline.createImportRunPlan(termFileIndex) :
+                            null
                         const usedImportWideSourceRun = importRunPlan !== null;
                         let sourceTermFileBatch = importRunPlan?.files ?? (termBankSourcePipeline.canPrefetch(termFile) ? termBankSourcePipeline.getBatch(termFileIndex) : []);
                         let tSourceArchiveReadStart = Date.now();
@@ -1738,7 +1744,7 @@ export class DictionaryImporter {
                             {
                                 loaders: importRunPlan.loaders,
                                 estimatedByteLengths: importRunPlan.estimatedByteLengths,
-                                compressed: importRunPlan === compressedImportRunPlan,
+                                compressed: importRunPlan === compressedSourcePlan,
                             };
                         sourceArchiveReadMs += Math.max(0, Date.now() - tSourceArchiveReadStart);
                         if (preloadedTermFileBytes === null) {

--- a/ext/js/dictionary/term-bank-source-pipeline.js
+++ b/ext/js/dictionary/term-bank-source-pipeline.js
@@ -381,20 +381,31 @@ export class TermBankSourcePipeline {
     }
 
     /**
-     * Builds an import-wide plan over raw ZIP payloads only when every source
-     * has complete central-directory metadata required for exact validation.
+     * Builds a lazy raw-ZIP plan with complete validation metadata. On a
+     * low-memory device, admit only the current bounded batch, never the
+     * entire import. The parser's independent source-size guard still applies.
      * @param {number} startIndex
      * @returns {{files: TermBankSourceFile[], loaders: Array<() => Promise<CompressedTermBankSource>>, estimatedByteLengths: number[]}|null}
      */
     createCompressedImportRunPlan(startIndex) {
-        if (!this._enabled || this._lowMemory || this._compressedReadPool === null) { return null; }
-        const files = this._termFiles.slice(startIndex);
-        if (files.length < 4) { return null; }
+        if (!this._enabled || this._compressedReadPool === null) { return null }
+        const boundedBatch = this._lowMemory ? this.getBatchPlan(startIndex) : null
+        if (boundedBatch !== null && (
+            boundedBatch.unknownSizeCount !== 0 ||
+            boundedBatch.estimatedBytes > this._batchMaxBytes
+        )) { return null }
+        const files = boundedBatch === null ? this._termFiles.slice(startIndex) : boundedBatch.files
+        if (files.length < 4) { return null }
         /** @type {Array<{compressionMethod: 0|8, compressedSize: number, uncompressedSize: number, signature: number}>} */
         const metadata = [];
+        let compressedBytes = 0
         for (const file of files) {
             const value = this._getCompressedSourceMetadata(file);
             if (value === null) { return null; }
+            // Bound compressed allocations independently of declared decoded
+            // sizes, including overlapping or adversarial ZIP entries.
+            if (this._lowMemory && value.compressedSize > this._batchMaxBytes - compressedBytes) { return null }
+            compressedBytes += value.compressedSize
             metadata.push(value);
         }
         const estimatedByteLengths = metadata.map(({uncompressedSize}) => uncompressedSize);

--- a/test/dictionary-import-ownership.test.js
+++ b/test/dictionary-import-ownership.test.js
@@ -359,7 +359,8 @@ describe('TermBankSourcePipeline', () => {
         });
 
         expect(pipeline.createImportRunPlan(0)).toBeNull();
-        expect(pipeline.createCompressedImportRunPlan(0)).toBeNull();
+        expect(pipeline.createCompressedImportRunPlan(0)?.files).toEqual(files.slice(0, 16))
+        expect(pipeline.createCompressedImportRunPlan(16)?.files).toEqual(files.slice(16, 32))
         expect(pipeline.getBatch(0)).toEqual(files.slice(0, 16));
         await pipeline.dispose();
     });

--- a/test/term-bank-bounded-compressed-plan.test.js
+++ b/test/term-bank-bounded-compressed-plan.test.js
@@ -1,0 +1,209 @@
+/*
+ * Copyright (C) 2023-2026  Yomitan Authors
+ * Copyright (C) 2020-2022  Yomichan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+/* eslint @stylistic/semi: ["error", "never"] */
+
+import {describe, expect, test, vi} from 'vitest'
+import {TermBankSourcePipeline} from '../ext/js/dictionary/term-bank-source-pipeline.js'
+
+const MiB = 1024 * 1024
+
+/**
+ * Sizes describe metadata only: tests do not allocate the uncompressed banks.
+ * @param {number[]} sizes
+ * @returns {{filename: string, offset: number, compressionMethod: number, compressedSize: number, uncompressedSize: number, signature: number, getData: () => void}[]}
+ */
+function filesFor(sizes) {
+    return sizes.map((size, index) => ({
+        filename: `term_bank_${index + 1}.json`,
+        offset: index * 64,
+        compressionMethod: 8,
+        compressedSize: 4,
+        uncompressedSize: size,
+        signature: index + 100,
+        getData() {},
+    }))
+}
+
+/**
+ * @param {ReturnType<typeof filesFor>} files
+ * @param {number} [deviceMemory=4]
+ * @returns {{pipeline: TermBankSourcePipeline, read: import('vitest').Mock<() => Promise<Uint8Array>>, readCompressed: import('vitest').Mock<() => Promise<Uint8Array>>}}
+ */
+function setup(files, deviceMemory = 4) {
+    const read = vi.fn(async () => new Uint8Array([91, 93]))
+    const readCompressed = vi.fn(async () => new Uint8Array(4))
+    const pipeline = new TermBankSourcePipeline({termFiles: files, enabled: true, read, readCompressed, deviceMemory})
+    return {pipeline, read, readCompressed}
+}
+
+describe('bounded compressed term-bank plans', () => {
+    test.each([0.5, 1, 2, 4])('keeps every lazy run within the existing source budget; deviceMemory=%s', async (memory) => {
+        const files = filesFor(new Array(64).fill(4 * MiB))
+        const {pipeline, read, readCompressed} = setup(files, memory)
+        for (let start = 0; start < files.length; start += 16) {
+            const plan = pipeline.createCompressedImportRunPlan(start)
+            expect(plan?.files).toEqual(files.slice(start, start + 16))
+            expect(plan?.estimatedByteLengths.reduce((sum, size) => sum + size, 0)).toBe(64 * MiB)
+            expect(plan?.loaders).toHaveLength(16)
+        }
+        expect(pipeline.createCompressedImportRunPlan(files.length)).toBeNull()
+        expect(read).not.toHaveBeenCalled()
+        expect(readCompressed).not.toHaveBeenCalled()
+        expect(pipeline.prefetchMaxBytes).toBe(24 * MiB)
+        await pipeline.dispose()
+    })
+
+    test('accepts exactly the limit and splits the next byte into another batch', async () => {
+        const sizes = [16 * MiB, 16 * MiB, 16 * MiB, 16 * MiB, 2, 2, 2, 2]
+        const files = filesFor(sizes)
+        const {pipeline} = setup(files)
+        expect(pipeline.createCompressedImportRunPlan(0)?.files).toEqual(files.slice(0, 4))
+        expect(pipeline.createCompressedImportRunPlan(4)?.files).toEqual(files.slice(4))
+        await pipeline.dispose()
+    })
+
+    test.each([0, Number.NaN, Infinity, -1, 64 * MiB + 1, Number.MAX_SAFE_INTEGER])('does not bypass the budget for an invalid or oversized first bank: %s', async (size) => {
+        const {pipeline, readCompressed} = setup(filesFor([size, 2, 2, 2, 2]))
+        expect(pipeline.createCompressedImportRunPlan(0)).toBeNull()
+        expect(readCompressed).not.toHaveBeenCalled()
+        await pipeline.dispose()
+    })
+
+    test('also bounds compressed input when it is larger than the claimed output', async () => {
+        const files = filesFor([2, 2, 2, 2])
+        for (const file of files) { file.compressedSize = 16 * MiB }
+        const {pipeline, readCompressed} = setup(files)
+        expect(pipeline.createCompressedImportRunPlan(0)?.files).toEqual(files)
+        files[0].compressedSize += 1
+        expect(pipeline.createCompressedImportRunPlan(0)).toBeNull()
+        expect(readCompressed).not.toHaveBeenCalled()
+        await pipeline.dispose()
+    })
+
+    test('retains ordinary fallback for fewer than four banks and no raw reader', async () => {
+        const files = filesFor([2, 2, 2])
+        const {pipeline} = setup(files)
+        expect(pipeline.createCompressedImportRunPlan(0)).toBeNull()
+        await pipeline.dispose()
+        const noRaw = new TermBankSourcePipeline({termFiles: filesFor([2, 2, 2, 2]), enabled: true, read: async () => new Uint8Array(2), deviceMemory: 4})
+        expect(noRaw.createCompressedImportRunPlan(0)).toBeNull()
+        await noRaw.dispose()
+    })
+
+    test.each([8, Number.NaN])('does not change the larger/unknown-memory import-wide policy: %s', async (memory) => {
+        const files = filesFor(new Array(100).fill(4 * MiB))
+        const {pipeline} = setup(files, memory)
+        expect(pipeline.createCompressedImportRunPlan(0)?.files).toEqual(files)
+        expect(pipeline.createCompressedImportRunPlan(16)?.files).toEqual(files.slice(16))
+        await pipeline.dispose()
+    })
+
+    test('keeps the file-count cap and preserves ordering even for tiny banks', async () => {
+        const files = filesFor(new Array(164).fill(2))
+        const {pipeline} = setup(files)
+        for (const start of [0, 80, 160]) {
+            expect(pipeline.createCompressedImportRunPlan(start)?.files).toEqual(files.slice(start, start + 80))
+        }
+        await pipeline.dispose()
+    })
+
+    test('validates the current batch without eagerly reading later invalid metadata', async () => {
+        const files = filesFor(new Array(32).fill(4 * MiB))
+        files[20].compressionMethod = 12
+        const {pipeline, readCompressed} = setup(files)
+        expect(pipeline.createCompressedImportRunPlan(0)?.files).toEqual(files.slice(0, 16))
+        expect(pipeline.createCompressedImportRunPlan(16)).toBeNull()
+        expect(readCompressed).not.toHaveBeenCalled()
+        await pipeline.dispose()
+    })
+
+    test('shares reads within a run and releases ownership before a later retry', async () => {
+        const files = filesFor(new Array(32).fill(4 * MiB))
+        const {pipeline, read, readCompressed} = setup(files)
+        const plan = pipeline.createCompressedImportRunPlan(0)
+        if (plan === null) { throw new Error('Expected bounded plan') }
+        await Promise.all([plan.loaders[0](), plan.loaders[0]()])
+        expect(readCompressed).toHaveBeenCalledTimes(1)
+        pipeline.releaseBatch(plan.files)
+        await plan.loaders[0]()
+        expect(readCompressed).toHaveBeenCalledTimes(2)
+        expect(read).not.toHaveBeenCalled()
+        await pipeline.dispose()
+        await expect(plan.loaders[0]()).rejects.toThrow('disposed')
+    })
+
+    test('joins cancelled raw reads before fallback without starting unclaimed loaders', async () => {
+        const files = filesFor(new Array(32).fill(4 * MiB))
+        /** @type {AbortSignal[]} */
+        const signals = []
+        /** @type {Array<() => void>} */
+        const finish = []
+        const pipeline = new TermBankSourcePipeline({
+            termFiles: files,
+            enabled: true,
+            deviceMemory: 4,
+            read: async () => new Uint8Array([91, 93]),
+            readCompressed: async (_file, signal) => {
+                signals.push(signal)
+                await new Promise((resolve) => { finish.push(() => resolve(void 0)) })
+                signal.throwIfAborted()
+                return new Uint8Array(4)
+            },
+        })
+        const plan = pipeline.createCompressedImportRunPlan(0)
+        if (plan === null) { throw new Error('Expected bounded plan') }
+        const reading = expect(plan.loaders[0]()).rejects.toThrow()
+        let joined = false
+        const aborting = pipeline.abortAndJoin().then(() => { joined = true })
+        expect(signals).toHaveLength(1)
+        expect(signals[0].aborted).toBe(true)
+        await Promise.resolve()
+        expect(joined).toBe(false)
+        finish[0]()
+        await Promise.all([reading, aborting])
+        expect(joined).toBe(true)
+        await expect(pipeline.read(files[0])).resolves.toEqual(new Uint8Array([91, 93]))
+        await pipeline.dispose()
+    })
+
+    test('never exceeds byte or file limits across deterministic uneven source plans', async () => {
+        let seed = 0x91271215
+        const random = () => {
+            seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0
+            return seed
+        }
+        for (let trial = 0; trial < 100; ++trial) {
+            const files = filesFor(Array.from({length: 200}, () => 2 + random() % (25 * MiB)))
+            const {pipeline} = setup(files)
+            for (let start = 0; start < files.length;) {
+                const ordinary = pipeline.getBatch(start)
+                const compressed = pipeline.createCompressedImportRunPlan(start)
+                if (compressed !== null) {
+                    expect(compressed.files).toEqual(ordinary)
+                    expect(compressed.files.length).toBeGreaterThanOrEqual(4)
+                    expect(compressed.files.length).toBeLessThanOrEqual(80)
+                    expect(compressed.estimatedByteLengths.reduce((a, b) => a + b, 0)).toBeLessThanOrEqual(64 * MiB)
+                } else {
+                    expect(ordinary.length).toBeLessThan(4)
+                }
+                start += ordinary.length
+            }
+            await pipeline.dispose()
+        }
+    })
+})

--- a/test/term-bank-bounded-compressed.test.js
+++ b/test/term-bank-bounded-compressed.test.js
@@ -24,18 +24,24 @@ const mib = 1024 * 1024
 /**
  * @param {number} count
  * @param {number} [decodedBytes]
+ * @returns {Array<{filename: string, offset: number, compressionMethod: number, compressedSize: number, uncompressedSize: number, signature: number, getData: () => void}>}
  */
 function filesFor(count, decodedBytes = 4 * mib) {
     return Array.from({length: count}, (_, index) => ({
-        filename: `term_bank_${index + 1}.json`, offset: index * 64,
-        compressionMethod: 8, compressedSize: 4, uncompressedSize: decodedBytes,
-        signature: index + 100, getData() {},
+        filename: `term_bank_${index + 1}.json`,
+        offset: index * 64,
+        compressionMethod: 8,
+        compressedSize: 4,
+        uncompressedSize: decodedBytes,
+        signature: index + 100,
+        getData() {},
     }))
 }
 
 /**
  * @param {ReturnType<typeof filesFor>} files
  * @param {number} [deviceMemory]
+ * @returns {{pipeline: TermBankSourcePipeline, read: import('vitest').Mock<() => Promise<Uint8Array>>, readCompressed: import('vitest').Mock<() => Promise<Uint8Array>>}}
  */
 function createPipeline(files, deviceMemory = 4) {
     const read = vi.fn(async () => new Uint8Array([91, 93]))
@@ -109,8 +115,11 @@ describe('bounded compressed source plans', () => {
     test.each([0, -1, 1.5, Number.NaN, Infinity])('falls back for unknown or invalid decoded size %s', async (size) => {
         const files = filesFor(4, size)
         const {pipeline} = createPipeline(files)
-        try { expect(pipeline.createCompressedImportRunPlan(0)).toBeNull() }
-        finally { await pipeline.dispose() }
+        try {
+            expect(pipeline.createCompressedImportRunPlan(0)).toBeNull()
+        } finally {
+            await pipeline.dispose()
+        }
     })
 
     test('does not reject a valid earlier batch because a later batch has invalid metadata', async () => {
@@ -146,7 +155,9 @@ describe('bounded compressed source plans', () => {
         const files = filesFor(4)
         let aborted = 0
         const pipeline = new TermBankSourcePipeline({
-            termFiles: files, enabled: true, deviceMemory: 4,
+            termFiles: files,
+            enabled: true,
+            deviceMemory: 4,
             read: async () => new Uint8Array(),
             readCompressed: (_file, signal) => new Promise((_resolve, reject) => {
                 signal.addEventListener('abort', () => {
@@ -161,7 +172,7 @@ describe('bounded compressed source plans', () => {
         const settled = Promise.allSettled(reads)
         await pipeline.abortAndJoin()
         expect(aborted).toBe(4)
-        expect((await settled).map(({status}) => status)).toEqual(Array(4).fill('rejected'))
+        expect((await settled).map(({status}) => status)).toEqual(new Array(4).fill('rejected'))
         await pipeline.dispose()
     })
 })

--- a/test/term-bank-bounded-compressed.test.js
+++ b/test/term-bank-bounded-compressed.test.js
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2026 Manabitan authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+/* eslint @stylistic/semi: ["error", "never"] */
+
+import {describe, expect, test, vi} from 'vitest'
+import {TermBankSourcePipeline} from '../ext/js/dictionary/term-bank-source-pipeline.js'
+
+const mib = 1024 * 1024
+
+/**
+ * @param {number} count
+ * @param {number} [decodedBytes]
+ */
+function filesFor(count, decodedBytes = 4 * mib) {
+    return Array.from({length: count}, (_, index) => ({
+        filename: `term_bank_${index + 1}.json`, offset: index * 64,
+        compressionMethod: 8, compressedSize: 4, uncompressedSize: decodedBytes,
+        signature: index + 100, getData() {},
+    }))
+}
+
+/**
+ * @param {ReturnType<typeof filesFor>} files
+ * @param {number} [deviceMemory]
+ */
+function createPipeline(files, deviceMemory = 4) {
+    const read = vi.fn(async () => new Uint8Array([91, 93]))
+    const readCompressed = vi.fn(async () => new Uint8Array(4))
+    const pipeline = new TermBankSourcePipeline({termFiles: files, enabled: true, read, readCompressed, deviceMemory})
+    return {pipeline, read, readCompressed}
+}
+
+describe('bounded compressed source plans', () => {
+    test.each([0.5, 1, 2, 4])('keeps every lazy batch within both byte budgets at deviceMemory=%s', async (memory) => {
+        const files = filesFor(64)
+        const {pipeline, read, readCompressed} = createPipeline(files, memory)
+        try {
+            expect(pipeline.createImportRunPlan(0)).toBeNull()
+            for (const start of [0, 16, 32, 48]) {
+                const plan = pipeline.createCompressedImportRunPlan(start)
+                expect(plan?.files).toEqual(files.slice(start, start + 16))
+                if (plan === null) { throw new Error('Missing bounded plan') }
+                expect(plan.estimatedByteLengths.reduce((a, b) => a + b, 0)).toBe(64 * mib)
+                expect(readCompressed).toHaveBeenCalledTimes(start / 16)
+                await expect(plan.loaders[0]()).resolves.toMatchObject({
+                    filename: files[start].filename, uncompressedSize: 4 * mib, signature: files[start].signature,
+                })
+                pipeline.releaseBatch(plan.files)
+            }
+            expect(read).not.toHaveBeenCalled()
+            expect(pipeline.createCompressedImportRunPlan(files.length)).toBeNull()
+        } finally {
+            await pipeline.dispose()
+        }
+    })
+
+    test('keeps the existing import-wide plan on unconstrained devices', async () => {
+        const files = filesFor(64)
+        const {pipeline, readCompressed} = createPipeline(files, 8)
+        try {
+            expect(pipeline.createCompressedImportRunPlan(0)?.files).toEqual(files)
+            expect(readCompressed).not.toHaveBeenCalled()
+        } finally { await pipeline.dispose() }
+    })
+
+    test('rejects a compressed allocation budget overflow even with tiny decoded sizes', async () => {
+        const files = filesFor(4, 1024)
+        for (const file of files) { file.compressedSize = 17 * mib }
+        const {pipeline, readCompressed} = createPipeline(files)
+        try {
+            expect(pipeline.createCompressedImportRunPlan(0)).toBeNull()
+            expect(readCompressed).not.toHaveBeenCalled()
+        } finally { await pipeline.dispose() }
+    })
+
+    test('accepts exact compressed and decoded limits without reading ahead', async () => {
+        const files = filesFor(5, 16 * mib)
+        for (const file of files) { file.compressedSize = 16 * mib }
+        const {pipeline, readCompressed} = createPipeline(files)
+        try {
+            expect(pipeline.createCompressedImportRunPlan(0)?.files).toEqual(files.slice(0, 4))
+            expect(readCompressed).not.toHaveBeenCalled()
+        } finally { await pipeline.dispose() }
+    })
+
+    test.each([64 * mib + 1, Number.MAX_SAFE_INTEGER])('does not admit an oversized first bank: %s', async (size) => {
+        const files = filesFor(4, size)
+        const {pipeline, readCompressed} = createPipeline(files)
+        try {
+            expect(pipeline.createCompressedImportRunPlan(0)).toBeNull()
+            expect(readCompressed).not.toHaveBeenCalled()
+        } finally { await pipeline.dispose() }
+    })
+
+    test.each([0, -1, 1.5, Number.NaN, Infinity])('falls back for unknown or invalid decoded size %s', async (size) => {
+        const files = filesFor(4, size)
+        const {pipeline} = createPipeline(files)
+        try { expect(pipeline.createCompressedImportRunPlan(0)).toBeNull() }
+        finally { await pipeline.dispose() }
+    })
+
+    test('does not reject a valid earlier batch because a later batch has invalid metadata', async () => {
+        const files = filesFor(32)
+        files[17].signature = -1
+        const {pipeline} = createPipeline(files)
+        try {
+            expect(pipeline.createCompressedImportRunPlan(0)?.files).toEqual(files.slice(0, 16))
+            expect(pipeline.createCompressedImportRunPlan(16)).toBeNull()
+        } finally { await pipeline.dispose() }
+    })
+
+    test('releases old reads before reopening the next bounded plan', async () => {
+        const files = filesFor(4)
+        const {pipeline, readCompressed} = createPipeline(files)
+        try {
+            const first = pipeline.createCompressedImportRunPlan(0)
+            if (first === null) { throw new Error('Missing source plan') }
+            const a = await first.loaders[0]()
+            const b = await first.loaders[0]()
+            expect(a.bytes).toBe(b.bytes)
+            expect(readCompressed).toHaveBeenCalledTimes(1)
+            pipeline.releaseBatch(first.files)
+            const second = pipeline.createCompressedImportRunPlan(0)
+            if (second === null) { throw new Error('Missing source plan') }
+            const c = await second.loaders[0]()
+            expect(c.bytes).not.toBe(a.bytes)
+            expect(readCompressed).toHaveBeenCalledTimes(2)
+        } finally { await pipeline.dispose() }
+    })
+
+    test('still cancels and joins every outstanding raw payload read', async () => {
+        const files = filesFor(4)
+        let aborted = 0
+        const pipeline = new TermBankSourcePipeline({
+            termFiles: files, enabled: true, deviceMemory: 4,
+            read: async () => new Uint8Array(),
+            readCompressed: (_file, signal) => new Promise((_resolve, reject) => {
+                signal.addEventListener('abort', () => {
+                    ++aborted
+                    reject(signal.reason)
+                }, {once: true})
+            }),
+        })
+        const plan = pipeline.createCompressedImportRunPlan(0)
+        if (plan === null) { throw new Error('Missing source plan') }
+        const reads = plan.loaders.map((load) => load())
+        const settled = Promise.allSettled(reads)
+        await pipeline.abortAndJoin()
+        expect(aborted).toBe(4)
+        expect((await settled).map(({status}) => status)).toEqual(Array(4).fill('rejected'))
+        await pipeline.dispose()
+    })
+})


### PR DESCRIPTION
## Draft: substantial constrained-runtime gains, JMnedict sign-off still open

[Full validation, failures, source accounting and reproduction](https://github.com/ManabiIO/manabitan/blob/perf-import-bounded-coverage-20260909/dev/perf/bounded-import-followup-20260909.md)

Baseline: PR #23 at `b8d68458cde8788b5d5301ceaf36beae7a1363f9`, not release main or upstream Yomitan. Reuse the existing bounded implementation `29eb2f1e322847566b724934cbd7ac9a9b81ed2b` rather than a competing implementation, and add 20 independent regression tests.

Exact source/test commit: `000dbe4decb6159b8cae323312088a79dd10cd5a`.
Exact tested source/test tree: `e6d11144e19efb196ffa17480eaa539e3596746b`.
Subsequent commit `ff9cbf2e848a86d6bbfd281179a6d753349e52f4` adds documentation only.

### Change

Send compressed term-bank payloads directly to the existing WASM parser workers for inflation, validation and parsing. Avoid first expanding them in the ZIP layer and transferring expanded JSON.

Low-memory source runs retain the existing 64 MiB decoded-source budget and 80-file cap, independently bound compressed inputs at 64 MiB, and re-plan subsequent batches after release. Retain ordinary fallback for unsupported metadata, oversized banks, fewer than four banks, and unavailable raw reads; higher/unknown-memory import-wide behavior is unchanged.

**These are source-batch limits, not total RSS/WASM-heap limits.** Parser, ZIP, Zstd, database, cache limits, compression level, global worker settings, persistent formats and UI behavior are unchanged. No custom ZIP backport or earlier rejected experiment is included.

### Completed whole-import results

Each row has four adjacent AB/BA pairs and one excluded warmup pair. Fresh profiles, locked fixtures, production defaults, identical corrected browser file-input-change-to-post-UI-completion timing. No outlier removal, pooling independent runners, or tracing during timing. Negative paired change means faster; it is not the ratio of the separate median columns.

| Environment | Dictionary | Baseline median | Candidate median | Median paired change | Faster pairs |
|---|---|---:|---:|---:|---:|
| Local 4 GiB, four-core quota | JMdict | 3882.0 ms | 3080.6 ms | -20.78% | 3/4 |
| Local 4 GiB, four-core quota | JMnedict | 2492.8 ms | 2885.8 ms | -4.52% | 3/4 |
| Local 4 GiB, four-core quota | Jitendex | 8779.6 ms | 6132.4 ms | -30.19% | 4/4 |
| Native constrained runner, first run | JMdict | 6739.8 ms | 5269.9 ms | -20.76% | 4/4 |
| Native constrained runner, first run | JMnedict | 4490.1 ms | 4031.1 ms | -7.06% | 3/4 |
| Native constrained runner, confirmation | Jitendex | 20566.4 ms | 11957.6 ms | -41.37% | 4/4 |

Node 24.20.0 / Playwright 1.63 / Chromium 153.0.8010.12. Native page and worker deviceMemory=4, with no override. Compiler/runtime/source/package fingerprints are retained. Small four-pair cells and shared-host variance do not establish universal device gains.

**JMnedict is not signed off:** one local candidate observation is 78.19% slower. Its paired median is lower, but the independent candidate median is higher and total time across four equal-work imports is **11.73% higher**. The constrained JMnedict uncertainty interval also crosses zero. All observations remain included.

### Acceptance and verification

- All **60 accepted reports** belonging to complete bounded comparisons (48 measured imports + 12 excluded warmups) pass exact title/revision/row-count checks and 12 persisted-content readability probes each, with no import/settings errors or fallback storage. Complete bank accounting and canonical-content/deduplication totals match. This is not exhaustive database byte equality.
- Jitendex transfers **33,696,215 compressed source bytes instead of 537,538,792 expanded bytes**, across nine bounded batches. Every batch meets both source-byte limits and the file cap. The 93.7% transfer-volume reduction is not a corresponding total-memory/time claim.
- Two independent validations of the exact tree: **5,478 unit tests passed, 46 existing skips**; options **25 passed**; all four strict TypeScript projects and all-target dry builds pass.
- Strict higher-memory Chromium integration controls pass **84 and 85 phases** without skipped verification. Historical constrained integration of identical runtime code passed 89 phases before test-only changes; retained as historical evidence, not a new execution.
- New tests cover lazy budgets, adversarial compressed sizes, later batches, file caps, metadata errors, read ownership/release/disposal, and cancellation joined before fallback; 100 deterministic uneven plans exercise 20,000 synthetic metadata entries. Local focused tests and new-file lint pass.

### Failed runs and exclusions

First run [34319896500](https://github.com/ManabiIO/manabitan/actions/runs/34319896500) completed JMdict/JMnedict, while Jitendex stopped before a later import at settings startup. Repeat [34321582663](https://github.com/ManabiIO/manabitan/actions/runs/34321582663) completed all Jitendex pairs **with zero retries**; repeat JMnedict failed at pre-import startup, and repeat JMdict reached the runner job limit. Incomplete lanes have no effect estimates and are never spliced. **The overall matrices are not green.**

A corrected harness predicate allows at most one logged retry only for the precise zero-phase pre-dispatch settings-selector timeout, not import, correctness, or slow-observation failures. This does not fix product startup reliability.

The direct-fill ZIP candidate passed correctness but showed +2.16% JMnedict and approximately flat other independent results. It is excluded. A separate candidate-only trace is retained as non-authoritative; SQLite Atomics.wait samples are not presented as active CPU work.

Raw reports, exact patches, audits, failed attempts and trace are preserved in the delivered evidence archive and identified workflow artifacts. No fonts, dictionaries, dependencies or generated product binaries are committed. JMnedict non-regression, startup reliability, larger samples and Firefox/ARM/Android/smaller-memory validation remain open. No release branch, vendor pin or earlier PR was merged or modified.