### PR TITLE
Add controlled bounded-import replication with same-binary and slow-tail checks

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+# actionlint 1.7.3 predates GitHub's hosted ubuntu-slim label. Its legacy
+# extra-label configuration is named self-hosted-runner, but this declaration
+# does not change where jobs run or suppress other workflow checks.
+# Remove this compatibility entry after upgrading actionlint's built-in labels.
+self-hosted-runner:
+  labels:
+    - ubuntu-slim

--- a/.github/workflows/bounded-followup-verify.yml
+++ b/.github/workflows/bounded-followup-verify.yml
@@ -102,8 +102,11 @@ jobs:
           git worktree add --detach "$arms/baseline" b8d68458cde8788b5d5301ceaf36beae7a1363f9
           git worktree add --detach "$arms/candidate" ff9cbf2e848a86d6bbfd281179a6d753349e52f4
           for arm in baseline candidate; do
-            ln -s "$GITHUB_WORKSPACE/node_modules" "$arms/$arm/node_modules"
-            (cd "$arms/$arm" && node dev/bin/build-libs.js && node dev/bin/build.js --target chrome-dev) > "$evidence/build-$arm.log" 2>&1
+            # The repository ignores node_modules/ directories, not symlinks.
+            # Install the same lockfile normally; keep the strict clean-tree gate.
+            (cd "$arms/$arm" && npm ci && node dev/bin/build-libs.js && node dev/bin/build.js --target chrome-dev) > "$evidence/build-$arm.log" 2>&1
+            git -C "$arms/$arm" status --porcelain > "$evidence/status-$arm.txt"
+            test ! -s "$evidence/status-$arm.txt"
           done
           for file in term-bank-parser.wasm zstd.wasm zip.js z-worker.js; do
             cmp "$arms/baseline/ext/lib/$file" "$arms/candidate/ext/lib/$file"
@@ -127,7 +130,7 @@ jobs:
             --candidate "$RUNNER_TEMP/arms/candidate" \
             --dictionary "$DICTIONARY" --pairs 6 --policy low \
             --output "$RUNNER_TEMP/evidence/paired" "${extra[@]}" \
-            | tee "$RUNNER_TEMP/evidence/driver.log"
+            2>&1 | tee "$RUNNER_TEMP/evidence/driver.log"
       - uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/.github/workflows/bounded-followup-verify.yml
+++ b/.github/workflows/bounded-followup-verify.yml
@@ -5,8 +5,8 @@ on:
     branches: [perf-import-bounded-followup-20260909]
     paths:
       - .github/workflows/bounded-followup-verify.yml
+      - dev/perf/bounded-followup/**
       - ext/js/dictionary/term-bank-source-pipeline.js
-      - test/term-bank-source-followup.test.js
   workflow_dispatch:
 
 permissions:
@@ -16,6 +16,9 @@ concurrency:
   group: bounded-followup-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  PYTHONDONTWRITEBYTECODE: '1'
+
 jobs:
   contracts:
     runs-on: ubuntu-24.04
@@ -24,52 +27,111 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Package identified tracked source for offline review
-        shell: python
-        run: |
-          import hashlib, json, os, pathlib, subprocess, tarfile
-          root = pathlib.Path.cwd()
-          out = pathlib.Path(os.environ['RUNNER_TEMP']) / 'bounded-followup'
-          out.mkdir()
-          paths = subprocess.check_output(['git', 'ls-files', '-z']).split(b'\0')
-          manifest = {}
-          excluded = {'.ttf', '.otf', '.woff', '.woff2', '.eot', '.ttc'}
-          with tarfile.open(out / 'source.tar.gz', 'w:gz') as archive:
-              for raw in paths:
-                  if not raw:
-                      continue
-                  path = pathlib.Path(os.fsdecode(raw))
-                  if path.is_file() and not path.is_symlink() and path.suffix.lower() not in excluded:
-                      manifest[str(path)] = hashlib.sha256(path.read_bytes()).hexdigest()
-                      archive.add(path, arcname=str(path), recursive=False)
-          data = {
-              'commit': subprocess.check_output(['git', 'rev-parse', 'HEAD'], text=True).strip(),
-              'tree': subprocess.check_output(['git', 'rev-parse', 'HEAD^{tree}'], text=True).strip(),
-              'files': manifest,
-          }
-          (out / 'source-manifest.json').write_text(json.dumps(data, indent=2))
-      - uses: actions/upload-artifact@v4
-        with:
-          name: bounded-followup-source-${{ github.sha }}
-          path: ${{ runner.temp }}/bounded-followup
-          retention-days: 14
-          if-no-files-found: error
       - uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: 24.20.0
           cache: npm
       - run: npm ci
-      - name: Source ownership and bounded planner contracts
+      - name: Build required generated libraries and identify tools
         shell: bash
         run: |
           set -euo pipefail
-          npx vitest run test/dictionary-import-ownership.test.js test/term-bank-bounded-compressed-plan.test.js test/term-bank-source-followup.test.js 2>&1 | tee "$RUNNER_TEMP/bounded-followup/contracts.log"
+          mkdir -p "$RUNNER_TEMP/evidence"
+          node --version > "$RUNNER_TEMP/evidence/node.txt"
+          clang --version > "$RUNNER_TEMP/evidence/clang.txt"
+          git rev-parse HEAD > "$RUNNER_TEMP/evidence/commit.txt"
+          node dev/bin/build-libs.js > "$RUNNER_TEMP/evidence/build-libs.log" 2>&1
+      - name: Protocol, complete unit, options and strict type checks
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 -m unittest discover -s dev/perf/bounded-followup -v > "$RUNNER_TEMP/evidence/protocol.log" 2>&1
+          node node_modules/vitest/vitest.mjs run > "$RUNNER_TEMP/evidence/unit.log" 2>&1
+          npm run test:ts > "$RUNNER_TEMP/evidence/types.log" 2>&1
+          node node_modules/vitest/vitest.mjs run --config test/data/vitest.options.config.json > "$RUNNER_TEMP/evidence/options.log" 2>&1
+          node dev/bin/build.js --dryRun --all > "$RUNNER_TEMP/evidence/dry-build.log" 2>&1
       - name: Ensure tracked sources stayed unchanged
-        run: git diff --exit-code
+        run: test -z "$(git status --porcelain)"
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: bounded-followup-contracts-${{ github.sha }}
-          path: ${{ runner.temp }}/bounded-followup/*.log
+          path: ${{ runner.temp }}/evidence/
           retention-days: 14
-          if-no-files-found: warn
+          if-no-files-found: error
+
+  constrained:
+    needs: contracts
+    runs-on: ubuntu-slim
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        dictionary: [jmnedict, jmdict, jitendex]
+        trial: [1, 2]
+    env:
+      DICTIONARY: ${{ matrix.dictionary }}
+      TRIAL: ${{ matrix.trial }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.20.0
+          cache: npm
+      - run: npm ci
+      - name: Prepare actual Chromium and native compiler
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v clang >/dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y clang lld
+          fi
+          node node_modules/playwright/cli.js install --with-deps chromium
+      - name: Verify native policy and build the two committed source controls
+        shell: bash
+        run: |
+          set -euo pipefail
+          evidence="$RUNNER_TEMP/evidence"
+          arms="$RUNNER_TEMP/arms"
+          mkdir -p "$evidence" "$arms"
+          node dev/perf/bounded-followup/memory-preflight.js "$evidence/runtime-preflight.json"
+          git worktree add --detach "$arms/baseline" b8d68458cde8788b5d5301ceaf36beae7a1363f9
+          git worktree add --detach "$arms/candidate" ff9cbf2e848a86d6bbfd281179a6d753349e52f4
+          for arm in baseline candidate; do
+            ln -s "$GITHUB_WORKSPACE/node_modules" "$arms/$arm/node_modules"
+            (cd "$arms/$arm" && node dev/bin/build-libs.js && node dev/bin/build.js --target chrome-dev) > "$evidence/build-$arm.log" 2>&1
+          done
+          for file in term-bank-parser.wasm zstd.wasm zip.js z-worker.js; do
+            cmp "$arms/baseline/ext/lib/$file" "$arms/candidate/ext/lib/$file"
+          done
+          (cd "$arms/baseline" && node dev/perf/prepare-dictionaries.js) > "$evidence/fixtures.log" 2>&1
+          ln -s "$arms/baseline/builds/e2e-dictionary-cache" "$arms/candidate/builds/e2e-dictionary-cache"
+          clang --version > "$evidence/compiler.txt"
+          node --version > "$evidence/node.txt"
+          lscpu > "$evidence/cpu.txt"
+          free -b > "$evidence/memory.txt"
+          git diff b8d68458cde8788b5d5301ceaf36beae7a1363f9 ff9cbf2e848a86d6bbfd281179a6d753349e52f4 --binary > "$evidence/source.patch"
+          cp dev/perf/bounded-followup/paired.py "$evidence/paired.py"
+      - name: Six adjacent pairs, two same-binary pairs, excluded warmups, no retries
+        shell: bash
+        run: |
+          set -euo pipefail
+          extra=()
+          if [ "$TRIAL" = 2 ]; then extra+=(--reverse); fi
+          python3 dev/perf/bounded-followup/paired.py \
+            --baseline "$RUNNER_TEMP/arms/baseline" \
+            --candidate "$RUNNER_TEMP/arms/candidate" \
+            --dictionary "$DICTIONARY" --pairs 6 --policy low \
+            --output "$RUNNER_TEMP/evidence/paired" "${extra[@]}" \
+            | tee "$RUNNER_TEMP/evidence/driver.log"
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: bounded-followup-${{ matrix.dictionary }}-${{ matrix.trial }}-${{ github.sha }}
+          path: ${{ runner.temp }}/evidence/
+          retention-days: 14
+          if-no-files-found: error

--- a/.github/workflows/bounded-followup-verify.yml
+++ b/.github/workflows/bounded-followup-verify.yml
@@ -1,0 +1,75 @@
+name: Bounded import follow-up verification
+
+on:
+  push:
+    branches: [perf-import-bounded-followup-20260909]
+    paths:
+      - .github/workflows/bounded-followup-verify.yml
+      - ext/js/dictionary/term-bank-source-pipeline.js
+      - test/term-bank-source-followup.test.js
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bounded-followup-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  contracts:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Package identified tracked source for offline review
+        shell: python
+        run: |
+          import hashlib, json, os, pathlib, subprocess, tarfile
+          root = pathlib.Path.cwd()
+          out = pathlib.Path(os.environ['RUNNER_TEMP']) / 'bounded-followup'
+          out.mkdir()
+          paths = subprocess.check_output(['git', 'ls-files', '-z']).split(b'\0')
+          manifest = {}
+          excluded = {'.ttf', '.otf', '.woff', '.woff2', '.eot', '.ttc'}
+          with tarfile.open(out / 'source.tar.gz', 'w:gz') as archive:
+              for raw in paths:
+                  if not raw:
+                      continue
+                  path = pathlib.Path(os.fsdecode(raw))
+                  if path.is_file() and not path.is_symlink() and path.suffix.lower() not in excluded:
+                      manifest[str(path)] = hashlib.sha256(path.read_bytes()).hexdigest()
+                      archive.add(path, arcname=str(path), recursive=False)
+          data = {
+              'commit': subprocess.check_output(['git', 'rev-parse', 'HEAD'], text=True).strip(),
+              'tree': subprocess.check_output(['git', 'rev-parse', 'HEAD^{tree}'], text=True).strip(),
+              'files': manifest,
+          }
+          (out / 'source-manifest.json').write_text(json.dumps(data, indent=2))
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bounded-followup-source-${{ github.sha }}
+          path: ${{ runner.temp }}/bounded-followup
+          retention-days: 14
+          if-no-files-found: error
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+      - run: npm ci
+      - name: Source ownership and bounded planner contracts
+        shell: bash
+        run: |
+          set -euo pipefail
+          npx vitest run test/dictionary-import-ownership.test.js test/term-bank-bounded-compressed-plan.test.js test/term-bank-source-followup.test.js 2>&1 | tee "$RUNNER_TEMP/bounded-followup/contracts.log"
+      - name: Ensure tracked sources stayed unchanged
+        run: git diff --exit-code
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: bounded-followup-contracts-${{ github.sha }}
+          path: ${{ runner.temp }}/bounded-followup/*.log
+          retention-days: 14
+          if-no-files-found: warn

--- a/dev/perf/bounded-followup/memory-preflight.js
+++ b/dev/perf/bounded-followup/memory-preflight.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2026 Manabitan authors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+import {createServer} from 'node:http';
+import {writeFile} from 'node:fs/promises';
+import {chromium} from '@playwright/test';
+
+// Observe the browser's real memory classification. Never override navigator.
+const server = createServer((_request, response) => {
+    response.writeHead(200, {
+        'Content-Type': 'text/html',
+        'Cross-Origin-Opener-Policy': 'same-origin',
+        'Cross-Origin-Embedder-Policy': 'require-corp',
+    });
+    response.end('<!doctype html><title>Runtime policy check</title>');
+});
+await new Promise(/** @param {(value?: void) => void} resolve */ (resolve) => server.listen(0, '127.0.0.1', resolve));
+const address = server.address();
+if (address === null || typeof address === 'string') { throw new Error('Missing preflight server address'); }
+const browser = await chromium.launch({headless: true, args: ['--no-sandbox']});
+try {
+    const page = await browser.newPage();
+    await page.goto(`http://127.0.0.1:${address.port}`);
+    const observed = await page.evaluate(async () => {
+        const url = URL.createObjectURL(new Blob([
+            'postMessage({deviceMemory:navigator.deviceMemory,cores:navigator.hardwareConcurrency})',
+        ], {type: 'text/javascript'}));
+        const worker = new Worker(url);
+        try {
+            const data = await new Promise(/** @param {(value: {deviceMemory?: number, cores?: number}) => void} resolve */ (resolve, reject) => {
+                const timeout = setTimeout(() => reject(new Error('Policy worker did not respond')), 10000);
+                worker.onmessage = (event) => { clearTimeout(timeout); resolve(event.data); };
+                worker.onerror = () => { clearTimeout(timeout); reject(new Error('Policy worker failed')); };
+            });
+            return {pageMemory: Reflect.get(navigator, 'deviceMemory'), worker: data,
+                crossOriginIsolated, userAgent: navigator.userAgent};
+        } finally {
+            worker.terminate();
+            URL.revokeObjectURL(url);
+        }
+    });
+    const result = {...observed, browserVersion: browser.version()};
+    await writeFile(process.argv[2], JSON.stringify(result, null, 2));
+    if (![result.pageMemory, result.worker.deviceMemory].every((value) => typeof value === 'number' && value > 0 && value <= 4)) {
+        throw new Error('Real page and worker did not select low-memory policy');
+    }
+} finally {
+    await browser.close();
+    await new Promise(/** @param {(value?: void) => void} resolve */ (resolve) => server.close(() => resolve()));
+}

--- a/dev/perf/bounded-followup/paired.py
+++ b/dev/perf/bounded-followup/paired.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Read-only, fixed-count browser import A/B with interleaved same-binary controls.
+
+Uses each committed tree's existing schema-3 event-to-completion harness. This
+is not a native Reader benchmark. No retries, outlier deletion or optional
+stopping: an incomplete plan never receives a performance estimate.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+from pathlib import Path
+import platform
+import statistics
+import subprocess
+import sys
+import time
+
+COMMON = (
+    'package-lock.json', 'test/perf/dictionaries.lock.json',
+    'dev/perf/dictionary-fixtures.js', 'dev/perf/import-benchmark.js',
+    'dev/perf/benchmark-support.js', 'test/e2e/import-timing.js',
+    'test/chromium/extension-two-dictionary-import.e2e.js',
+    'ext/js/pages/settings/dictionary-import-controller.js',
+    'ext/lib/zstd.wasm', 'ext/lib/term-bank-parser.wasm',
+    'ext/lib/zip.js', 'ext/lib/z-worker.js',
+)
+PACKAGE = 'builds/manabitan-chrome-dev.zip'
+
+
+def digest(path: Path) -> str:
+    with path.open('rb') as stream:
+        return hashlib.file_digest(stream, 'sha256').hexdigest()
+
+
+def save(path: Path, value: object) -> None:
+    temporary = path.with_suffix(path.suffix + '.tmp')
+    temporary.write_text(json.dumps(value, indent=2, allow_nan=False) + '\n')
+    temporary.replace(path)
+
+
+def git(root: Path, *args: str) -> str:
+    return subprocess.check_output(['git', *args], cwd=root, text=True).strip()
+
+
+def schedule(pairs: int, reverse: bool = False) -> list[dict]:
+    if pairs < 4 or pairs % 2:
+        raise ValueError('Use an even pair count of at least four')
+    result = []
+    for kind, pair, arms in [('warmup', 0, ['baseline', 'candidate'])]:
+        for position, arm in enumerate(reversed(arms) if reverse else arms):
+            result.append(dict(kind=kind, pair=pair, position=position, arm=arm))
+    for pair in range(1, pairs + 1):
+        arms = ['baseline', 'candidate']
+        if bool(pair % 2 == 0) != reverse:
+            arms.reverse()
+        for position, arm in enumerate(arms):
+            result.append(dict(kind='ab', pair=pair, position=position, arm=arm))
+        # Two A/A pairs: different source builds, same binary within each pair.
+        if pair in (2, pairs - 1):
+            arm = 'baseline' if pair == 2 else 'candidate'
+            for position in range(2):
+                result.append(dict(kind='aa', pair=pair, position=position, arm=arm))
+    return result
+
+
+def validate(summary: dict, report: dict, dataset: str, fixture: dict,
+             policy: str, expected_source: dict) -> dict:
+    if (summary.get('schemaVersion') != 3 or
+            summary.get('authoritativeTiming') is not True or
+            summary.get('traceEnabled') is not False or
+            summary.get('dictionary') != dataset or summary.get('fixture') != fixture or
+            summary.get('importFlags') is not None or len(summary.get('runs', [])) != 1):
+        raise ValueError('Unexpected benchmark schema, fixture, flags or timing mode')
+    if (report.get('status') != 'success' or report.get('skippedVerification') is not False or
+            report.get('benchmark', {}).get('productionImportDefaults') is not True):
+        raise ValueError('Failed or weakened verification')
+    run = summary['runs'][0]
+    elapsed = run.get('totalImportMs')
+    if isinstance(elapsed, bool) or not isinstance(elapsed, (int, float)) or not math.isfinite(elapsed) or elapsed <= 0:
+        raise ValueError('Invalid event-to-completion elapsed time')
+    validation = run.get('validation', {})
+    if (validation.get('title') != fixture['expectedTitle'] or
+            validation.get('revision') != fixture['revision'] or
+            validation.get('termRows') != fixture['termRows'] or
+            validation.get('contentReadable') is not True or validation.get('probeCount', 0) < 12):
+        raise ValueError('Persisted dictionary verification mismatch')
+    source = summary.get('source', {})
+    if source.get('gitSha') != expected_source['commit'] or source.get('dirty') is not False:
+        raise ValueError('Tested source differs from committed clean tree')
+    if source.get('sha256', {}).get(PACKAGE) != expected_source['package_sha256']:
+        raise ValueError('Package changed during import')
+    phases = run.get('importDebug', {}).get('importerPhaseTimings', [])
+    batches = [p['details'] for p in phases if p.get('phase', '').startswith('term-file-fast-path:')]
+    if not batches or sum(p.get('rows', 0) for p in batches) != fixture['termRows']:
+        raise ValueError('Complete fast-path row accounting missing')
+    expected_budget = (64 if policy == 'low' else 192) * 1024 * 1024
+    if any(p.get('sourceBatchMaxBytes') != expected_budget for p in batches):
+        raise ValueError('Actual importer selected the wrong memory tier')
+    if sum(p.get('batchedFileCount', 0) for p in batches) != expected_source['bank_count']:
+        raise ValueError('Complete term-bank accounting mismatch')
+    # Keep overlapping worker/wall diagnostics as raw fields, never sum them
+    # into total CPU or subtract them from the authoritative import interval.
+    metrics = {}
+    for key in ('parserSourceTransferredBytes', 'parserSourceCompressedBytes',
+                'parserSourceUncompressedBytes', 'sourceArchiveReadMs',
+                'parserSourceInflateMs', 'parserResultCopyMs', 'parserOrderedSinkWaitMs'):
+        values = [p.get(key) for p in batches]
+        metrics[key] = sum(values) if all(isinstance(v, (int, float)) for v in values) else None
+    return dict(elapsed_ms=elapsed, worker_ms=run.get('workerImportMs'),
+                stages=run.get('step4Breakdown'), source_metrics=metrics,
+                batches=batches, validation=validation, browser=summary.get('browserVersion'))
+
+
+def effects(plan: list[dict], runs: list[dict]) -> dict:
+    if len(plan) != len(runs) or any(any(r.get(k) != p[k] for k in p) for p, r in zip(plan, runs)):
+        raise ValueError('Incomplete or reordered plan; do not estimate an effect')
+    pairs = sorted({r['pair'] for r in runs if r['kind'] == 'ab'})
+    paired, baseline, candidate = [], [], []
+    for pair in pairs:
+        by_arm = {r['arm']: r['elapsed_ms'] for r in runs if r['kind'] == 'ab' and r['pair'] == pair}
+        a, b = by_arm['baseline'], by_arm['candidate']
+        baseline.append(a)
+        candidate.append(b)
+        paired.append(100 * (b / a - 1))
+    aa = []
+    for pair in sorted({r['pair'] for r in runs if r['kind'] == 'aa'}):
+        rows = [r for r in runs if r['kind'] == 'aa' and r['pair'] == pair]
+        aa.append(dict(arm=rows[0]['arm'], first_ms=rows[0]['elapsed_ms'],
+                       second_ms=rows[1]['elapsed_ms'],
+                       change_percent=100 * (rows[1]['elapsed_ms'] / rows[0]['elapsed_ms'] - 1)))
+    return dict(paired_changes_percent=paired, median_paired_percent=statistics.median(paired),
+                baseline_median_ms=statistics.median(baseline), candidate_median_ms=statistics.median(candidate),
+                total_equal_work_percent=100 * (sum(candidate) / sum(baseline) - 1),
+                worst_pair_percent=max(paired), faster_pairs=sum(x < 0 for x in paired),
+                aa_controls=aa)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--baseline', type=Path, required=True)
+    parser.add_argument('--candidate', type=Path, required=True)
+    parser.add_argument('--dictionary', choices=['jmdict', 'jmnedict', 'jitendex'], required=True)
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--pairs', type=int, default=6)
+    parser.add_argument('--reverse', action='store_true')
+    parser.add_argument('--policy', choices=['low', 'high'], default='low')
+    args = parser.parse_args()
+    plan = schedule(args.pairs, args.reverse)
+    roots = dict(baseline=args.baseline.resolve(), candidate=args.candidate.resolve())
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=False)
+    fixture = json.loads((roots['baseline'] / 'test/perf/dictionaries.lock.json').read_text())['dictionaries'][args.dictionary]
+    import zipfile
+    source = {}
+    for arm, root in roots.items():
+        if git(root, 'status', '--porcelain'):
+            raise ValueError('Refusing a dirty source tree: ' + arm)
+        archive = root / 'builds/e2e-dictionary-cache' / fixture['cacheFile']
+        if digest(archive) != fixture['sha256'] or archive.stat().st_size != fixture['sizeBytes']:
+            raise ValueError('Fixture bytes differ: ' + arm)
+        with zipfile.ZipFile(archive) as bank_zip:
+            import re
+            bank_count = sum(bool(re.fullmatch(r'term_bank_\d+\.json', n)) for n in bank_zip.namelist())
+        source[arm] = dict(commit=git(root, 'rev-parse', 'HEAD'), tree=git(root, 'rev-parse', 'HEAD^{tree}'),
+                           package_sha256=digest(root / PACKAGE), bank_count=bank_count,
+                           common={p: digest(root / p) for p in COMMON},
+                           production={p: digest(root / p) for p in (
+                               'ext/js/dictionary/term-bank-source-pipeline.js',
+                               'ext/js/dictionary/dictionary-importer.js')})
+    if source['baseline']['common'] != source['candidate']['common']:
+        raise ValueError('Harness, fixture locks or native libraries differ')
+    result = dict(status='running', plan=plan, runs=[], source=source, fixture=fixture,
+                  policy=args.policy, platform=platform.platform(), driver_sha256=digest(Path(__file__)),
+                  started_at=time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime()),
+                  failure_policy='No retries; no estimates for incomplete plans')
+    save(output / 'plan.json', result)
+    try:
+        for index, item in enumerate(plan):
+            root = roots[item['arm']]
+            name = f"{index:02d}-{item['kind']}-{item['pair']:02d}-{item['arm']}-{item['position']}"
+            folder = output / name
+            command = ['node', 'dev/perf/import-benchmark.js', args.dictionary,
+                       '--runs', '1', '--no-build', '--output', str(folder)]
+            print('START', name, flush=True)
+            before = os.getloadavg() if hasattr(os, 'getloadavg') else None
+            with (output / (name + '.log')).open('w') as log:
+                subprocess.run(command, cwd=root, stdout=log, stderr=subprocess.STDOUT, check=True, timeout=150)
+            summary_path, report_path = folder / 'summary.json', folder / 'run-1.json'
+            summary, report = json.loads(summary_path.read_text()), json.loads(report_path.read_text())
+            measured = validate(summary, report, args.dictionary, fixture, args.policy, source[item['arm']])
+            result['runs'].append(dict(**item, **measured, summary=str(summary_path.relative_to(output)),
+                                      report_sha256=digest(report_path), summary_sha256=digest(summary_path),
+                                      load_before=before, command=command))
+            save(output / 'results.json', result)
+            print('DONE', name, measured['elapsed_ms'], flush=True)
+        for arm, root in roots.items():
+            if git(root, 'status', '--porcelain') or digest(root / PACKAGE) != source[arm]['package_sha256']:
+                raise ValueError('Source or package changed during verification')
+        result['effect'] = effects(plan, result['runs'])
+        result['status'] = 'complete'
+    except BaseException as error:
+        result['status'] = 'failed'
+        result['error'] = str(error)
+        raise
+    finally:
+        save(output / 'results.json', result)
+        print(result['status'], flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/dev/perf/bounded-followup/test_paired.py
+++ b/dev/perf/bounded-followup/test_paired.py
@@ -1,0 +1,107 @@
+"""Regression tests for complete-plan statistics; synthetic timings are not performance data."""
+import copy
+import math
+import unittest
+from paired import effects, schedule, validate, PACKAGE
+
+
+class ProtocolTests(unittest.TestCase):
+    def test_balanced_fixed_schedule_and_controls(self):
+        for reverse in (False, True):
+            plan = schedule(6, reverse)
+            self.assertEqual(len(plan), 18)
+            self.assertEqual(sum(p['kind'] == 'warmup' for p in plan), 2)
+            self.assertEqual(sum(p['kind'] == 'aa' for p in plan), 4)
+            for pair in range(1, 7):
+                group = [p for p in plan if p['kind'] == 'ab' and p['pair'] == pair]
+                self.assertEqual({p['arm'] for p in group}, {'baseline', 'candidate'})
+                if pair > 1:
+                    self.assertNotEqual(group[0]['arm'], previous)
+                previous = group[0]['arm']
+            for pair in (2, 5):
+                group = [p for p in plan if p['kind'] == 'aa' and p['pair'] == pair]
+                self.assertEqual(group[0]['arm'], group[1]['arm'])
+
+    def test_invalid_pair_counts(self):
+        for value in (-1, 0, 2, 3, 5):
+            with self.assertRaises(ValueError):
+                schedule(value)
+
+    def test_slow_observation_cannot_be_hidden_by_paired_median(self):
+        plan = schedule(4)
+        runs = [dict(p, elapsed_ms=100) for p in plan]
+        values = iter([90, 91, 92, 190])
+        for r in runs:
+            if r['kind'] == 'ab' and r['arm'] == 'candidate':
+                r['elapsed_ms'] = next(values)
+        result = effects(plan, runs)
+        self.assertLess(result['median_paired_percent'], 0)
+        self.assertGreater(result['total_equal_work_percent'], 0)
+        self.assertAlmostEqual(result['worst_pair_percent'], 90)
+        self.assertEqual(result['faster_pairs'], 3)
+
+    def test_incomplete_and_reordered_fail_closed(self):
+        plan = schedule(4)
+        runs = [dict(p, elapsed_ms=100) for p in plan]
+        with self.assertRaises(ValueError):
+            effects(plan, runs[:-1])
+        runs[2], runs[3] = runs[3], runs[2]
+        with self.assertRaises(ValueError):
+            effects(plan, runs)
+
+    def valid(self):
+        fixture = dict(expectedTitle='fixture', revision='v1', termRows=10)
+        source = dict(commit='abc', package_sha256='123', bank_count=4)
+        run = dict(totalImportMs=100, validation=dict(title='fixture', revision='v1', termRows=10,
+                   contentReadable=True, probeCount=12), importDebug=dict(importerPhaseTimings=[
+            dict(phase='term-file-fast-path:terms', details=dict(rows=10, batchedFileCount=4,
+                sourceBatchMaxBytes=64*1024*1024, parserSourceTransferredBytes=40))]))
+        summary = dict(schemaVersion=3, authoritativeTiming=True, traceEnabled=False,
+            dictionary='jmdict', fixture=fixture, importFlags=None, runs=[run],
+            source=dict(gitSha='abc', dirty=False, sha256={PACKAGE:'123'}))
+        report = dict(status='success', skippedVerification=False,
+                      benchmark=dict(productionImportDefaults=True))
+        return summary, report, fixture, source
+
+    def test_validation_and_missing_metrics(self):
+        summary, report, fixture, source = self.valid()
+        result = validate(summary, report, 'jmdict', fixture, 'low', source)
+        self.assertEqual(result['elapsed_ms'], 100)
+        self.assertIsNone(result['source_metrics']['parserSourceInflateMs'])
+
+    def test_invalid_timings(self):
+        for value in (0, -1, math.nan, math.inf, True, None):
+            summary, report, fixture, source = self.valid()
+            summary['runs'][0]['totalImportMs'] = value
+            with self.assertRaises(ValueError):
+                validate(summary, report, 'jmdict', fixture, 'low', source)
+
+    def test_protocol_mutations(self):
+        for field, value in [('schemaVersion', 2), ('traceEnabled', True),
+                ('authoritativeTiming', False), ('dictionary', 'other'), ('importFlags', {})]:
+            summary, report, fixture, source = self.valid()
+            summary[field] = value
+            with self.assertRaises(ValueError):
+                validate(summary, report, 'jmdict', fixture, 'low', source)
+        summary, report, fixture, source = self.valid()
+        for field, value in [('status', 'failure'), ('skippedVerification', True)]:
+            bad = copy.deepcopy(report)
+            bad[field] = value
+            with self.assertRaises(ValueError):
+                validate(summary, bad, 'jmdict', fixture, 'low', source)
+
+    def test_dirty_source_policy_and_incomplete_accounting(self):
+        for mutation in ('source', 'policy', 'rows', 'files', 'package'):
+            summary, report, fixture, source = self.valid()
+            details = summary['runs'][0]['importDebug']['importerPhaseTimings'][0]['details']
+            if mutation == 'source': summary['source']['dirty'] = True
+            if mutation == 'policy': details['sourceBatchMaxBytes'] *= 3
+            if mutation == 'rows': details['rows'] -= 1
+            if mutation == 'files': details['batchedFileCount'] -= 1
+            if mutation == 'package': summary['source']['sha256'][PACKAGE] = 'wrong'
+            with self.assertRaises(ValueError):
+                validate(summary, report, 'jmdict', fixture, 'low', source)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Scope

Follow-up to #24, stacked on its exact documentation head `ff9cbf2e848a86d6bbfd281179a6d753349e52f4`. No importer production source or release branch changes. This is executable verification code, not another competing compressed-import implementation or a new speed claim.

## Why

The bounded compressed path has promising JMdict/Jitendex results, but four pairs cannot resolve the local JMnedict slow run. A favorable median of paired ratios can coexist with more total time across equal work. The new protocol always reports both, plus worst pair and same-binary controls; incomplete plans receive no effect estimate.

## Added

- Read-only fixed six-pair A/B driver, alternating order and reversing initial order across two independent jobs.
- One excluded warmup pair plus two interleaved A/A pairs per dictionary/job (one control-build pair and one candidate-build pair); fresh browser profiles through the unchanged schema-3 file-input-change-to-post-UI-completion harness.
- Exact committed PR #23 versus PR #24 checkouts, fixed browser fixture hashes and package/harness/WASM identities, no source edits or patches during CI.
- Native browser page/worker memory-policy preflight without overriding navigator, plus actual importer memory-tier and complete source-bank/row accounting checks in every successful report.
- All raw reports and stage diagnostics retained. Overlapping phase timings are not presented as CPU or subtracted from whole-import timing. Persisted-content probes remain sampled, not exhaustive database equality.
- Eight locally passed Python protocol regression tests, including the favorable-median/adverse-total scenario, incomplete/reordered plans, dirty-source rejection, wrong memory tier and invalid timing.

The new full unit/options/strict-type/build checks and six constrained benchmark lanes are running from committed code. Results are not yet claimed. The first workspace attempt successfully exported identified source and passed the existing 20 bounded planner tests, but ownership test collection failed because the workflow omitted generated `ext/lib/zip.js`; this workflow now builds the libraries first. That setup error was not an importer regression.

## Separation from native Reader work

This public browser-extension repository's Actions jobs execute. The private ManabiDictionaries #12 retry, run `34307330593` attempt 3, still failed before runner assignment with empty steps and runner_id 0. Browser gains are not Reader-native or iPhone gains. Reader's vendor pin and all v3-hotfix branches remain untouched.

Keep #24, #23 and their #20 parent release gates separate. Do not merge based on incomplete benchmark lanes or discard the reported historical JMnedict +78.19% pair.