### PR TITLE
Optimize owned import-cache copies from unaligned shared WASM slabs (performance hold)

### DIFF
--- a/ext/js/core/copy-stable-byte-view.js
+++ b/ext/js/core/copy-stable-byte-view.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2023-2025  Yomitan Authors
+ * Copyright (C) 2016-2022  Yomichan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Copies a stable byte view into an exact-sized, private buffer. The caller
+ * must keep the source alive and unmodified until this synchronous call ends;
+ * this is not a snapshot protocol for concurrently modified shared memory.
+ *
+ * For large unaligned shared views, first copy an aligned tail, then move it
+ * inside the private destination and fill the short prefix. This avoids the
+ * slow unaligned shared-byte copy in affected engines without retaining
+ * padding, borrowing the source, or reading outside the requested view.
+ * @param {Uint8Array} source
+ * @returns {Uint8Array}
+ */
+export function copyStableByteView(source) {
+    const length = source.byteLength;
+    const prefix = (8 - (source.byteOffset & 7)) & 7;
+    if (
+        prefix === 0 || length < 1024 ||
+        typeof SharedArrayBuffer === 'undefined' || !(source.buffer instanceof SharedArrayBuffer)
+    ) {
+        // eslint-disable-next-line unicorn/prefer-spread -- TypedArray ownership and return type must be preserved.
+        return source.slice();
+    }
+    const owned = new Uint8Array(length);
+    owned.set(source.subarray(prefix));
+    owned.copyWithin(prefix, 0, length - prefix);
+    owned.set(source.subarray(0, prefix));
+    return owned;
+}

--- a/ext/js/dictionary/dictionary-database.js
+++ b/ext/js/dictionary/dictionary-database.js
@@ -21,6 +21,7 @@
 
 import {initWasm, Resvg} from '../../lib/resvg-wasm.js';
 import {createApiMap, invokeApiMapHandler} from '../core/api-map.js';
+import {copyStableByteView} from '../core/copy-stable-byte-view.js';
 import {isDevDiagnosticsBuild, reportDiagnostics, reportDiagnosticsLazy} from '../core/diagnostics-reporter.js';
 import {ExtensionError} from '../core/extension-error.js';
 import {parseJson} from '../core/json.js';
@@ -5730,7 +5731,7 @@ export class DictionaryDatabase {
             this._nextRecentTermContentSourceBatchId = 1;
         }
         const batchId = this._nextRecentTermContentSourceBatchId++;
-        const owned = spans.buffer.slice(minimumOffset, maximumEnd);
+        const owned = copyStableByteView(spans.buffer.subarray(minimumOffset, maximumEnd));
         this._recentTermContentSourceBatches.set(batchId, owned);
         this._recentTermContentSourceBatchBytes += owned.byteLength;
         for (let i = 0; i < staged.indexes.length; ++i) {

--- a/test/copy-stable-byte-view.test.js
+++ b/test/copy-stable-byte-view.test.js
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2026  Manabitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+import {afterEach, describe, expect, test, vi} from 'vitest';
+import {copyStableByteView} from '../ext/js/core/copy-stable-byte-view.js';
+
+/** @param {Uint8Array} bytes */
+function fillPattern(bytes) {
+    for (let i = 0; i < bytes.length; ++i) { bytes[i] = (i * 17 + Math.floor(i / 256)) & 255; }
+}
+
+afterEach(() => { vi.unstubAllGlobals(); });
+
+describe.each([false, true])('copyStableByteView shared=%s', (shared) => {
+    test.each(Array.from({length: 16}, (_, index) => index))('preserves exact bytes, ownership and allocation at offset %i', (offset) => {
+        const lengths = [...Array.from({length: 128}, (_, index) => index), 1023, 1024, 1025, 4095, 4096, 4097, 8191, 8192, 8193];
+        for (const length of lengths) {
+            const buffer = shared ? new SharedArrayBuffer(length + 64) : new ArrayBuffer(length + 64);
+            const all = new Uint8Array(buffer);
+            fillPattern(all);
+            // Both the view and selected subview have nonzero offsets. Sentinels
+            // before/after the selected bytes must never leak into the result.
+            const source = all.subarray(16, -16).subarray(offset, offset + length);
+            const expected = Uint8Array.from(source);
+            const copied = copyStableByteView(source);
+            expect(copied).toStrictEqual(expected);
+            expect(copied.buffer).toBeInstanceOf(ArrayBuffer);
+            expect(copied.byteOffset).toBe(0);
+            expect(copied.buffer.byteLength).toBe(length);
+            expect(copied.buffer).not.toBe(buffer);
+            expect(source).toStrictEqual(expected);
+            source.fill(0);
+            expect(copied).toStrictEqual(expected);
+            copied.fill(255);
+            expect(source.every((byte) => byte === 0)).toBe(true);
+        }
+    });
+});
+
+test('uses the unaligned shared path without source slice', () => {
+    const source = new Uint8Array(new SharedArrayBuffer(8200), 3, 8193);
+    fillPattern(source);
+    const expected = Uint8Array.from(source);
+    const slice = vi.spyOn(source, 'slice').mockImplementation(() => { throw new Error('unexpected byte slice'); });
+    expect(copyStableByteView(source)).toStrictEqual(expected);
+    expect(slice).not.toHaveBeenCalled();
+});
+
+test('retains ordinary and small/aligned shared slice paths', () => {
+    for (const source of [new Uint8Array(new ArrayBuffer(2050), 1, 2048), new Uint8Array(new SharedArrayBuffer(2056), 8, 2048), new Uint8Array(new SharedArrayBuffer(100), 1, 99)]) {
+        const slice = vi.spyOn(source, 'slice');
+        copyStableByteView(source);
+        expect(slice).toHaveBeenCalledOnce();
+    }
+});
+
+test('works when the SharedArrayBuffer constructor is unavailable', () => {
+    const source = new Uint8Array(new SharedArrayBuffer(2050), 1, 2048);
+    fillPattern(source);
+    const expected = Uint8Array.from(source);
+    vi.stubGlobal('SharedArrayBuffer', void 0);
+    expect(copyStableByteView(source)).toStrictEqual(expected);
+});
+
+test('owns shared WASM bytes across source reuse and memory growth', () => {
+    const memory = new WebAssembly.Memory({initial: 1, maximum: 2, shared: true});
+    for (let alignment = 0; alignment < 8; ++alignment) {
+        const source = new Uint8Array(memory.buffer, 1024 + alignment, 8197);
+        fillPattern(source);
+        const expected = Uint8Array.from(source);
+        const owned = copyStableByteView(source);
+        source.fill(0);
+        if (alignment === 0) { memory.grow(1); }
+        expect(owned).toStrictEqual(expected);
+        expect(owned.buffer.byteLength).toBe(source.byteLength);
+    }
+});
+
+test('keeps detached ordinary source failure semantics', () => {
+    const source = new Uint8Array(1024);
+    structuredClone(source.buffer, {transfer: [source.buffer]});
+    expect(() => copyStableByteView(source)).toThrow(TypeError);
+});

--- a/test/dictionary-database-content-dedup.test.js
+++ b/test/dictionary-database-content-dedup.test.js
@@ -222,6 +222,54 @@ function createArtifactOverlapHarness(sourceValues = [1, 2, 3], hash1 = 10, hash
 }
 
 describe('DictionaryDatabase term content dedup metadata cache', () => {
+    test('owns large unaligned shared source spans without retaining source padding', async () => {
+        const database = new DictionaryDatabase();
+        const backing = new SharedArrayBuffer(8300);
+        const source = new Uint8Array(backing, 9, 8250);
+        for (let i = 0; i < source.length; ++i) { source[i] = (i * 31) & 255; }
+        const expected = source.slice(4, 8201);
+        const {meta, staged} = publishSlabMeta(database, source, 4, expected.length, 10, 20);
+        const findRecent = Reflect.get(database, '_findRecentTermContentSource').bind(database);
+        const cached = findRecent(meta);
+        if (typeof cached === 'undefined') { throw new Error('Expected an owned recent source'); }
+        expect(cached.offset).toBe(0);
+        expect(cached.buffer.buffer).toBeInstanceOf(ArrayBuffer);
+        expect(cached.buffer.buffer.byteLength).toBe(expected.length);
+        expect(Reflect.get(database, '_recentTermContentSourceBatchBytes')).toBe(expected.length);
+        source.fill(0);
+        const readStorage = vi.fn(async () => { throw new Error('recent source should stay readable'); });
+        Reflect.set(database, '_readTermEntryContentBytesDetailedBatch', readStorage);
+        const findBatch = Reflect.get(database, '_findMatchingPersistedTermEntryContentMetaBatch').bind(database);
+        const [result] = await findBatch([{hash1: 10, hash2: 20, contentBytes: expected, primary: meta}]);
+        expect(result).toMatchObject({existingMeta: meta, recentSourceHit: true});
+        expect(readStorage).not.toHaveBeenCalled();
+        Reflect.get(database, '_rollbackStagedArtifactTermContentMetadata').call(database, staged);
+        expect(findRecent(meta)).toBeUndefined();
+        expect(Reflect.get(database, '_recentTermContentSourceBatchBytes')).toBe(0);
+    });
+
+    test('keeps an exact-budget unaligned shared batch and evicts it for the next batch', () => {
+        const database = new DictionaryDatabase();
+        const limit = 48 * 1024 * 1024;
+        const source = new Uint8Array(new SharedArrayBuffer(limit + 1), 1, limit);
+        source[0] = 42;
+        source[limit - 1] = 99;
+        const first = publishSlabMeta(database, source, 0, limit, 10, 20);
+        const findRecent = Reflect.get(database, '_findRecentTermContentSource').bind(database);
+        const cached = findRecent(first.meta);
+        if (typeof cached === 'undefined') { throw new Error('Expected an exact-budget recent source'); }
+        expect(cached.buffer.byteLength).toBe(limit);
+        expect(cached.buffer.buffer.byteLength).toBe(limit);
+        expect(cached.buffer[0]).toBe(42);
+        expect(cached.buffer[limit - 1]).toBe(99);
+        expect(Reflect.get(database, '_recentTermContentSourceBatchBytes')).toBe(limit);
+        const second = publishSlabMeta(database, source, 8, 1025, 30, 40);
+        expect(findRecent(first.meta)).toBeUndefined();
+        expect(findRecent(second.meta)).toBeDefined();
+        expect(Reflect.get(database, '_recentTermContentSourceBatchBytes')).toBe(1025);
+        expect(Reflect.get(database, '_recentTermContentSourceBatches').size).toBe(1);
+    });
+
     test('owns recent published source bytes across borrowed slab reuse', async () => {
         const database = new DictionaryDatabase();
         const source = new Uint8Array([90, 1, 2, 3, 4, 91]);


### PR DESCRIPTION
## Decision: keep draft; do not merge on current performance evidence

The source is correctness-validated, but cheaper copying did **not** reliably improve whole imports. This PR preserves the isolated implementation and negative results for review; it is not a regression-free speedup claim. #29 is a separate candidate based directly on #24, not on this change.

Tested source commit: `808f7864c68180543048074eff81413e31195b43`.
Exact full source/test tree: `de590b82fe22487b4f95f90bb8ea4195b1f390ab`.
Baseline: #24 head `ff9cbf2e848a86d6bbfd281179a6d753349e52f4` (tree `dc3098b9acc761caf193952537d568652196dc76`), not release main or upstream Yomitan.

## Implementation

A separate trace identified `_cacheRecentPublishedTermContentSources` as an application-side hotspot. For a stable, large, unaligned SharedArrayBuffer view, copy an aligned tail into a private destination, shift those private bytes into their final position, then fill the short prefix. The allocation is **exactly the requested byte length**, not a padded buffer. Ordinary, small and aligned views retain the existing slice path.

The synchronous ownership fence is unchanged: cached bytes are copied before the parser's borrowed slab can be released or reused. This is not an atomic snapshot protocol for concurrently modified shared memory. No bytes outside the selected view are read.

The **48 MiB cache budget, accounting, eviction, deduplication and integrity verification remain unchanged**. No worker, compression-level, persistent-format, ZIP or parser changes. This differs from the earlier rejected slice-to-constructor experiment and cache-tail policy change. It adds a private memory move; it does not claim to eliminate all copying.

## Whole-import results

Six fixed adjacent AB/BA pairs per completed dictionary/runtime cohort, fresh profiles, pinned dictionaries, separately excluded warmup pair and same-binary A/A pair. Timing is the unchanged browser file-input change through import UI completion. No retries, tracing, outlier removal, pooling of runners, or import-policy overrides.

Positive values below mean less elapsed time; negative means slower. Equal-work reduction compares the total of all six baseline imports with all six candidate imports.

| Runtime | Dictionary | Paired median reduction | Equal-work reduction |
| --- | --- | ---: | ---: |
| Local native 4 GiB | JMnedict | -0.99% | -1.99% |
| Local native 4 GiB | JMdict | +4.38% | +4.90% |
| Local native 4 GiB | Jitendex | -1.63% | -0.97% |
| Independent native 16 GiB | JMnedict | -0.54% | -1.37% |
| Independent native 16 GiB | JMdict | -1.18% | **-7.15%** |
| Independent native 16 GiB | Jitendex | +0.64% | +0.71% |
| Independent native 4 GiB | JMnedict | +10.20% | +11.98% |

The independent constrained JMnedict cohort still contains a candidate **34.09% slower** than its paired baseline, and its same-binary control swung substantially (7414.2 to 6242.7 ms). That favorable median does not establish general non-regression. The constrained runner exposed one hardware thread; it is not interchangeable with the local four-core-quota runtime.

Independent constrained JMdict and Jitendex jobs reached the runner time limit after 7 and 6 successful observations respectively. Their partial data are retained with **no performance estimate**. The overall performance workflow is not green.

Every completed measured import in the full cohorts passed exact dictionary metadata and row-count checks, identical source-bank/deduplication accounting, and 12 persisted-content readability probes. The probes are sampled, not an exhaustive database-equivalence proof.

## Correctness and CI

Local and independent GitHub validation of the exact complete source/test tree:

- **5,517 unit tests passed**, 46 existing skips; **39 new tests**.
- **25 options tests passed**; all four strict TypeScript projects passed.
- All-target dry builds and focused new-file ESLint passed.
- Package payload comparison differs only in the two intended JavaScript files; generated WASM and dependency libraries are unchanged.
- Tests cover byte offsets and boundaries, exact allocation, non-aliasing, source reuse, unavailable SharedArrayBuffer, shared WASM growth, detached ordinary sources, cache hits after source mutation, rollback, exact 48 MiB retention and eviction. Existing collision checks remain intact.

Independent source validation: https://github.com/ManabiIO/manabitan/actions/runs/34330765775 (artifact `owned-copy-source-verification`).
Performance and separate strict Chromium validation: https://github.com/ManabiIO/manabitan/actions/runs/34331609561. Strict integration passed **82 phases**, with OPFS-sahpool verified and no skipped verification.
Normal PR CI https://github.com/ManabiIO/manabitan/actions/runs/34331443760 passed full Chromium and Firefox integration. Its overall matrix failed Markdown formatting in two files unchanged by this PR (`dev/perf/bounded-import-followup-20260909.md` and `dev/perf/composite-state-review.md`), cancelling other checks. This is not a claim that normal CI is fully green.

Local source commits are offline reconstruction aliases; Git tree identity, not their commit IDs, establishes correspondence to the remote source. Independent validation tested the remote source tree directly. Transport patches and temporary verification workflows are excluded from this branch.

No earlier PR or release branch has been merged, rewritten or retargeted. #24's own rollout gates remain separate.