### PR TITLE
[Rejected / retained evidence] Old-stack i64 inflater experiment

### DIFF
--- a/.github/workflows/bounded-inflate64.yml
+++ b/.github/workflows/bounded-inflate64.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - .github/workflows/bounded-inflate64.yml
       - dev/perf/bounded-followup/**
+      - test/native/wasm-inflate-oracle.js
       - test/term-bank-inflate-matches.test.js
       - ext/js/dictionary/wasm/**
   workflow_dispatch:
@@ -63,7 +64,7 @@ jobs:
           python3 dev/perf/bounded-followup/prepare-inflate-banks.py --source . --output "$RUNNER_TEMP/banks"
           cp "$RUNNER_TEMP/control/ext/lib/term-bank-parser.wasm" "$evidence/baseline.wasm"
           cp ext/lib/term-bank-parser.wasm "$evidence/candidate.wasm"
-          node dev/perf/bounded-followup/wasm-inflate-oracle.mjs \
+          node test/native/wasm-inflate-oracle.js \
             "$evidence/baseline.wasm" "$evidence/candidate.wasm" "$evidence/decoder.json" "$RUNNER_TEMP/banks/manifest.json" \
             > "$evidence/decoder.log" 2>&1
           test -z "$(git status --porcelain)"

--- a/.github/workflows/bounded-inflate64.yml
+++ b/.github/workflows/bounded-inflate64.yml
@@ -1,0 +1,151 @@
+name: Bounded inflater i64 verification
+on:
+  push:
+    branches: [perf-bounded-inflate64-20260909]
+    paths:
+      - .github/workflows/bounded-inflate64.yml
+      - dev/perf/bounded-followup/**
+      - test/term-bank-inflate-matches.test.js
+      - ext/js/dictionary/wasm/**
+  workflow_dispatch:
+permissions:
+  contents: read
+concurrency:
+  group: bounded-inflate64-${{ github.ref }}
+  cancel-in-progress: false
+env:
+  PYTHONDONTWRITEBYTECODE: '1'
+jobs:
+  verify:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.20.0
+          cache: npm
+      - run: npm ci
+      - name: Build committed source and run unit, types and sanitizer contracts
+        shell: bash
+        run: |
+          set -euo pipefail
+          evidence="$RUNNER_TEMP/evidence"
+          mkdir -p "$evidence"
+          git rev-parse HEAD > "$evidence/commit.txt"
+          clang --version > "$evidence/compiler.txt"
+          node --version > "$evidence/node.txt"
+          node dev/bin/build-libs.js > "$evidence/build.log" 2>&1
+          python3 -m unittest discover -s dev/perf/bounded-followup -v > "$evidence/protocol.log" 2>&1
+          node node_modules/vitest/vitest.mjs run > "$evidence/unit.log" 2>&1
+          npm run test:ts > "$evidence/types.log" 2>&1
+          node node_modules/vitest/vitest.mjs run --config test/data/vitest.options.config.json > "$evidence/options.log" 2>&1
+          node dev/bin/build.js --dryRun --all > "$evidence/dry-build.log" 2>&1
+          for bits in 32 64; do
+            clang -std=c11 -D_GNU_SOURCE -O1 -g -DTEST_BITS="$bits" \
+              -fsanitize=address,undefined -fno-omit-frame-pointer \
+              -Iext/js/dictionary/wasm/vendor/miniz \
+              dev/perf/bounded-followup/inflate-buffer-contract.c -lz -o "$evidence/core-$bits"
+            ASAN_OPTIONS=detect_leaks=1:halt_on_error=1 UBSAN_OPTIONS=halt_on_error=1 \
+              "$evidence/core-$bits" > "$evidence/core-$bits.log" 2>&1
+          done
+      - name: Full fixed-bank decoder oracles and component comparisons
+        shell: bash
+        run: |
+          set -euo pipefail
+          evidence="$RUNNER_TEMP/evidence"
+          git worktree add --detach "$RUNNER_TEMP/control" ff9cbf2e848a86d6bbfd281179a6d753349e52f4
+          (cd "$RUNNER_TEMP/control" && npm ci && node dev/bin/build-libs.js) > "$evidence/control-build.log" 2>&1
+          node dev/perf/prepare-dictionaries.js > "$evidence/fixtures.log" 2>&1
+          python3 dev/perf/bounded-followup/prepare-inflate-banks.py --source . --output "$RUNNER_TEMP/banks"
+          cp "$RUNNER_TEMP/control/ext/lib/term-bank-parser.wasm" "$evidence/baseline.wasm"
+          cp ext/lib/term-bank-parser.wasm "$evidence/candidate.wasm"
+          node dev/perf/bounded-followup/wasm-inflate-oracle.mjs \
+            "$evidence/baseline.wasm" "$evidence/candidate.wasm" "$evidence/decoder.json" "$RUNNER_TEMP/banks/manifest.json" \
+            > "$evidence/decoder.log" 2>&1
+          test -z "$(git status --porcelain)"
+          test -z "$(git -C "$RUNNER_TEMP/control" status --porcelain)"
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: inflate64-correctness-${{ github.sha }}
+          path: ${{ runner.temp }}/evidence/
+          retention-days: 14
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v4
+        with:
+          name: inflate64-fixed-banks-${{ github.sha }}
+          path: ${{ runner.temp }}/banks/
+          compression-level: 0
+          retention-days: 14
+          if-no-files-found: error
+  constrained:
+    needs: verify
+    runs-on: ubuntu-slim
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        dictionary: [jmnedict, jmdict, jitendex]
+        trial: [1, 2]
+    env:
+      DICTIONARY: ${{ matrix.dictionary }}
+      TRIAL: ${{ matrix.trial }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.20.0
+          cache: npm
+      - run: npm ci
+      - name: Prepare actual browser and compiler
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! command -v clang >/dev/null; then
+            sudo apt-get update
+            sudo apt-get install -y clang lld
+          fi
+          node node_modules/playwright/cli.js install --with-deps chromium
+      - name: Build exact product controls and observe real memory policy
+        shell: bash
+        run: |
+          set -euo pipefail
+          evidence="$RUNNER_TEMP/evidence"
+          arms="$RUNNER_TEMP/arms"
+          mkdir -p "$evidence" "$arms"
+          node dev/perf/bounded-followup/memory-preflight.js "$evidence/preflight.json"
+          git worktree add --detach "$arms/baseline" ff9cbf2e848a86d6bbfd281179a6d753349e52f4
+          git worktree add --detach "$arms/candidate" dc226aaf88a0f8d2d4b2bcc37778352be0104622
+          for arm in baseline candidate; do
+            (cd "$arms/$arm" && npm ci && node dev/bin/build-libs.js && node dev/bin/build.js --target chrome-dev) > "$evidence/build-$arm.log" 2>&1
+          done
+          (cd "$arms/baseline" && node dev/perf/prepare-dictionaries.js) > "$evidence/fixtures.log" 2>&1
+          ln -s "$arms/baseline/builds/e2e-dictionary-cache" "$arms/candidate/builds/e2e-dictionary-cache"
+          clang --version > "$evidence/compiler.txt"
+          lscpu > "$evidence/cpu.txt"
+          free -b > "$evidence/memory.txt"
+          git diff ff9cbf2e848a86d6bbfd281179a6d753349e52f4 dc226aaf88a0f8d2d4b2bcc37778352be0104622 -- ext > "$evidence/production.patch"
+      - name: Six fixed A-B pairs, same-binary controls and warmups
+        shell: bash
+        run: |
+          set -euo pipefail
+          extra=()
+          if [ "$TRIAL" = 2 ]; then extra+=(--reverse); fi
+          python3 dev/perf/bounded-followup/inflate64.py \
+            --baseline "$RUNNER_TEMP/arms/baseline" --candidate "$RUNNER_TEMP/arms/candidate" \
+            --dictionary "$DICTIONARY" --pairs 6 --output "$RUNNER_TEMP/evidence/paired" "${extra[@]}" \
+            2>&1 | tee "$RUNNER_TEMP/evidence/driver.log"
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: inflate64-${{ matrix.dictionary }}-${{ matrix.trial }}-${{ github.sha }}
+          path: ${{ runner.temp }}/evidence/
+          retention-days: 14
+          if-no-files-found: error

--- a/.github/workflows/inflate64-tooling-checks.yml
+++ b/.github/workflows/inflate64-tooling-checks.yml
@@ -1,0 +1,39 @@
+name: Inflater verification tooling checks
+on:
+  push:
+    branches: [perf-bounded-inflate64-20260909]
+    paths:
+      - .github/workflows/inflate64-tooling-checks.yml
+      - dev/perf/bounded-followup/wasm-inflate-oracle.*
+      - test/term-bank-inflate-matches.test.js
+      - dev/jsconfig.json
+  workflow_dispatch:
+permissions:
+  contents: read
+jobs:
+  lint:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24.20.0
+          cache: npm
+      - run: npm ci
+      - run: node dev/bin/build-libs.js
+      - name: Check only introduced JavaScript verification code
+        shell: bash
+        run: |
+          set -euo pipefail
+          npx eslint dev/perf/bounded-followup/wasm-inflate-oracle.* test/term-bank-inflate-matches.test.js \
+            > "$RUNNER_TEMP/inflater-tooling-lint.log" 2>&1
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: inflater-tooling-lint-${{ github.sha }}
+          path: ${{ runner.temp }}/inflater-tooling-lint.log
+          retention-days: 14
+          if-no-files-found: warn

--- a/.github/workflows/inflate64-tooling-checks.yml
+++ b/.github/workflows/inflate64-tooling-checks.yml
@@ -4,9 +4,8 @@ on:
     branches: [perf-bounded-inflate64-20260909]
     paths:
       - .github/workflows/inflate64-tooling-checks.yml
-      - dev/perf/bounded-followup/wasm-inflate-oracle.*
+      - test/native/wasm-inflate-oracle.js
       - test/term-bank-inflate-matches.test.js
-      - dev/jsconfig.json
   workflow_dispatch:
 permissions:
   contents: read
@@ -24,16 +23,21 @@ jobs:
           cache: npm
       - run: npm ci
       - run: node dev/bin/build-libs.js
-      - name: Check only introduced JavaScript verification code
+      - name: Check introduced verification code with existing test rules
         shell: bash
         run: |
           set -euo pipefail
-          npx eslint dev/perf/bounded-followup/wasm-inflate-oracle.* test/term-bank-inflate-matches.test.js \
+          npx eslint test/native/wasm-inflate-oracle.js test/term-bank-inflate-matches.test.js \
             > "$RUNNER_TEMP/inflater-tooling-lint.log" 2>&1
+          npm run test:ts:test > "$RUNNER_TEMP/inflater-tooling-types.log" 2>&1
+          node test/native/wasm-inflate-oracle.js ext/lib/term-bank-parser.wasm ext/lib/term-bank-parser.wasm "$RUNNER_TEMP/oracle-self-control.json" \
+            > "$RUNNER_TEMP/inflater-tooling-oracle.log" 2>&1
       - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: inflater-tooling-lint-${{ github.sha }}
-          path: ${{ runner.temp }}/inflater-tooling-lint.log
+          path: |
+            ${{ runner.temp }}/inflater-tooling-*.log
+            ${{ runner.temp }}/oracle-self-control.json
           retention-days: 14
           if-no-files-found: warn

--- a/dev/perf/bounded-followup/inflate-buffer-contract.c
+++ b/dev/perf/bounded-followup/inflate-buffer-contract.c
@@ -1,0 +1,119 @@
+/* SPDX-License-Identifier: GPL-3.0-or-later
+ * Production miniz core, with a test-selected bit-buffer type. No source edits.
+ * zlib creates the independent compressed inputs. mmap guards bounded reads.
+ */
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#include <zlib.h>
+
+#define MINIZ_NO_MALLOC
+#define MINIZ_NO_STDIO
+#define MINIZ_NO_TIME
+#define MINIZ_NO_ARCHIVE_APIS
+#define MINIZ_NO_DEFLATE_APIS
+#define MINIZ_NO_ZLIB_APIS
+#define MINIZ_NO_ZLIB_COMPATIBLE_NAMES
+#ifndef TEST_BITS
+#define TEST_BITS 64
+#endif
+/* Fix the type before the platform heuristic is loaded by miniz.h. */
+#define MINIZ_HAS_64BIT_REGISTERS (TEST_BITS == 64)
+#include "miniz_tinfl.h"
+#undef MINIZ_HAS_64BIT_REGISTERS
+#include "miniz_tinfl.c"
+_Static_assert(TINFL_BITBUF_SIZE == TEST_BITS, "test did not select the requested bit buffer");
+
+static void require(int ok, const char *why) {
+    if (!ok) { fprintf(stderr, "FAIL: %s\n", why); exit(1); }
+}
+static unsigned cases = 0;
+static void check(const unsigned char *input, size_t compressed_size,
+                  const unsigned char *raw, size_t raw_size, size_t in_chunk, size_t out_chunk) {
+    unsigned char *output = malloc(raw_size + 32);
+    require(output != NULL, "allocation");
+    memset(output, 0xa5, raw_size + 32);
+    tinfl_decompressor decoder;
+    tinfl_init(&decoder);
+    size_t in_pos = 0, out_pos = 0, iteration = 0;
+    tinfl_status status;
+    do {
+        size_t in_size = compressed_size - in_pos;
+        if (in_size > in_chunk) in_size = in_chunk;
+        size_t out_size = raw_size - out_pos;
+        if (out_size > out_chunk) out_size = out_chunk;
+        unsigned flags = TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF;
+        if (in_pos + in_size < compressed_size) flags |= TINFL_FLAG_HAS_MORE_INPUT;
+        status = tinfl_decompress(&decoder, input + in_pos, &in_size,
+                                 output + 16, output + 16 + out_pos, &out_size, flags);
+        in_pos += in_size; out_pos += out_size;
+        require(++iteration <= raw_size + compressed_size + 100, "progress");
+    } while (status > TINFL_STATUS_DONE);
+    require(status == TINFL_STATUS_DONE && out_pos == raw_size && in_pos == compressed_size, "decode completion");
+    require(memcmp(output + 16, raw, raw_size) == 0, "independent bytes");
+    for (size_t i = 0; i < 16; ++i) {
+        require(output[i] == 0xa5 && output[16 + raw_size + i] == 0xa5, "output guard");
+    }
+    free(output); ++cases;
+}
+int main(void) {
+    const int levels[] = {0, 1, 6, 9};
+    const size_t lengths[] = {0, 1, 2, 7, 8, 9, 31, 32, 63, 64, 257, 258, 1024, 32767, 32768, 32769, 65536};
+    const size_t page = (size_t)sysconf(_SC_PAGESIZE);
+    require(page > 0, "page size");
+    for (size_t l = 0; l < sizeof(levels) / sizeof(levels[0]); ++l) {
+        for (size_t n = 0; n < sizeof(lengths) / sizeof(lengths[0]); ++n) {
+            for (unsigned mode = 0; mode < 4; ++mode) {
+                size_t size = lengths[n];
+                unsigned char *raw = malloc(size + 1);
+                uLong bound = compressBound(size) + 64;
+                unsigned char *compressed = malloc(bound);
+                require(raw != NULL && compressed != NULL, "fixture allocation");
+                uint32_t random = 0x91e10da5u;
+                for (size_t i = 0; i < size; ++i) {
+                    random ^= random << 13; random ^= random >> 17; random ^= random << 5;
+                    raw[i] = mode == 0 ? 'a' : mode == 1 ? (unsigned char)(i % 251) :
+                             mode == 2 ? (unsigned char)((i / 259) % 17) : (unsigned char)random;
+                }
+                z_stream encoder = {0};
+                require(deflateInit2(&encoder, levels[l], Z_DEFLATED, -15, 8, Z_DEFAULT_STRATEGY) == Z_OK, "zlib init");
+                encoder.next_in = raw; encoder.avail_in = (uInt)size;
+                encoder.next_out = compressed; encoder.avail_out = (uInt)bound;
+                require(deflate(&encoder, Z_FINISH) == Z_STREAM_END, "zlib encode");
+                size_t compressed_size = encoder.total_out;
+                deflateEnd(&encoder);
+                size_t pages = (compressed_size + page - 1) / page;
+                unsigned char *mapping = mmap(NULL, (pages + 1) * page, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+                require(mapping != MAP_FAILED, "mmap");
+                require(mprotect(mapping + pages * page, page, PROT_NONE) == 0, "guard page");
+                unsigned char *guarded_input = mapping + pages * page - compressed_size;
+                memcpy(guarded_input, compressed, compressed_size);
+                check(guarded_input, compressed_size, raw, size, compressed_size, size + 1);
+                check(guarded_input, compressed_size, raw, size, 7, 257);
+                check(guarded_input, compressed_size, raw, size, 31, 4096);
+                /* Every truncated suffix ends immediately at the unreadable page. */
+                for (size_t cut = 1; cut <= 16 && cut <= compressed_size; ++cut) {
+                    size_t truncated = compressed_size - cut;
+                    unsigned char *tail = mapping + pages * page - truncated;
+                    memmove(tail, compressed, truncated);
+                    unsigned char *output = malloc(size + 32);
+                    require(output != NULL, "truncated output");
+                    memset(output, 0xa5, size + 32);
+                    tinfl_decompressor decoder; tinfl_init(&decoder);
+                    size_t in_size = truncated, out_size = size;
+                    tinfl_status status = tinfl_decompress(&decoder, tail, &in_size, output + 16, output + 16, &out_size, TINFL_FLAG_USING_NON_WRAPPING_OUTPUT_BUF);
+                    require(status != TINFL_STATUS_DONE, "truncated stream unexpectedly complete");
+                    for (size_t i = 0; i < 16; ++i) require(output[i] == 0xa5 && output[16 + size + i] == 0xa5, "truncated guard");
+                    free(output); ++cases;
+                }
+                munmap(mapping, (pages + 1) * page);
+                free(compressed); free(raw);
+            }
+        }
+    }
+    printf("PASS: %u exact-byte, streaming and guard-page cases; bit buffer %u\n", cases, TINFL_BITBUF_SIZE);
+    return 0;
+}

--- a/dev/perf/bounded-followup/inflate64.py
+++ b/dev/perf/bounded-followup/inflate64.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Fixed, read-only #24 vs isolated i64 inflater comparison. No retries."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import platform
+import re
+import subprocess
+import time
+import zipfile
+
+from paired import COMMON, PACKAGE, digest, effects, git, save, schedule, validate
+
+HEADER = 'ext/js/dictionary/wasm/vendor/miniz/miniz.h'
+WASM = 'ext/lib/term-bank-parser.wasm'
+HEADER_BLOBS = {'baseline': '6b71bda7605c11f0cb6da7f150d7d0fce6a5a6d2',
+                'candidate': '22d72694d7361cc2642e845a7136eb38e6afeb63'}
+BASE = 'ff9cbf2e848a86d6bbfd281179a6d753349e52f4'
+CANDIDATE = 'dc226aaf88a0f8d2d4b2bcc37778352be0104622'
+
+
+def check_common(source: dict) -> None:
+    """Retain every identity; permit ONLY the intentionally different WASM."""
+    a, b = (source[arm]['common'] for arm in ('baseline', 'candidate'))
+    if set(a) != set(COMMON) or set(b) != set(COMMON):
+        raise ValueError('Missing common build identity')
+    changed = {p for p in COMMON if a[p] != b[p]}
+    if changed != {WASM}:
+        raise ValueError(f'Unexpected common build differences: {sorted(changed)}')
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--baseline', type=Path, required=True)
+    parser.add_argument('--candidate', type=Path, required=True)
+    parser.add_argument('--output', type=Path, required=True)
+    parser.add_argument('--dictionary', choices=['jmdict', 'jmnedict', 'jitendex'], required=True)
+    parser.add_argument('--pairs', type=int, default=6)
+    parser.add_argument('--reverse', action='store_true')
+    args = parser.parse_args()
+    roots = {'baseline': args.baseline.resolve(), 'candidate': args.candidate.resolve()}
+    output = args.output.resolve()
+    output.mkdir(parents=True, exist_ok=False)
+    plan = schedule(args.pairs, args.reverse)
+    result = dict(status='preflight', plan=plan, runs=[], source={},
+                  driver_sha256=digest(Path(__file__)), helper_sha256=digest(Path(__file__).with_name('paired.py')),
+                  platform=platform.platform(), started_at=time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime()),
+                  comparison='isolated-i64-bitbuffer', failure_policy='No retries; incomplete plans have no effect estimate')
+    save(output / 'plan.json', result)
+    try:
+        expected_refs = dict(baseline=BASE, candidate=CANDIDATE)
+        source = result['source']
+        fixture = json.loads((roots['baseline'] / 'test/perf/dictionaries.lock.json').read_text())['dictionaries'][args.dictionary]
+        result['fixture'] = fixture
+        for arm, root in roots.items():
+            if git(root, 'rev-parse', 'HEAD') != expected_refs[arm] or git(root, 'status', '--porcelain'):
+                raise ValueError(f'{arm}: not the pinned clean checkout')
+            if git(root, 'hash-object', HEADER) != HEADER_BLOBS[arm]:
+                raise ValueError(f'{arm}: wrong inflater header')
+            archive = root / 'builds/e2e-dictionary-cache' / fixture['cacheFile']
+            if archive.stat().st_size != fixture['sizeBytes'] or digest(archive) != fixture['sha256']:
+                raise ValueError(f'{arm}: fixture mismatch')
+            with zipfile.ZipFile(archive) as z:
+                bank_count = sum(bool(re.fullmatch(r'term_bank_\d+\.json', n)) for n in z.namelist())
+            source[arm] = dict(commit=git(root, 'rev-parse', 'HEAD'), tree=git(root, 'rev-parse', 'HEAD^{tree}'),
+                               package_sha256=digest(root / PACKAGE), bank_count=bank_count,
+                               common={p: digest(root / p) for p in COMMON},
+                               header_sha256=digest(root / HEADER))
+        # Test tools/docs may differ; the actual shipped source has one change.
+        changed = git(roots['candidate'], 'diff', '--name-only', BASE, CANDIDATE, '--', 'ext').splitlines()
+        if changed != [HEADER]:
+            raise ValueError(f'Unexpected production changes: {changed}')
+        check_common(source)
+        result['status'] = 'running'
+        save(output / 'plan.json', result)
+        for index, item in enumerate(plan):
+            root = roots[item['arm']]
+            name = f"{index:02d}-{item['kind']}-{item['pair']:02d}-{item['arm']}-{item['position']}"
+            folder = output / name
+            command = ['node', 'dev/perf/import-benchmark.js', args.dictionary,
+                       '--runs', '1', '--no-build', '--output', str(folder)]
+            print('START', name, flush=True)
+            before = os.getloadavg()
+            with (output / (name + '.log')).open('w') as log:
+                # Kill the entire automation tree on timeout, not only its parent.
+                child = subprocess.Popen(command, cwd=root, stdout=log, stderr=subprocess.STDOUT, start_new_session=True)
+                try:
+                    code = child.wait(timeout=150)
+                except BaseException:
+                    import signal
+                    os.killpg(child.pid, signal.SIGKILL)
+                    child.wait()
+                    raise
+                if code != 0:
+                    raise RuntimeError(f'{name}: benchmark exited {code}; retain its raw failure report')
+            summary_path, report_path = folder / 'summary.json', folder / 'run-1.json'
+            summary, report = json.loads(summary_path.read_text()), json.loads(report_path.read_text())
+            measured = validate(summary, report, args.dictionary, fixture, 'low', source[item['arm']])
+            if summary.get('source', {}).get('sha256', {}).get(WASM) != source[item['arm']]['common'][WASM]:
+                raise ValueError('Per-run WASM identity differs from the pinned build')
+            result['runs'].append(dict(**item, **measured, summary=str(summary_path.relative_to(output)),
+                                      report_sha256=digest(report_path), summary_sha256=digest(summary_path),
+                                      load_before=before, command=command))
+            save(output / 'results.json', result)
+            print('DONE', name, measured['elapsed_ms'], flush=True)
+        for arm, root in roots.items():
+            if git(root, 'status', '--porcelain') or digest(root / PACKAGE) != source[arm]['package_sha256']:
+                raise ValueError('Source or package changed during verification')
+            if {p: digest(root / p) for p in COMMON} != source[arm]['common']:
+                raise ValueError('Build identities changed during verification')
+        result['effect'] = effects(plan, result['runs'])
+        result['status'] = 'complete'
+    except BaseException as error:
+        result.update(status='failed', error=str(error))
+        raise
+    finally:
+        save(output / 'results.json', result)
+
+
+if __name__ == '__main__':
+    main()

--- a/dev/perf/bounded-followup/inflate64.py
+++ b/dev/perf/bounded-followup/inflate64.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -30,6 +31,21 @@ def check_common(source: dict) -> None:
     changed = {p for p in COMMON if a[p] != b[p]}
     if changed != {WASM}:
         raise ValueError(f'Unexpected common build differences: {sorted(changed)}')
+
+
+
+def check_wasm_identity(root: Path, expected: dict) -> None:
+    """Hash the actual build and shipped member; schema 3 only reports ZIP SHA."""
+    if digest(root / WASM) != expected['common'][WASM]:
+        raise ValueError('Per-run WASM build changed')
+    if digest(root / PACKAGE) != expected['package_sha256']:
+        raise ValueError('Per-run extension package changed')
+    with zipfile.ZipFile(root / PACKAGE) as archive:
+        member = WASM.removeprefix('ext/')
+        if archive.namelist().count(member) != 1:
+            raise ValueError('Missing or ambiguous packaged WASM')
+        if hashlib.sha256(archive.read(member)).hexdigest() != expected['common'][WASM]:
+            raise ValueError('Shipped WASM differs from identified build')
 
 
 def main() -> None:
@@ -74,6 +90,8 @@ def main() -> None:
         if changed != [HEADER]:
             raise ValueError(f'Unexpected production changes: {changed}')
         check_common(source)
+        for arm, root in roots.items():
+            check_wasm_identity(root, source[arm])
         result['status'] = 'running'
         save(output / 'plan.json', result)
         for index, item in enumerate(plan):
@@ -99,8 +117,7 @@ def main() -> None:
             summary_path, report_path = folder / 'summary.json', folder / 'run-1.json'
             summary, report = json.loads(summary_path.read_text()), json.loads(report_path.read_text())
             measured = validate(summary, report, args.dictionary, fixture, 'low', source[item['arm']])
-            if summary.get('source', {}).get('sha256', {}).get(WASM) != source[item['arm']]['common'][WASM]:
-                raise ValueError('Per-run WASM identity differs from the pinned build')
+            check_wasm_identity(root, source[item['arm']])
             result['runs'].append(dict(**item, **measured, summary=str(summary_path.relative_to(output)),
                                       report_sha256=digest(report_path), summary_sha256=digest(summary_path),
                                       load_before=before, command=command))

--- a/dev/perf/bounded-followup/prepare-inflate-banks.py
+++ b/dev/perf/bounded-followup/prepare-inflate-banks.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Derive raw compressed-bank inputs from hash-locked archives, outside timing."""
+import argparse
+import hashlib
+import json
+from pathlib import Path
+import re
+import struct
+import zipfile
+
+parser = argparse.ArgumentParser(description=__doc__)
+parser.add_argument('--source', type=Path, required=True)
+parser.add_argument('--output', type=Path, required=True)
+args = parser.parse_args()
+args.output.mkdir(parents=True, exist_ok=False)
+fixtures = json.loads((args.source / 'test/perf/dictionaries.lock.json').read_text())['dictionaries']
+manifest = {'fixtures': fixtures, 'banks': []}
+for dictionary, fixture in fixtures.items():
+    path = args.source / 'builds/e2e-dictionary-cache' / fixture['cacheFile']
+    data = path.read_bytes()
+    assert len(data) == fixture['sizeBytes'] and hashlib.sha256(data).hexdigest() == fixture['sha256']
+    rows = 0
+    with zipfile.ZipFile(path) as archive:
+        banks = sorted((x for x in archive.infolist() if re.fullmatch(r'term_bank_\d+\.json', x.filename)),
+                       key=lambda x: int(re.search(r'\d+', x.filename).group()))
+        for info in banks:
+            assert info.compress_type in (0, 8) and not info.flag_bits & 1
+            assert data[info.header_offset:info.header_offset + 4] == b'PK\x03\x04'
+            name_size, extra_size = struct.unpack_from('<HH', data, info.header_offset + 26)
+            offset = info.header_offset + 30 + name_size + extra_size
+            compressed = data[offset:offset + info.compress_size]
+            raw = archive.read(info)
+            assert len(compressed) == info.compress_size and len(raw) == info.file_size
+            terms = json.loads(raw)
+            assert isinstance(terms, list)
+            rows += len(terms)
+            name = dictionary + '-' + info.filename + '.compressed'
+            (args.output / name).write_bytes(compressed)
+            manifest['banks'].append(dict(dictionary=dictionary, file=name, method=info.compress_type,
+                size=info.file_size, crc=info.CRC, rows=len(terms),
+                compressedSha256=hashlib.sha256(compressed).hexdigest(), rawSha256=hashlib.sha256(raw).hexdigest()))
+    assert rows == fixture['termRows'], (dictionary, rows)
+(args.output / 'manifest.json').write_text(json.dumps(manifest, indent=2) + '\n')
+print('Prepared', len(manifest['banks']), 'complete fixed source banks')

--- a/dev/perf/bounded-followup/test_inflate64.py
+++ b/dev/perf/bounded-followup/test_inflate64.py
@@ -1,6 +1,10 @@
 import copy
 import unittest
-from inflate64 import COMMON, WASM, check_common
+import tempfile
+import zipfile
+import warnings
+from pathlib import Path
+from inflate64 import COMMON, WASM, PACKAGE, check_common, check_wasm_identity, digest
 
 class BuildIdentityTests(unittest.TestCase):
     def good(self):
@@ -27,5 +31,49 @@ class BuildIdentityTests(unittest.TestCase):
             if path == WASM: continue
             data = self.good(); data['candidate']['common'][path] = 'wrong'
             with self.assertRaises(ValueError): check_common(data)
+
+class PackagedIdentityTests(unittest.TestCase):
+    def setup_files(self, root, member='lib/term-bank-parser.wasm', content=b'wasm', duplicate=False):
+        (root / WASM).parent.mkdir(parents=True, exist_ok=True)
+        (root / WASM).write_bytes(b'wasm')
+        (root / PACKAGE).parent.mkdir(parents=True, exist_ok=True)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            with zipfile.ZipFile(root / PACKAGE, 'w') as z:
+                z.writestr(member, content)
+                if duplicate: z.writestr(member, content)
+        return {'common': {WASM: digest(root / WASM)}, 'package_sha256': digest(root / PACKAGE)}
+
+    def test_real_schema_does_not_need_per_run_wasm_summary_field(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp); expected = self.setup_files(root)
+            check_wasm_identity(root, expected)
+
+    def test_changed_build_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp); expected = self.setup_files(root)
+            (root / WASM).write_bytes(b'changed')
+            with self.assertRaises(ValueError): check_wasm_identity(root, expected)
+
+    def test_changed_zip_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp); expected = self.setup_files(root)
+            (root / PACKAGE).write_bytes(b'changed')
+            with self.assertRaises(ValueError): check_wasm_identity(root, expected)
+
+    def test_wrong_shipped_wasm_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp); expected = self.setup_files(root, content=b'different')
+            with self.assertRaises(ValueError): check_wasm_identity(root, expected)
+
+    def test_missing_shipped_wasm_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp); expected = self.setup_files(root, member='other')
+            with self.assertRaises(ValueError): check_wasm_identity(root, expected)
+
+    def test_duplicate_member_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp); expected = self.setup_files(root, duplicate=True)
+            with self.assertRaises(ValueError): check_wasm_identity(root, expected)
 
 if __name__ == '__main__': unittest.main()

--- a/dev/perf/bounded-followup/test_inflate64.py
+++ b/dev/perf/bounded-followup/test_inflate64.py
@@ -1,0 +1,31 @@
+import copy
+import unittest
+from inflate64 import COMMON, WASM, check_common
+
+class BuildIdentityTests(unittest.TestCase):
+    def good(self):
+        a = {p: 'same' for p in COMMON}
+        b = {**a, WASM: 'intentionally different'}
+        return {'baseline': {'common': a}, 'candidate': {'common': b}}
+
+    def test_only_wasm_change_is_accepted(self):
+        check_common(self.good())
+
+    def test_same_binary_is_not_a_bitbuffer_comparison(self):
+        data = self.good()
+        data['candidate']['common'] = copy.deepcopy(data['baseline']['common'])
+        with self.assertRaises(ValueError): check_common(data)
+
+    def test_missing_identity_fails(self):
+        for arm in ('baseline', 'candidate'):
+            for path in COMMON:
+                data = self.good(); del data[arm]['common'][path]
+                with self.assertRaises(ValueError): check_common(data)
+
+    def test_any_other_changed_identity_fails(self):
+        for path in COMMON:
+            if path == WASM: continue
+            data = self.good(); data['candidate']['common'][path] = 'wrong'
+            with self.assertRaises(ValueError): check_common(data)
+
+if __name__ == '__main__': unittest.main()

--- a/dev/perf/bounded-followup/wasm-inflate-oracle.mjs
+++ b/dev/perf/bounded-followup/wasm-inflate-oracle.mjs
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Complete production WASM; independent node:zlib bytes. Not database parity.
+import assert from 'node:assert/strict';
+import {readFileSync, writeFileSync} from 'node:fs';
+import {createHash} from 'node:crypto';
+import {dirname, resolve} from 'node:path';
+import {crc32, deflateRawSync, inflateRawSync} from 'node:zlib';
+import {performance} from 'node:perf_hooks';
+
+const [before, after, output, manifestPath] = process.argv.slice(2);
+assert(before && after && output, 'usage: node wasm-inflate-oracle.mjs BEFORE.wasm AFTER.wasm OUTPUT.json [BANK-MANIFEST.json]');
+const sha = (bytes) => createHash('sha256').update(bytes).digest('hex');
+const modules = [];
+for (const filename of [before, after]) {
+    const bytes = readFileSync(filename);
+    const {instance} = await WebAssembly.instantiate(bytes);
+    modules.push({wasm: instance.exports, filename, sha256: sha(bytes)});
+}
+const report = {node: process.version, platform: process.platform, arch: process.arch,
+    modules: modules.map(({filename, sha256}) => ({filename, sha256})),
+    cases: 0, fixtureBanks: 0, fixtureBytes: 0, runs: [], scope: 'inflate/CRC/array-compaction only; not full import'};
+const whitespace = (v) => [9, 10, 13, 32].includes(v);
+function oracle(raw) {
+    let s = 0, e = raw.length;
+    while (s < e && whitespace(raw[s])) ++s;
+    while (e > s && whitespace(raw[e - 1])) --e;
+    assert(raw[s] === 91 && raw[e - 1] === 93);
+    ++s; --e;
+    while (s < e && whitespace(raw[s])) ++s;
+    while (e > s && whitespace(raw[e - 1])) --e;
+    return Buffer.concat([Buffer.from('['), raw.subarray(s, e), Buffer.from(']')]);
+}
+function run(wasm, compressed, raw, options = {}) {
+    wasm.wasm_reset_heap();
+    const pad = options.pad ?? 0;
+    const inputBase = wasm.wasm_alloc(compressed.length + 32 + pad);
+    const input = inputBase + 16 + pad;
+    const meta = wasm.wasm_alloc(24);
+    const cap = options.cap ?? raw.length + 2;
+    const outputBase = wasm.wasm_alloc(cap + 32 + pad);
+    const dest = outputBase + 16 + pad;
+    const heap = new Uint8Array(wasm.memory.buffer);
+    heap.fill(0xa5, inputBase, input + compressed.length + 16);
+    heap.set(compressed, input);
+    heap.fill(0xa5, outputBase, dest + cap + 16);
+    new Uint32Array(wasm.memory.buffer, meta, 6).set([0, compressed.length,
+        options.size ?? raw.length, options.method ?? 8, options.crc ?? crc32(raw), 0]);
+    const cpu0 = process.cpuUsage();
+    const start = performance.now();
+    const status = wasm.inflate_and_join_term_banks(input, compressed.length, meta, meta + 4,
+        meta + 8, meta + 12, meta + 16, 1, dest, cap);
+    const elapsedMs = performance.now() - start;
+    const cpu = process.cpuUsage(cpu0);
+    assert(heap.subarray(outputBase, dest).every((v) => v === 0xa5), 'prefix guard overwritten');
+    assert(heap.subarray(dest + cap, dest + cap + 16).every((v) => v === 0xa5), 'suffix guard overwritten');
+    assert.deepEqual(Buffer.from(heap.subarray(input, input + compressed.length)), Buffer.from(compressed), 'input mutated');
+    return {status, bytes: status < 0 ? null : Buffer.from(heap.subarray(dest, dest + status)),
+        elapsedMs, cpuUs: cpu.user + cpu.system};
+}
+function compare(compressed, raw, options, expected = undefined) {
+    const a = run(modules[0].wasm, compressed, raw, options);
+    const b = run(modules[1].wasm, compressed, raw, options);
+    assert.equal(b.status, a.status, 'status differs');
+    assert.deepEqual(b.bytes, a.bytes, 'bytes differ');
+    if (expected !== undefined) assert.deepEqual(b.bytes, expected, 'independent oracle differs');
+    ++report.cases;
+}
+for (const level of [0, 1, 6, 9]) {
+    for (let n = 0; n < 32; ++n) {
+        const raw = Buffer.from(` \n[ ${JSON.stringify(`日本語🙂:${n}:${'abcd'.repeat(n * 73)}`)} ]\t`);
+        const compressed = deflateRawSync(raw, {level});
+        assert.deepEqual(inflateRawSync(compressed), raw);
+        for (const pad of [0, 1, 7, 15]) compare(compressed, raw, {pad}, oracle(raw));
+        compare(compressed, raw, {crc: crc32(raw) ^ 1});
+        compare(compressed, raw, {cap: Math.max(2, raw.length - 1)});
+        compare(compressed, raw, {size: raw.length + 1});
+        compare(Buffer.concat([compressed, Buffer.from([0, 1])]), raw, {});
+        for (let cut = 0; cut < Math.min(16, compressed.length); ++cut) {
+            compare(compressed.subarray(0, compressed.length - cut - 1), raw, {});
+        }
+        for (let j = 0; j < 8; ++j) {
+            const modified = Buffer.from(compressed);
+            modified[Math.floor((modified.length - 1) * j / 7)] ^= 1 << (j % 8);
+            compare(modified, raw, {});
+        }
+    }
+}
+if (manifestPath) {
+    const manifest = JSON.parse(readFileSync(manifestPath));
+    report.fixtures = manifest.fixtures;
+    const banks = manifest.banks.map((entry) => {
+        const compressed = readFileSync(resolve(dirname(manifestPath), entry.file));
+        assert.equal(sha(compressed), entry.compressedSha256);
+        const raw = entry.method === 0 ? compressed : inflateRawSync(compressed);
+        assert.equal(raw.length, entry.size);
+        assert.equal(crc32(raw), entry.crc);
+        assert.equal(sha(raw), entry.rawSha256);
+        const expected = oracle(raw);
+        compare(compressed, raw, {method: entry.method}, expected);
+        ++report.fixtureBanks; report.fixtureBytes += raw.length;
+        return {...entry, compressed, raw, expected};
+    });
+    // Each dictionary stays separate; all checks/copies happen outside call timing.
+    for (const dictionary of Object.keys(manifest.fixtures)) {
+        const group = banks.filter((bank) => bank.dictionary === dictionary);
+        for (let pair = 0; pair <= 6; ++pair) {
+            for (const arm of pair % 2 ? [1, 0] : [0, 1]) {
+                let elapsedMs = 0, cpuUs = 0;
+                for (const bank of group) {
+                    const r = run(modules[arm].wasm, bank.compressed, bank.raw, {method: bank.method});
+                    assert.deepEqual(r.bytes, bank.expected);
+                    elapsedMs += r.elapsedMs; cpuUs += r.cpuUs;
+                }
+                report.runs.push({dictionary, pair, warmup: pair === 0, arm, elapsedMs, cpuUs});
+            }
+        }
+    }
+}
+writeFileSync(output, JSON.stringify(report, null, 2) + '\n');
+console.log(JSON.stringify({cases: report.cases, fixtureBanks: report.fixtureBanks, fixtureBytes: report.fixtureBytes, measuredCalls: report.runs.length}));

--- a/dev/perf/inflate64-decision-20260909.md
+++ b/dev/perf/inflate64-decision-20260909.md
@@ -1,0 +1,24 @@
+# Final inspected decision — isolated i64 inflater, September 9, 2026
+
+**Do not promote PR #28 as a whole-import speed improvement. Keep it draft and out of the release integration.** The component decompressor improved, but the latest complete JMnedict comparison was slower in all six pairs. This finding supersedes the provisional assessment in `inflate64-followup-20260909.md`; that report's earlier results remain valid and retained, not replaced.
+
+Product controls are unchanged: baseline #24 `ff9cbf2e848a86d6bbfd281179a6d753349e52f4`, candidate `dc226aaf88a0f8d2d4b2bcc37778352be0104622`. The confirmation run [34335944244](https://github.com/ManabiIO/manabitan/actions/runs/34335944244) uses helper head `60ab7874bf2fc67181b7d1c8f25dd5389c64830a`; only the typed component-oracle location/documentation changed from the preceding verification. Whole-import driver, product code, inputs, six-pair A/B protocol, two interleaved A/A pairs, excluded warmup pair, fresh profiles and native memory selection did not change.
+
+Both inspected JMnedict plans completed 18/18 imports, with all 36 reports independently revalidated. Artifact ZIP SHA-256, report hashes, source/package provenance, row/bank counts, complete source-byte accounting, native memory tier and sampled persisted readability passed. No outliers, retries or spliced jobs.
+
+| Confirmation lane | Paired median | Equal-work total | Faster pairs | Worst pair |
+|---|---:|---:|---:|---:|
+| JMnedict 1 | -2.92% | -1.31% | 4/6 | +24.14% |
+| JMnedict 2 | **+6.35%** | **+8.57%** | **0/6** | +21.51% |
+
+Lane 2's exact pair changes: `[7.828122217417022, 4.868338339038347, 21.50936607524332, 8.44029919660123, 3.411625472256863, 4.453830936215963]` percent. Its same-binary baseline and candidate pairs varied -2.12% and +2.61%, respectively. Lane 1's same-binary baseline varied -45.53%, candidate +2.38%. Hosts are not pooled. These data justify withholding acceptance; they do not establish the underlying cause of the slower whole imports.
+
+The earlier complete JMnedict jobs had paired medians +3.53% and -10.39%, as recorded in the preceding report. A faster isolated stage cannot be used to average away this whole-import concern. Previously established correctness and component results remain separate from release approval.
+
+Confirmation artifact 10098193792: SHA-256 `af203297abe348195bb30145ac49905ef4b8e4991876aa94bdc3f3a63e4190d9`.
+Confirmation artifact 10098172081: SHA-256 `81081df8486a3d1c6306001b64c13fd1c18198f9c783b9d2788f0f94fde08206`.
+Full-precision independent recalculation and all raw inspected reports are retained as `CONFIRMATION-AUDIT.json` and `import-audit/confirmation/` in the delivered evidence bundle.
+
+The other confirmation lanes and later queued helper-only workflow are not given effect estimates in this decision; only downloaded and validated complete plans support its claims. The preceding complete six-lane audit retains all 65 successful observations, including incomplete lanes with no effect estimates. The two sets together contain 101 revalidated retained reports; this count is not 101 independent A/B pairs.
+
+Next useful work is paired attribution of parsing, copying/compression, storage and waits on a runtime that can complete the fixed plan reliably. Do not combine this candidate with #27/#29 to hide regression, change dictionary-specific policy, or weaken correctness gates. Reconcile the selected release ancestry separately and apply any shared #22 header change only once if later accepted. No release merge, Reader vendor update or v3-hotfix modification was made.

--- a/dev/perf/inflate64-followup-20260909.md
+++ b/dev/perf/inflate64-followup-20260909.md
@@ -1,0 +1,64 @@
+# Isolated WASM inflater follow-up — September 9, 2026
+
+## Decision
+
+**PR #28 contains committed production source, but remains draft. The decompression component improves; a regression-free whole-import result is not established.** No release merge, Reader vendor update or v3-hotfix change was made by this work.
+
+Parent: #26 at `925421edcb5262dd99f8879818c86fbace8e458a`. Performance baseline: #24 at `ff9cbf2e848a86d6bbfd281179a6d753349e52f4`. Actual production/test candidate: `dc226aaf88a0f8d2d4b2bcc37778352be0104622`. Later commits change verification tooling, not product code.
+
+Only the miniz header's WebAssembly i64 capability selection is reused from #22. Its bulk history-copy experiment is excluded. Batch sizes, worker selection, memory budgets, grammar, CRC/size/trailing-input checks, caches and persisted formats are unchanged.
+
+Candidate `miniz.h` Git blob: `22d72694d7361cc2642e845a7136eb38e6afeb63`; SHA-256: `619fbff2e98605a83f327a2879d52f219b5edaa579036a657937910f0707a43b`. Baseline blob: `6b71bda7605c11f0cb6da7f150d7d0fce6a5a6d2`; SHA-256: `8f03a9180dfc53fecfe26baa3566527f83af49cb432a60304aff75adb3b99f51`.
+
+## Executed correctness
+
+Independent correctness jobs in [34332509223](https://github.com/ManabiIO/manabitan/actions/runs/34332509223) and [34333540881](https://github.com/ManabiIO/manabitan/actions/runs/34333540881) passed. Each passed **5,511 unit tests**, 46 existing skips, 25 options tests, all four strict TypeScript projects and all-target dry builds. Their raw artifacts were downloaded and inspected. Protocol checks increased from 12 to 18 after the provenance repair.
+
+Each CI job and local Clang 17 verification passed **3,847 native inflater cases for each bit-buffer width under ASan+UBSan**, with leak detection enabled: zlib byte oracles, streaming input/output boundaries, guard pages, truncation, exact consumption and output guards. This instruments the affected core, not the whole browser; no TSan pass is claimed.
+
+Actual complete production WASM modules passed **4,434 oracle comparisons**: 4,096 synthetic cases plus all **338 fixed dictionary banks**, representing **754,052,959 decoded bytes**. Every emitted inflater/array-join byte matches both controls and an independent normalized-array oracle. This is exhaustive at that boundary, **not exhaustive persisted-database equivalence**.
+
+The final typed oracle in `test/native/wasm-inflate-oracle.js`, blob `29b6c4850db961d0e2553ca61887d28266512551`, again passed all 4,434 cases locally. Focused repository lint, strict test types and a same-binary oracle passed in [34336244322](https://github.com/ManabiIO/manabitan/actions/runs/34336244322). No lint rules or source gates were weakened. The ordinary strict Chromium integration job in [34332513883](https://github.com/ManabiIO/manabitan/actions/runs/34332513883) also passed; its overall matrix was not green.
+
+## Component measurements, not whole imports
+
+Six alternating pairs per dictionary/environment, one excluded warmup pair, resident fixed compressed inputs. The real inflation/CRC/array-join export is timed; setup and verification are outside. CPU and elapsed bracket that call. Values are medians of within-pair changes; independent environments are not pooled.
+
+| Dictionary | Local elapsed | First CI elapsed | Second CI elapsed |
+| ---------- | ------------: | ---------------: | ----------------: |
+| JMdict     |        -5.73% |           -8.40% |            -9.73% |
+| JMnedict   |        -5.60% |          -12.10% |            -8.17% |
+| Jitendex   |        -3.41% |           -6.88% |            -9.07% |
+
+CPU medians also fell in every cell. The second CI JMnedict comparison includes a slower pair, retained in the evidence. Local: Clang 17/Node 22.16; CI: Clang 18/Node 24.20. These percentages are not whole-import, memory, ARM/Android, native Reader or iPhone claims.
+
+## Complete browser comparisons
+
+[34333540881](https://github.com/ManabiIO/manabitan/actions/runs/34333540881) used corrected driver `cd61590ec61b17198b7d03819a706ac21d604b54` with the same pinned product controls above. Each lane predeclared 18 fresh-profile imports: six alternating A/B pairs, two interleaved same-binary pairs and an excluded warmup pair. Trial 2 reversed initial order. Native page/worker memory classification was observed, not overridden. Timing remained file-input-change to post-UI completion.
+
+Both JMnedict lanes completed and passed:
+
+| Lane | Paired median | Equal-work total | Faster pairs | Worst pair |
+| ---- | ------------: | ---------------: | -----------: | ---------: |
+| 1    |        +3.53% |           -0.87% |          2/6 |    +22.69% |
+| 2    |       -10.39% |          -11.40% |          4/6 |    +29.99% |
+
+Same-binary changes were -12.60%/-0.04% in lane 1 and -20.73%/-13.42% in lane 2. The variation prevents a general speedup claim or a causal explanation of the slower pairs. #24's previous slow-tail concern remains open.
+
+JMdict lane 1 retained 10/18 reports; Jitendex lanes 1/2 retained 10/18 and 9/18, then those jobs ended cancelled. JMdict lane 2 failed before its first import at the 30-second settings-input selector timeout. **These incomplete lanes have no effect estimates.** All six artifacts were downloaded, SHA-verified, and all 65 retained successful reports independently revalidated for source/package identity, rows, banks, memory tier, complete source-byte accounting, report hashes and sampled persisted readability. No observations were deleted, spliced or retried.
+
+Artifacts for that run: correctness `10096887318`; JMdict 1/2 `10097473157`/`10097347626`; JMnedict 1/2 `10097431496`/`10097452564`; Jitendex 1/2 `10097476739`/`10097473529`. Raw artifacts, identities and full-precision audit output are also retained in the delivered evidence bundle.
+
+## Errors and prior evidence kept separate
+
+The first attempted full comparison rejected successful warmups because the new driver expected a WASM hash field absent from schema 3. The fixed driver checks actual build bytes, the entire ZIP and its unique WASM member before timing and after each import; the report's ZIP hash remains mandatory. Six new regression tests cover missing, duplicate and changed bytes. The first attempt has no effect estimate. One lane also hit its process limit after UI import completion but before complete verification; that output is not accepted.
+
+Focused lint initially found the `.mjs` oracle outside all configured projects. Moving and typing it in the existing test project, then correcting two layout errors, produced the successful focused check above. Production code did not change.
+
+Separately, the historical #26 run [34328594992](https://github.com/ManabiIO/manabitan/actions/runs/34328594992), which compares #23 with #24, was audited: 46 retained reports; only JMnedict lane 1 complete. Its paired median was -3.44%, equal-work total +1.12%, worst pair +18.38%, faster 4/6. The other lanes are incomplete. These are historical observations, not new local runs or part of #28's effect.
+
+## Continuation gates
+
+Use the browser lock's 526,942 JMdict, 667,942 JMnedict and 435,448 Jitendex rows; these JMdict/JMnedict archives differ from native Reader's fixed fixtures. Keep source and binary identities and complete plans. Improve setup/startup reliability or use a suitable measured runtime rather than dropping slow observations, changing memory classification, or combining incomplete runs.
+
+Keep #28 draft pending complete whole-import evidence and platform coverage. Reconcile the selected #25/#22 release train with #23/#24 before release; apply the shared miniz header change only once. Concurrent #27/#29 copy experiments were not combined or duplicated. Native #12's Apple gate remains separate. Reader and v3-hotfix branches remain outside this work.

--- a/ext/js/dictionary/wasm/vendor/miniz/miniz.h
+++ b/ext/js/dictionary/wasm/vendor/miniz/miniz.h
@@ -225,7 +225,8 @@
 #endif
 #endif
 
-#if defined(_M_X64) || defined(_WIN64) || defined(__MINGW64__) || defined(_LP64) || defined(__LP64__) || defined(__ia64__) || defined(__x86_64__)
+/* WebAssembly has i64 arithmetic independently of its pointer width. */
+#if defined(_M_X64) || defined(_WIN64) || defined(__MINGW64__) || defined(_LP64) || defined(__LP64__) || defined(__ia64__) || defined(__x86_64__) || defined(__wasm__)
 /* Set MINIZ_HAS_64BIT_REGISTERS to 1 if operations on 64-bit integers are reasonably fast (and don't involve compiler generated calls to helper functions). */
 #define MINIZ_HAS_64BIT_REGISTERS 1
 #else

--- a/test/native/wasm-inflate-oracle.js
+++ b/test/native/wasm-inflate-oracle.js
@@ -1,35 +1,80 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Complete production WASM; independent node:zlib bytes. Not database parity.
 import assert from 'node:assert/strict';
-import {readFileSync, writeFileSync} from 'node:fs';
 import {createHash} from 'node:crypto';
+import {readFileSync, writeFileSync} from 'node:fs';
 import {dirname, resolve} from 'node:path';
-import {crc32, deflateRawSync, inflateRawSync} from 'node:zlib';
 import {performance} from 'node:perf_hooks';
+import {crc32, deflateRawSync, inflateRawSync} from 'node:zlib';
 
 const [before, after, output, manifestPath] = process.argv.slice(2);
-assert(before && after && output, 'usage: node wasm-inflate-oracle.mjs BEFORE.wasm AFTER.wasm OUTPUT.json [BANK-MANIFEST.json]');
+assert(before && after && output, 'usage: node wasm-inflate-oracle.js BEFORE.wasm AFTER.wasm OUTPUT.json [BANK-MANIFEST.json]');
+/**
+ * @param {Uint8Array} bytes
+ * @returns {string}
+ */
 const sha = (bytes) => createHash('sha256').update(bytes).digest('hex');
+/**
+ * @typedef {{memory: WebAssembly.Memory, wasm_reset_heap: () => void,
+ * wasm_alloc: (length: number) => number,
+ * inflate_and_join_term_banks: (...args: number[]) => number}} Inflater
+ * @typedef {{dictionary: string, file: string, method: number, size: number,
+ * crc: number, rows: number, compressedSha256: string, rawSha256: string}} Bank
+ */
+/** @type {Array<{wasm: Inflater, filename: string, sha256: string}>} */
 const modules = [];
 for (const filename of [before, after]) {
     const bytes = readFileSync(filename);
     const {instance} = await WebAssembly.instantiate(bytes);
-    modules.push({wasm: instance.exports, filename, sha256: sha(bytes)});
+    const wasm = /** @type {Inflater} */ (/** @type {unknown} */ (instance.exports));
+    modules.push({wasm, filename, sha256: sha(bytes)});
 }
-const report = {node: process.version, platform: process.platform, arch: process.arch,
+/**
+ * @type {{node: string, platform: string, arch: string,
+ * modules: Array<{filename: string, sha256: string}>, cases: number,
+ * fixtureBanks: number, fixtureBytes: number, fixtures?: Record<string, object>,
+ * runs: Array<{dictionary: string, pair: number, warmup: boolean, arm: number,
+ * elapsedMs: number, cpuUs: number}>, scope: string}}
+ */
+const report = {
+    node: process.version,
+    platform: process.platform,
+    arch: process.arch,
     modules: modules.map(({filename, sha256}) => ({filename, sha256})),
-    cases: 0, fixtureBanks: 0, fixtureBytes: 0, runs: [], scope: 'inflate/CRC/array-compaction only; not full import'};
+    cases: 0,
+    fixtureBanks: 0,
+    fixtureBytes: 0,
+    runs: [],
+    scope: 'inflate/CRC/array-compaction only; not full import',
+};
+/**
+ * @param {number} v
+ * @returns {boolean}
+ */
 const whitespace = (v) => [9, 10, 13, 32].includes(v);
+/**
+ * @param {Buffer} raw
+ * @returns {Buffer}
+ */
 function oracle(raw) {
-    let s = 0, e = raw.length;
-    while (s < e && whitespace(raw[s])) ++s;
-    while (e > s && whitespace(raw[e - 1])) --e;
+    let s = 0;
+    let e = raw.length;
+    while (s < e && whitespace(raw[s])) { ++s; }
+    while (e > s && whitespace(raw[e - 1])) { --e; }
     assert(raw[s] === 91 && raw[e - 1] === 93);
-    ++s; --e;
-    while (s < e && whitespace(raw[s])) ++s;
-    while (e > s && whitespace(raw[e - 1])) --e;
+    ++s;
+    --e;
+    while (s < e && whitespace(raw[s])) { ++s; }
+    while (e > s && whitespace(raw[e - 1])) { --e; }
     return Buffer.concat([Buffer.from('['), raw.subarray(s, e), Buffer.from(']')]);
 }
+/**
+ * @param {Inflater} wasm
+ * @param {Buffer} compressed
+ * @param {Buffer} raw
+ * @param {{pad?: number, cap?: number, size?: number, method?: number, crc?: number}} options
+ * @returns {{status: number, bytes: Buffer|null, elapsedMs: number, cpuUs: number}}
+ */
 function run(wasm, compressed, raw, options = {}) {
     wasm.wasm_reset_heap();
     const pad = options.pad ?? 0;
@@ -43,26 +88,38 @@ function run(wasm, compressed, raw, options = {}) {
     heap.fill(0xa5, inputBase, input + compressed.length + 16);
     heap.set(compressed, input);
     heap.fill(0xa5, outputBase, dest + cap + 16);
-    new Uint32Array(wasm.memory.buffer, meta, 6).set([0, compressed.length,
-        options.size ?? raw.length, options.method ?? 8, options.crc ?? crc32(raw), 0]);
+    new Uint32Array(wasm.memory.buffer, meta, 6).set([
+        0, compressed.length, options.size ?? raw.length, options.method ?? 8, options.crc ?? crc32(raw), 0,
+    ]);
     const cpu0 = process.cpuUsage();
     const start = performance.now();
-    const status = wasm.inflate_and_join_term_banks(input, compressed.length, meta, meta + 4,
-        meta + 8, meta + 12, meta + 16, 1, dest, cap);
+    const status = wasm.inflate_and_join_term_banks(
+        input, compressed.length, meta, meta + 4, meta + 8, meta + 12, meta + 16, 1, dest, cap,
+    );
     const elapsedMs = performance.now() - start;
     const cpu = process.cpuUsage(cpu0);
     assert(heap.subarray(outputBase, dest).every((v) => v === 0xa5), 'prefix guard overwritten');
     assert(heap.subarray(dest + cap, dest + cap + 16).every((v) => v === 0xa5), 'suffix guard overwritten');
     assert.deepEqual(Buffer.from(heap.subarray(input, input + compressed.length)), Buffer.from(compressed), 'input mutated');
-    return {status, bytes: status < 0 ? null : Buffer.from(heap.subarray(dest, dest + status)),
-        elapsedMs, cpuUs: cpu.user + cpu.system};
+    return {
+        status,
+        bytes: status < 0 ? null : Buffer.from(heap.subarray(dest, dest + status)),
+        elapsedMs,
+        cpuUs: cpu.user + cpu.system,
+    };
 }
-function compare(compressed, raw, options, expected = undefined) {
+/**
+ * @param {Buffer} compressed
+ * @param {Buffer} raw
+ * @param {{pad?: number, cap?: number, size?: number, method?: number, crc?: number}} options
+ * @param {Buffer|undefined} expected
+ */
+function compare(compressed, raw, options, expected = void 0) {
     const a = run(modules[0].wasm, compressed, raw, options);
     const b = run(modules[1].wasm, compressed, raw, options);
     assert.equal(b.status, a.status, 'status differs');
     assert.deepEqual(b.bytes, a.bytes, 'bytes differ');
-    if (expected !== undefined) assert.deepEqual(b.bytes, expected, 'independent oracle differs');
+    if (typeof expected !== 'undefined') { assert.deepEqual(b.bytes, expected, 'independent oracle differs'); }
     ++report.cases;
 }
 for (const level of [0, 1, 6, 9]) {
@@ -70,7 +127,7 @@ for (const level of [0, 1, 6, 9]) {
         const raw = Buffer.from(` \n[ ${JSON.stringify(`日本語🙂:${n}:${'abcd'.repeat(n * 73)}`)} ]\t`);
         const compressed = deflateRawSync(raw, {level});
         assert.deepEqual(inflateRawSync(compressed), raw);
-        for (const pad of [0, 1, 7, 15]) compare(compressed, raw, {pad}, oracle(raw));
+        for (const pad of [0, 1, 7, 15]) { compare(compressed, raw, {pad}, oracle(raw)); }
         compare(compressed, raw, {crc: crc32(raw) ^ 1});
         compare(compressed, raw, {cap: Math.max(2, raw.length - 1)});
         compare(compressed, raw, {size: raw.length + 1});
@@ -86,7 +143,8 @@ for (const level of [0, 1, 6, 9]) {
     }
 }
 if (manifestPath) {
-    const manifest = JSON.parse(readFileSync(manifestPath));
+    /** @type {{fixtures: Record<string, object>, banks: Bank[]}} */
+    const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
     report.fixtures = manifest.fixtures;
     const banks = manifest.banks.map((entry) => {
         const compressed = readFileSync(resolve(dirname(manifestPath), entry.file));
@@ -97,7 +155,8 @@ if (manifestPath) {
         assert.equal(sha(raw), entry.rawSha256);
         const expected = oracle(raw);
         compare(compressed, raw, {method: entry.method}, expected);
-        ++report.fixtureBanks; report.fixtureBytes += raw.length;
+        ++report.fixtureBanks;
+        report.fixtureBytes += raw.length;
         return {...entry, compressed, raw, expected};
     });
     // Each dictionary stays separate; all checks/copies happen outside call timing.
@@ -105,11 +164,13 @@ if (manifestPath) {
         const group = banks.filter((bank) => bank.dictionary === dictionary);
         for (let pair = 0; pair <= 6; ++pair) {
             for (const arm of pair % 2 ? [1, 0] : [0, 1]) {
-                let elapsedMs = 0, cpuUs = 0;
+                let elapsedMs = 0;
+                let cpuUs = 0;
                 for (const bank of group) {
                     const r = run(modules[arm].wasm, bank.compressed, bank.raw, {method: bank.method});
                     assert.deepEqual(r.bytes, bank.expected);
-                    elapsedMs += r.elapsedMs; cpuUs += r.cpuUs;
+                    elapsedMs += r.elapsedMs;
+                    cpuUs += r.cpuUs;
                 }
                 report.runs.push({dictionary, pair, warmup: pair === 0, arm, elapsedMs, cpuUs});
             }

--- a/test/native/wasm-inflate-oracle.js
+++ b/test/native/wasm-inflate-oracle.js
@@ -93,9 +93,7 @@ function run(wasm, compressed, raw, options = {}) {
     ]);
     const cpu0 = process.cpuUsage();
     const start = performance.now();
-    const status = wasm.inflate_and_join_term_banks(
-        input, compressed.length, meta, meta + 4, meta + 8, meta + 12, meta + 16, 1, dest, cap,
-    );
+    const status = wasm.inflate_and_join_term_banks(input, compressed.length, meta, meta + 4, meta + 8, meta + 12, meta + 16, 1, dest, cap);
     const elapsedMs = performance.now() - start;
     const cpu = process.cpuUsage(cpu0);
     assert(heap.subarray(outputBase, dest).every((v) => v === 0xa5), 'prefix guard overwritten');

--- a/test/term-bank-inflate-matches.test.js
+++ b/test/term-bank-inflate-matches.test.js
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2026 Manabitan authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+/* eslint @stylistic/semi: ["error", "never"] */
+
+import {readFile} from 'node:fs/promises'
+import {crc32, deflateRawSync, inflateRawSync} from 'node:zlib'
+import {beforeAll, describe, expect, test} from 'vitest'
+
+/** @typedef {{memory: WebAssembly.Memory, wasm_reset_heap: () => void, wasm_alloc: (size: number) => number, inflate_and_join_term_banks: (...args: number[]) => number}} InflateExports */
+/** @type {InflateExports} */
+let wasm
+beforeAll(async () => {
+    const module = await WebAssembly.compile(await readFile(new URL('../ext/lib/term-bank-parser.wasm', import.meta.url)))
+    wasm = /** @type {InflateExports} */ (/** @type {unknown} */ ((await WebAssembly.instantiate(module)).exports))
+})
+
+/**
+ * Hand-build a fixed-Huffman block so the match distance/length, including
+ * self-overlapping expansion, are known rather than chosen by a compressor.
+ * @param {number} distance
+ * @param {number} length
+ * @param {number} padding
+ * @returns {{compressed: Uint8Array, expected: Uint8Array}}
+ */
+function fixedMatch(distance, length, padding) {
+    /** @type {number[]} */
+    const output = []
+    /** @type {number[]} */
+    const compressed = []
+    let byte = 0
+    let bitCount = 0
+    /**
+     * @param {number} value
+     * @param {number} count
+     */
+    const bits = (value, count) => {
+        for (let i = 0; i < count; ++i) {
+            byte |= ((value >>> i) & 1) << bitCount
+            if (++bitCount === 8) {
+                compressed.push(byte)
+                byte = bitCount = 0
+            }
+        }
+    }
+    /**
+     * @param {number} code
+     * @param {number} count
+     */
+    const codeBits = (code, count) => {
+        for (let i = count - 1; i >= 0; --i) { bits(code >>> i, 1) }
+    }
+    /** @param {number} symbol */
+    const symbol = (symbol) => {
+        if (symbol <= 143) {
+            codeBits(0x30 + symbol, 8)
+        } else if (symbol <= 255) {
+            codeBits(0x190 + symbol - 144, 9)
+        } else if (symbol <= 279) {
+            codeBits(symbol - 256, 7)
+        } else {
+            codeBits(0xc0 + symbol - 280, 8)
+        }
+    }
+    /** @param {number} value */
+    const literal = (value) => {
+        output.push(value)
+        symbol(value)
+    }
+    bits(3, 3) // Final block, fixed Huffman coding.
+    literal(91)
+    literal(34)
+    for (let i = 0; i < distance + padding; ++i) { literal(97 + i % 26) }
+    const bases = [3, 4, 5, 6, 7, 8, 9, 10, 11, 13, 15, 17, 19, 23, 27, 31, 35, 43, 51, 59, 67, 83, 99, 115, 131, 163, 195, 227, 258]
+    const extras = [0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 0]
+    let code = bases.length - 1
+    while (length < bases[code]) { --code }
+    symbol(257 + code)
+    bits(length - bases[code], extras[code])
+    code = 29
+    const distanceBase = (/** @type {number} */ value) => (value < 4 ? value + 1 : ((2 + (value & 1)) << ((value >>> 1) - 1)) + 1)
+    while (distance < distanceBase(code)) { --code }
+    codeBits(code, 5)
+    bits(distance - distanceBase(code), code < 4 ? 0 : (code >>> 1) - 1)
+    for (let i = 0; i < length; ++i) { output.push(output[output.length - distance]) }
+    literal(34)
+    literal(93)
+    symbol(256)
+    if (bitCount !== 0) { compressed.push(byte) }
+    return {compressed: Uint8Array.from(compressed), expected: Uint8Array.from(output)}
+}
+
+/**
+ * @param {Uint8Array} compressed
+ * @param {Uint8Array} expected
+ * @param {{crc?: number, capacity?: number}} [options]
+ * @returns {{status: number, output: Uint8Array}}
+ */
+function inflate(compressed, expected, options = {}) {
+    wasm.wasm_reset_heap()
+    const input = wasm.wasm_alloc(compressed.length)
+    const metadata = wasm.wasm_alloc(24)
+    const capacity = options.capacity ?? expected.length + 2
+    const output = wasm.wasm_alloc(capacity + 32)
+    const heap = new Uint8Array(wasm.memory.buffer)
+    heap.set(compressed, input)
+    heap.fill(0xa5, output, output + capacity + 32)
+    new Uint32Array(wasm.memory.buffer, metadata, 6).set([
+        0, compressed.length, expected.length, 8, options.crc ?? crc32(expected),
+    ])
+    const status = wasm.inflate_and_join_term_banks(
+        input,
+        compressed.length,
+        metadata,
+        metadata + 4,
+        metadata + 8,
+        metadata + 12,
+        metadata + 16,
+        1,
+        output,
+        capacity,
+    )
+    expect([...heap.subarray(output + capacity, output + capacity + 32)]).toEqual(new Array(32).fill(0xa5))
+    return {status, output: heap.slice(output, output + Math.max(0, status))}
+}
+
+const distances = [1, 2, 3, 4, 7, 8, 9, 15, 16, 17, 31, 32, 33, 63, 64, 65, 127, 128, 129, 255, 256, 257, 258, 259, 512, 1024, 4096, 32768]
+const lengths = [3, 8, 9, 15, 16, 17, 31, 32, 63, 64, 127, 128, 255, 256, 257, 258]
+describe('WASM DEFLATE history and bit buffers', () => {
+    test.each(distances)('preserves known match distance %i across lengths and alignments', (distance) => {
+        for (const length of lengths) {
+            for (const padding of [0, 1, 7, 15]) {
+                const fixture = fixedMatch(distance, length, padding)
+                expect(inflateRawSync(fixture.compressed).equals(Buffer.from(fixture.expected))).toBe(true)
+                const result = inflate(fixture.compressed, fixture.expected)
+                expect(result.status).toBe(fixture.expected.length)
+                expect(Buffer.from(result.output).equals(Buffer.from(fixture.expected))).toBe(true)
+            }
+        }
+    })
+
+    test.each([0, 1, 6, 9])('preserves compressor-produced blocks at level %i', (level) => {
+        const text = JSON.stringify([Array.from({length: 4096}, (_, i) => `${i % 37}:日本語と🙂:${'abc'.repeat(i % 19)}`)])
+        const expected = new TextEncoder().encode(text)
+        const compressed = deflateRawSync(expected, {level})
+        const result = inflate(compressed, expected)
+        expect(result.status).toBe(expected.length)
+        expect(Buffer.from(result.output).equals(Buffer.from(expected))).toBe(true)
+    })
+
+    test('still rejects CRC errors, truncated data, and insufficient capacity', () => {
+        const {compressed, expected} = fixedMatch(257, 258, 7)
+        expect(inflate(compressed, expected, {crc: crc32(expected) ^ 1}).status).toBeLessThan(0)
+        expect(inflate(compressed.subarray(0, -2), expected).status).toBeLessThan(0)
+        expect(inflate(compressed, expected, {capacity: expected.length}).status).toBeLessThan(0)
+    })
+})


### PR DESCRIPTION
## HOLD: do not promote as a whole-import speed improvement

[Final inspected decision and confirmation results](https://github.com/ManabiIO/manabitan/blob/perf-bounded-inflate64-20260909/dev/perf/inflate64-decision-20260909.md) · [Full implementation, correctness, component and earlier import evidence](https://github.com/ManabiIO/manabitan/blob/perf-bounded-inflate64-20260909/dev/perf/inflate64-followup-20260909.md)

The latest complete JMnedict comparison is **6.35% slower by paired median, 8.57% slower across equal measured work, and slower in all 6/6 pairs**. A faster decompression component does not override that whole-import concern. Keep this PR draft and out of release integration.

## Exact committed production source

Stacked on #26 at `925421edcb5262dd99f8879818c86fbace8e458a`. Performance control: #24 `ff9cbf2e848a86d6bbfd281179a6d753349e52f4`. Actual product/test candidate: **`dc226aaf88a0f8d2d4b2bcc37778352be0104622`**. Later commits change verification tools and documentation only.

Reuse only the WebAssembly i64 capability selection from #22, **not its history-copy change**. Adding `__wasm__` to miniz's capability heuristic selects its existing 64-bit DEFLATE bit buffer on wasm32. Header blob `22d72694d7361cc2642e845a7136eb38e6afeb63`, SHA-256 `619fbff2e98605a83f327a2879d52f219b5edaa579036a657937910f0707a43b`. No changes to validation, CRC/size/trailing checks, history copying, batches, memory budgets, workers, grammar, caches or persisted formats. CI builds committed production source, never a patched source tree.

## Completed correctness and component verification

Independent correctness jobs in [34332509223](https://github.com/ManabiIO/manabitan/actions/runs/34332509223) and [34333540881](https://github.com/ManabiIO/manabitan/actions/runs/34333540881) passed and their raw evidence was downloaded and inspected:

- **5,511 unit tests**, 46 existing skips; **25 options tests**; all four strict TypeScript projects and all-target dry builds passed per runner.
- **3,847 native miniz cases per bit-buffer width under ASan+UBSan**, leak detection enabled, per runner and locally. Independent zlib bytes, streaming boundaries, exact consumption, truncations and guard pages. Affected-core coverage, not whole-browser sanitization; no TSan claim.
- **4,434 complete-production-WASM oracle cases**: 4,096 synthetic plus **338 full fixed dictionary banks**, **754,052,959 decoded bytes**. Exact equality with both controls and an independent inflater/array-join oracle. This is exhaustive at that boundary, **not exhaustive persisted-database equivalence**.
- Final typed oracle again passed all 4,434 cases locally. Focused ESLint, strict test types and same-binary oracle passed in [34336244322](https://github.com/ManabiIO/manabitan/actions/runs/34336244322), without weakening rules. Strict Chromium integration passed in [34332513883](https://github.com/ManabiIO/manabitan/actions/runs/34332513883); its overall matrix was not green.

Actual inflation/CRC/array-join call, six alternating resident-input pairs and excluded warmup per dictionary/environment; setup and verification outside timing. Paired elapsed medians:

| Dictionary | Local | CI 1 | CI 2 |
|---|---:|---:|---:|
| JMdict | -5.73% | -8.40% | -9.73% |
| JMnedict | -5.60% | -12.10% | -8.17% |
| Jitendex | -3.41% | -6.88% | -9.07% |

CPU medians also fell in every cell; slower individual observations remain. **These are component results, not whole-import, peak-memory, Reader or iPhone gains.**

## Complete whole-import JMnedict evidence

Each lane separately completed all 18 fresh-profile imports: six alternating A/B pairs, two interleaved same-binary pairs and excluded warmup pair. Trial 2 reverses initial order. Native page/worker memory classification is observed, not overridden. Timing stays file-input-change to post-UI completion. No retries, outlier deletion, pooling independent hosts or splicing jobs.

| Run / lane | Paired median | Equal-work total | Faster pairs | Worst pair |
|---|---:|---:|---:|---:|
| 34333540881 / 1 | +3.53% | -0.87% | 2/6 | +22.69% |
| 34333540881 / 2 | -10.39% | -11.40% | 4/6 | +29.99% |
| 34335944244 / 1 | -2.92% | -1.31% | 4/6 | +24.14% |
| **34335944244 / 2** | **+6.35%** | **+8.57%** | **0/6** | +21.51% |

The last lane's same-binary pairs changed -2.12% and +2.61%; other hosts have substantially larger noise. The six consistently slower pairs are an acceptance concern, not proof of their mechanism. All earlier favorable and unfavorable results are retained.

All six artifacts from run 34333540881 were SHA-verified, and all **65 retained successful reports** independently revalidated. Only its two JMnedict lanes completed; JMdict lane 1 retained 10/18, Jitendex lanes 1/2 10/18 and 9/18 before cancellation, and JMdict lane 2 failed before importing at settings startup. Incomplete lanes receive **no effect estimates**. The two later complete JMnedict artifacts add **36 revalidated reports**; 101 retained reports total is not 101 independent pairs. The final decision document identifies every inspected artifact and limitations on uninspected later lanes.

## Verification repairs and retained failures

The first driver wrongly expected a per-WASM hash field absent from schema 3. It now verifies actual build bytes, complete package hash and the unique packaged WASM member before benchmarking and after each run; original source/report ZIP checks remain. Six rejection tests cover missing, duplicate and changed bytes. Failed initial plans receive no effect estimate.

Focused lint initially found the `.mjs` oracle outside configured projects. It is now typed under the existing test project and passes focused lint/types. No production code, benchmark timing or acceptance checks were relaxed.

## Integration decision

Do not merge this candidate to claim a general speedup. Keep #24's original JMnedict concern and the parent-stack gates separate. Next work should attribute whole-import parsing, copying/compression, storage and wait costs instead of stacking unrelated candidates to hide the slower results. Concurrent #27/#29 copy experiments are not included. Reconcile the selected #25/#22 release ancestry separately and apply the shared header change only once if later accepted.

No release branch, Reader vendor pointer, private native importer or v3-hotfix branch was modified or merged by this work.