### PR TITLE
[Rejected / retained evidence] Shared-span compression gather experiment

### DIFF
--- a/dev/lib/zstd-wasm.js
+++ b/dev/lib/zstd-wasm.js
@@ -320,6 +320,11 @@ export function prepareSpanCompression(
         throw new RangeError('Zstd output buffer size exceeds the safe integer range');
     }
     const buffers = ensureContextBuffers(context, contentBytes, destinationSize, dictionary.byteLength);
+    // The parser may lend shared bytes, but the compression heap must own a
+    // stable copy before this synchronous gather releases that source.
+    const sharedSource = typeof SharedArrayBuffer !== 'undefined' &&
+    source.buffer instanceof SharedArrayBuffer && !(module.HEAPU8.buffer instanceof SharedArrayBuffer);
+    const alignmentDelta = (module.HEAPU8.byteOffset + buffers.source - source.byteOffset) & 7;
     let outputOffset = 0;
     for (let i = 0; i < sourceOffsets.length;) {
         const runOffset = sourceOffsets[i];
@@ -343,10 +348,18 @@ export function prepareSpanCompression(
             ++runSpanCount;
             ++i;
         } while (i < sourceOffsets.length);
-        module.HEAPU8.set(
-            source.subarray(runOffset, runOffset + runLength),
-            buffers.source + outputOffset,
-        );
+        const destinationOffset = buffers.source + outputOffset;
+        const prefix = sharedSource && runLength >= 1024 ? (alignmentDelta + outputOffset - runOffset) & 7 : 0;
+        if (prefix !== 0) {
+            // Match source/destination alignment for the shared bulk copy, then
+            // shift only private bytes and fill the short prefix. No scratch
+            // allocation, source padding or out-of-span read is required.
+            module.HEAPU8.set(source.subarray(runOffset + prefix, runOffset + runLength), destinationOffset);
+            module.HEAPU8.copyWithin(destinationOffset + prefix, destinationOffset, destinationOffset + runLength - prefix);
+            module.HEAPU8.set(source.subarray(runOffset, runOffset + prefix), destinationOffset);
+        } else {
+            module.HEAPU8.set(source.subarray(runOffset, runOffset + runLength), destinationOffset);
+        }
         outputOffset += runLength;
     }
     if (outputOffset !== contentBytes) {

--- a/test/zstd-wasm.test.js
+++ b/test/zstd-wasm.test.js
@@ -7,6 +7,8 @@
  * (at your option) any later version.
  */
 
+import fs from 'node:fs/promises';
+
 import {beforeEach, describe, expect, test, vi} from 'vitest';
 
 const mockState = vi.hoisted(() => ({
@@ -21,6 +23,127 @@ describe('zstd wasm wrapper', () => {
     beforeEach(() => {
         vi.resetModules();
         vi.clearAllMocks();
+    });
+
+    test.each(Array.from({length: 8}, (_, index) => index))('owns exact gathered bytes for source alignment %i and every destination alignment', async (sourceAlignment) => {
+        for (const shared of [false, true]) {
+            for (let destinationAlignment = 0; destinationAlignment < 8; ++destinationAlignment) {
+                const module = createMockModule({heap: new Uint8Array(65536), allocations: [512 + destinationAlignment, 40000, 41000]});
+                module.HEAPU8.fill(165);
+                mockState.createModule.mockResolvedValue(module);
+                vi.resetModules();
+                const {init, prepareSpanCompression} = await import('../dev/lib/zstd-wasm.js');
+                await init();
+                const backing = shared ? new SharedArrayBuffer(20000) : new ArrayBuffer(20000);
+                const source = new Uint8Array(backing, 16 + sourceAlignment, 19000);
+                for (let i = 0; i < source.length; ++i) { source[i] = (i * 131 + Math.floor(i / 256)) & 255; }
+                const offsets = new Uint32Array([3, 4, 9, 1032, 2056, 4000, 12200]);
+                const lengths = new Uint32Array([1, 2, 1023, 1024, 1025, 8193, 0]);
+                const expected = Uint8Array.from([...offsets].flatMap((offset, i) => [...source.subarray(offset, offset + lengths[i])]));
+                const before = Uint8Array.from(source);
+                const prepared = prepareSpanCompression(23, source, offsets, lengths, expected.length, new Uint8Array([30, 31]), 12, 1, true);
+                const start = prepared.buffers.source;
+                expect(module.HEAPU8.subarray(start, start + expected.length)).toEqual(expected);
+                expect(source).toEqual(before);
+                expect(module.HEAPU8[start - 1]).toBe(165);
+                expect(module.HEAPU8[start + expected.length]).toBe(165);
+                expect(module._malloc).toHaveBeenNthCalledWith(1, expected.length);
+                expect(module._malloc).toHaveBeenNthCalledWith(2, 76);
+                expect(module._malloc).toHaveBeenNthCalledWith(3, 2);
+                source.fill(0);
+                expect(module.HEAPU8.subarray(start, start + expected.length)).toEqual(expected);
+                expect(module._ZSTD_compress_usingDict).not.toHaveBeenCalled();
+            }
+        }
+    });
+
+    test('keeps shared-destination gathers on the ordinary set path', async () => {
+        const module = createMockModule({heap: new Uint8Array(new SharedArrayBuffer(16384))});
+        const copyWithin = vi.spyOn(module.HEAPU8, 'copyWithin');
+        mockState.createModule.mockResolvedValue(module);
+        const {init, prepareSpanCompression} = await import('../dev/lib/zstd-wasm.js');
+        await init();
+        const source = new Uint8Array(new SharedArrayBuffer(4100), 1, 4097);
+        source.fill(57);
+        const prepared = prepareSpanCompression(23, source, new Uint32Array([0]), new Uint32Array([4097]), 4097, new Uint8Array(), 0);
+        expect(module.HEAPU8.subarray(prepared.buffers.source, prepared.buffers.source + 4097)).toEqual(Uint8Array.from(source));
+        expect(copyWithin).not.toHaveBeenCalled();
+    });
+
+    test('handles a nonzero destination view offset without touching its guards', async () => {
+        const heap = new Uint8Array(new ArrayBuffer(16384), 3, 16000);
+        heap.fill(165);
+        const copyWithin = vi.spyOn(heap, 'copyWithin');
+        const module = createMockModule({heap});
+        mockState.createModule.mockResolvedValue(module);
+        const {init, prepareSpanCompression} = await import('../dev/lib/zstd-wasm.js');
+        await init();
+        const source = new Uint8Array(new SharedArrayBuffer(4100), 1, 4097);
+        for (let i = 0; i < source.length; ++i) { source[i] = i & 255; }
+        const prepared = prepareSpanCompression(23, source, new Uint32Array([0]), new Uint32Array([4097]), 4097, new Uint8Array(), 0);
+        const start = prepared.buffers.source;
+        expect(copyWithin).toHaveBeenCalledOnce();
+        expect(heap.subarray(start, start + 4097)).toEqual(Uint8Array.from(source));
+        expect(heap[start - 1]).toBe(165);
+        expect(heap[start + 4097]).toBe(165);
+    });
+
+    test('rejects malformed large shared spans before compression', async () => {
+        const module = createMockModule({heap: new Uint8Array(16384)});
+        mockState.createModule.mockResolvedValue(module);
+        const {compressSpansUsingDictWithPrefix, init} = await import('../dev/lib/zstd-wasm.js');
+        await init();
+        const source = new Uint8Array(new SharedArrayBuffer(4100), 1, 4097);
+        /** @type {Array<[number[], number[], number]>} */
+        const cases = [
+            [[0], [], 4097],
+            [[4098], [0], 0],
+            [[1], [4097], 4097],
+            [[0], [4097], 4096],
+            [[0], [4096], 4097],
+            [[0], [1], -1],
+        ];
+        for (const [offsets, lengths, contentBytes] of cases) {
+            expect(() => compressSpansUsingDictWithPrefix(23, source, new Uint32Array(offsets), new Uint32Array(lengths), contentBytes, new Uint8Array(), 0)).toThrow(RangeError);
+        }
+        expect(module._ZSTD_compress_usingDict).not.toHaveBeenCalled();
+    });
+
+    test('preserves real compressed bytes and envelopes after shared source release', async () => {
+        const {default: createZstdModule} = /** @type {typeof import('../dev/lib/zstd-simd-module.js')} */ (await vi.importActual('../dev/lib/zstd-simd-module.js'));
+        const wasmBinary = await fs.readFile(new URL('../dev/data/zstd-simd.wasm', import.meta.url));
+        const module = await createZstdModule({wasmBinary});
+        mockState.createModule.mockResolvedValue(module);
+        const api = await import('../dev/lib/zstd-wasm.js');
+        await api.init();
+        const ordinaryContext = api.createCCtx();
+        const sharedContext = api.createCCtx();
+        const decodeContext = api.createDCtx();
+        const memory = new WebAssembly.Memory({initial: 1, maximum: 2, shared: true});
+        try {
+            for (const dictionary of [new Uint8Array(), new TextEncoder().encode('Japanese dictionary term content dictionary dictionary')]) {
+                for (let alignment = 0; alignment < 8; ++alignment) {
+                    for (const length of [1023, 1024, 8193]) {
+                        const source = new Uint8Array(memory.buffer, alignment, 2 * length + 2000);
+                        for (let i = 0; i < source.length; ++i) { source[i] = (i * 131 + Math.floor(i / 256)) & 255; }
+                        const offsets = new Uint32Array([3, 4, 25, 25 + length, 2 * length + 40]);
+                        const lengths = new Uint32Array([1, 2, length, 2, 1025]);
+                        const expected = Uint8Array.from([...offsets].flatMap((offset, i) => [...source.subarray(offset, offset + lengths[i])]));
+                        const baseline = api.compressUsingDictWithPrefix(ordinaryContext, expected, dictionary, 12, 1, true);
+                        const prepared = api.prepareSpanCompression(sharedContext, source, offsets, lengths, expected.length, dictionary, 12, 1, true);
+                        source.fill(0);
+                        if (dictionary.length === 0 && alignment === 0 && length === 8193) { memory.grow(1); }
+                        const candidate = api.finishPreparedSpanCompression(prepared);
+                        expect(candidate).toEqual(baseline);
+                        expect(api.decompressUsingDict(decodeContext, candidate.subarray(12), dictionary)).toEqual(expected);
+                    }
+                }
+            }
+        } finally {
+            api.freeCCtx(ordinaryContext);
+            api.freeCCtx(sharedContext);
+            api.freeDCtx(decodeContext);
+        }
     });
 
     test('compresses into a prefixed retained buffer with a raw dictionary', async () => {
@@ -203,11 +326,10 @@ describe('zstd wasm wrapper', () => {
 });
 
 /**
- * @param {{allocations?: number[]}} [options]
+ * @param {{allocations?: number[], heap?: Uint8Array}} [options]
  * @returns {import('core').SafeAny}
  */
-function createMockModule({allocations = []} = {}) {
-    const heap = new Uint8Array(4096);
+function createMockModule({allocations = [], heap = new Uint8Array(4096)} = {}) {
     let nextPointer = 512;
     const allocationQueue = [...allocations];
     const malloc = vi.fn((size) => {


### PR DESCRIPTION
## Closed unmerged: not established as a general whole-import win

Decision updated September 9, 2026 after independently downloading and SHA-256-verifying four artifacts from run **34333346731** and recomputing their raw observations. Preserve branch `perf-import-aligned-gather-20260909` at **`848b81cf5048a145e6ac11cc52a61e9130720b1e`**; no source rewrite or branch deletion. No open PR directly targets this branch.

Exact candidate source/test tree: `3055b20bb29e11e8dfd7282cd774249279835868`. Control is #24 `ff9cbf2e848a86d6bbfd281179a6d753349e52f4`, tree `dc3098b9acc761caf193952537d568652196dc76`, **not accepted develop and not #27**.

## Corrected whole-import evidence

Three ordinary Ubuntu 24.04 cohorts each completed the fixed plan: six alternating candidate/control pairs, excluded warmup pair, and one separate same-binary control pair. Positive change means slower. Hosts/cohorts are not pooled.

| Dictionary | Paired median change | Equal-work total change | Candidate faster | A/A change |
|---|---:|---:|---:|---:|
| JMdict | +0.78% | +0.42% | 2/6 | -3.72% |
| JMnedict | -0.12% | -3.48% | 3/6 | +2.32% |
| Jitendex | -2.94% | -3.42% | 5/6 | -0.74% |

The constrained `ubuntu-slim` JMdict plan is **incomplete: 11 of 16 planned observations**, comprising two warmups, four complete measured pairs, and one **unmatched fifth candidate**. Its four matched pair changes are **+14.85%, +1.21%, +13.91%, +4.34%**. All four are slower; this is a risk signal, not a formal completed-cohort estimate. Same-binary controls did not complete.

**Correction to the handoff:** the reported **+35.36% 'equal-work'** figure divides **five candidate imports by four baseline imports** and is invalid as equal-work evidence. The four matched-pair totals differ by **+8.59%**, and their observed paired median is +9.13%. These remain descriptive partial observations only, not an accepted effect estimate. The unmatched candidate (5127.4 ms) is retained, not silently discarded or assigned an invented baseline. No incomplete lanes are spliced.

The audit reread all 59 successful reports in these four inspected artifacts, checked plan order/source identities, matching validation/accounting within each cohort, production defaults, no profiling, OPFS-sahpool use, and exact browser file-input-change-to-completion timing against the stored observations. These are **reanalysed historical runs, not 59 new imports**. Persisted-content probes are sampled, not exhaustive database equality. Other constrained dictionary artifacts were not used for an effect claim.

Inspected artifact IDs / SHA-256:
- Ubuntu JMdict `10096755404`: `d5a04246e42db12c28d2f60a9c2f2f81351a30407730be878bacb13bf4ae39bd`
- Ubuntu JMnedict `10096761245`: `86664176e12d17adb82e720ab756d7d378c2aae3bada023b84c3fbe3e8e88b88`
- Ubuntu Jitendex `10096779291`: `e071d1c48f608483473cebe34d8cb38859c725818e7ab416c6c7f91d1dbda4b0`
- Slim JMdict `10097239300`: `4f4a790087e0aaf19daadeaa9a64458c7cfdfbf86b4f123df7e58fbb6d0a275d`

Run: https://github.com/ManabiIO/manabitan/actions/runs/34333346731

## Preserved implementation and earlier correctness evidence

The two-file diff changes only `dev/lib/zstd-wasm.js` and `test/zstd-wasm.test.js`. For large shared-source spans with mismatched alignment, gather via an alignment-matched load, move private destination bytes, then copy the short prefix. No scratch allocation, padding, retained-byte/cache-policy change, source-release-order change, compression-level change or persistent-format change. Ordinary/small/aligned sources and shared destinations retain `TypedArray.set`. This is not a concurrent shared-memory snapshot protocol.

Earlier local and independent validation reported 5,490 unit tests passed, 46 existing skips, 12 new tests, 25 options tests, strict types, focused lint and all-target builds. Real Zstd tests compare complete compressed envelopes and decompressed bytes after source mutation/shared WASM growth. Coverage includes all alignment combinations, nonzero destination offsets, guard bytes and malformed spans. Those historical correctness results are retained; this audit reviewed the exact implementation/tests but does not relabel those results as new execution.

Source validation: https://github.com/ManabiIO/manabitan/actions/runs/34332962536 . Packaged changes remain only the wrapper and its source map; WASM and other payloads are unchanged in the retained package comparison. The initial packaging assertion omitted the expected source map; that pre-benchmark failure remains historical evidence.

## Future integration boundary

Current accepted develop is `da8f7436d34e510441d30692c8d698806b70e13f` (#25 + #22). Its `prepareSpanCompression` path exists and still uses the ordinary coalesced gather; this was read directly during the audit. Closing this experiment does not prove the helper can never be improved. Revisit only as an isolated new hypothesis on that accepted ancestry with fresh Chromium/Firefox, low-memory and complete fixed-plan A/B/A/A qualification. Do not merge this old #20/#23/#24 ancestry wholesale or revive the rejected term-bank parser. #24's independent JMnedict gate remains open. No release branch or Reader pointer changed.