### PR TITLE
perf(import): coalesce adjacent interned-key copies without changing stored bytes

### DIFF
--- a/dev/perf/term-plan-copy-runs-20260909.md
+++ b/dev/perf/term-plan-copy-runs-20260909.md
@@ -1,0 +1,60 @@
+# Interned-key copy coalescing — September 9, 2026
+
+## Decision
+
+**Draft #30: tested allocation reduction, not a demonstrated general whole-import speedup. Nothing merged.**
+
+This is a new production optimization on #24, separate from #26's verification-only work. The favorable preliminary three-pair JMnedict observation did not repeat in the six-pair local confirmation. Do not advertise the early 10.6% paired-median result as a confirmed improvement or treat this as resolution of #24's JMnedict gate.
+
+## Exact source and change
+
+Baseline: `ff9cbf2e848a86d6bbfd281179a6d753349e52f4`, tree `dc3098b9acc761caf193952537d568652196dc76`.
+
+Candidate source/test commit: `3ef73a422410d2f0ac0be00fb8e618a4c7949416`, tree `75d9ba432ad37413b720ff2677a1dd8e6006040d`. Later documentation does not change measured code.
+
+`compactTermRecordPreinternedPlan` previously created a subarray view and performed a typed-array copy for every referenced expression/reading key. It now copies adjacent source ranges together, preserving first-reference order and flushing on gaps or reordered nonempty keys. Zero-length keys retain metadata without empty copies. Output remains an independent, exact-sized arena; no parser slab is borrowed.
+
+Lengths, offsets, hashes, row remaps, scratch cleanup, and full structural validation remain unchanged. No parser/WASM/ZIP, persistent format, compression level, source budget, cache bound, global worker setting, or UI change is included. The 4,096-key contiguous regression fixture needs one source view instead of 4,096; this is not a claim that every real dictionary is one contiguous run.
+
+Both local packaged builds differ in exactly one payload: `js/dictionary/term-record-preinterned-plan.js`. Local reconstructed Git commits have synthetic IDs but match the exact remote trees. Independent jobs check out the actual remote commits, require clean sources, verify the sole packaged difference, and freeze package hashes before and after timing.
+
+## Complete confirmation results inspected so far
+
+Negative change means faster. Paired change is the median of within-pair ratios; aggregate change compares total time across equal work. Neither is the ratio of the separate median durations.
+
+| Environment | Dictionary | Pairs | Paired change | Aggregate change | Faster pairs |
+| --- | --- | ---: | ---: | ---: | ---: |
+| Local | JMnedict | 6 | +1.47% | +1.82% | 2/6 |
+| Local | JMdict | 6 | +1.43% | +0.92% | 2/6 |
+| Local | Jitendex | 6 | -0.97% | -0.28% | 4/6 |
+| Independent higher-memory | JMnedict | 4 | -1.71% | -1.36% | 3/4 |
+| Independent higher-memory | JMdict | 4 | -2.15% | -2.02% | 3/4 |
+| Independent higher-memory | Jitendex | 4 | -0.37% | -0.23% | 3/4 |
+
+Every cell's exploratory paired-median percentile interval includes zero. Same-build A/A and B/B controls in the independent lanes vary by up to approximately 4%, comparable to these candidate effects. These small shared-host comparisons do not establish universal performance or non-regression. Runners and exploratory/confirmation samples are never pooled.
+
+Local confirmation has 36 measured imports and six excluded warmups. Each independent complete lane has eight A/B imports, two excluded warmups and four same-build-control imports. Fixed adjacent AB/BA order, fresh browser profiles, pinned dictionaries, unchanged production defaults, no outlier removal, no import retries. The unchanged schema-3 timing runs from the browser file-input change event through post-UI import completion. Tracing, phase profiling, screenshots and process sampling are disabled during timing.
+
+The local median sum of reported compaction-phase wall times falls from 170.85 to 125.0 ms for JMnedict and 195.05 to 141.1 ms for Jitendex. These overlapping internal phase counters are not active CPU time or quantities to subtract from total elapsed time. Faster compaction did not produce a consistent whole-import improvement.
+
+Runtime: Node 24.20.0, Playwright 1.63, Chromium 153.0.8010.12. Local cgroup: 4 GiB and four-core quota, clang 17. A separate post-timing native page/worker check reports deviceMemory=4 and 168 exposed hardware threads; the latter is not the CPU quota. Independent higher-memory preflights report deviceMemory=16 and four hardware threads. No browser memory value was overridden. Constrained lanes are kept separate and are not included in this table without complete reports.
+
+## Correctness
+
+Two inspected independent validations of the exact source/test tree pass **5,495 unit tests, 46 existing skips, 159 files; 25 options tests; all four strict TypeScript projects; new-test lint; all-target dry builds; and strict Chromium integration with 86 phases and no skipped verification**. Local full units/types/options/builds also pass, with the final 17 new tests repeated after test-only lint cleanup.
+
+The new tests cover contiguous, gapped, reversed, repeated, omitted, empty and maximum-length keys; nonzero byte offsets; SharedArrayBuffer inputs; independent output ownership; equality masks; optional offsets/hashes; malformed unreferenced metadata; and 1,000 seeded uneven plans compared with an independent per-key-copy oracle.
+
+All **84 reports** in the complete local and higher-memory confirmation plans were re-audited for exact locked title/revision/row counts, 12 persisted-content readability probes each, no import/settings errors or fallback storage, complete bank counts and compressed/decoded source bytes, and identical deduplication counters within pairs. Independent report source SHAs match their pinned identities. These are sampled content probes and accounting checks, not exhaustive database byte equivalence.
+
+Firefox, ARM/Android, smaller-memory systems, and repository-wide lint are not newly qualified. Inherited #24/#23/#20 release gates remain separate.
+
+## Verification failures and evidence
+
+Earlier runs [34337033172](https://github.com/ManabiIO/manabitan/actions/runs/34337033172) and [34337652717](https://github.com/ManabiIO/manabitan/actions/runs/34337652717) did not complete their performance plans. The inspected failed JMnedict artifacts show an audit-script fixture-schema error after a warmup: it treated the lock's keyed mapping as a list and expected `title` instead of `expectedTitle`. This was verification code, not importer failure. Initial suspicion about dependency-symlink cleanliness was not supported by those downloaded failure reports. The corrected audit was exercised against all 42 local confirmation reports. Final comparison workspaces use ordinary locked dependency directories and retain clean-tree and single-payload-difference gates.
+
+[Final independent verification 34338285732](https://github.com/ManabiIO/manabitan/actions/runs/34338285732) uses verification-only commit `3b123cb294c3e8bc74bdecbe953e6bf787f64ac2`, while pinning product source to `3ef73a4...`. Earlier failed/incomplete matrices are not presented as green, and no incomplete lane receives an effect estimate.
+
+Inspected final higher-memory artifacts: JMnedict `10098712452`, JMdict `10098728991`, Jitendex `10098724685`; exact-source correctness `10098781680` and earlier `10098289326`. Downloaded final artifacts were SHA-256 checked against GitHub's artifact digests. Full pairs, interval calculations, re-audit records, local reports, inspected independent artifacts, source/test patch and setup failures are preserved in the delivered evidence archive without fonts, dictionary ZIPs, dependencies, browser runtimes or generated extension binaries.
+
+Keep this PR draft until the benefit justifies promotion. Do not merge on the preliminary sample or component counters alone. No older PR, release branch, or Reader vendor pointer was modified.

--- a/ext/js/dictionary/term-record-preinterned-plan.js
+++ b/ext/js/dictionary/term-record-preinterned-plan.js
@@ -398,11 +398,26 @@ export function compactTermRecordPreinternedPlan(plan, start, count, remapScratc
     }
     const stringsBuffer = new Uint8Array(stringsByteLength);
     let cursor = 0;
+    let runStart = 0;
+    let runEnd = 0;
     for (const oldIndex of referencedOldIndexes) {
         const oldOffset = sourceStringOffsets[oldIndex];
         const length = plan.stringLengths[oldIndex];
-        stringsBuffer.set(plan.stringsBuffer.subarray(oldOffset, oldOffset + length), cursor);
-        cursor += length;
+        if (length === 0) { continue; }
+        // Parser plans intern strings in encounter order. Copy adjacent source
+        // ranges together instead of allocating one view per referenced key.
+        // A gap or reordered key must end the run; unreferenced bytes stay out.
+        if (oldOffset !== runEnd) {
+            if (runEnd > runStart) {
+                stringsBuffer.set(plan.stringsBuffer.subarray(runStart, runEnd), cursor);
+                cursor += runEnd - runStart;
+            }
+            runStart = oldOffset;
+        }
+        runEnd = oldOffset + length;
+    }
+    if (runEnd > runStart) {
+        stringsBuffer.set(plan.stringsBuffer.subarray(runStart, runEnd), cursor);
     }
     return {stringLengths, stringOffsets, stringHashes, stringsBuffer, expressionIndexes, readingIndexes};
 }

--- a/test/term-plan-copy-runs.test.js
+++ b/test/term-plan-copy-runs.test.js
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2026 Manabitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import {describe, expect, test, vi} from 'vitest';
+import {compactTermRecordPreinternedPlan} from '../ext/js/dictionary/term-record-preinterned-plan.js';
+
+/** @typedef {import('../ext/js/dictionary/term-record-preinterned-plan.js').PreinternedTermRecordPlan} Plan */
+
+/**
+ * @param {number[][]} keys
+ * @param {number[]} expressions
+ * @param {number[]} readings
+ * @param {boolean} [shared]
+ * @returns {Plan}
+ */
+function createPlan(keys, expressions, readings, shared = false) {
+    const flattened = keys.flat();
+    const storage = shared ? new SharedArrayBuffer(flattened.length + 13) : new ArrayBuffer(flattened.length + 13);
+    const allBytes = new Uint8Array(storage);
+    allBytes.fill(0xee);
+    // Exercise a nonzero byteOffset; offsets in a plan are relative to its view.
+    const stringsBuffer = new Uint8Array(storage, 7, flattened.length);
+    stringsBuffer.set(flattened);
+    let offset = 0;
+    return {
+        stringsBuffer,
+        stringLengths: Uint16Array.from(keys, (key) => key.length),
+        stringOffsets: Uint32Array.from(keys, (key) => {
+            const result = offset;
+            offset += key.length;
+            return result;
+        }),
+        stringHashes: Uint32Array.from(keys, (_, index) => (index * 97) >>> 0),
+        expressionIndexes: Uint32Array.from(expressions),
+        readingIndexes: Uint32Array.from(readings),
+    };
+}
+
+/**
+ * Independent per-key copy oracle: no contiguous-range inference.
+ * @param {Plan} plan
+ * @param {number} start
+ * @param {number} count
+ * @param {boolean[]|Uint8Array} [equal]
+ * @returns {Plan}
+ */
+function referenceCompact(plan, start, count, equal) {
+    const sourceOffsets = [];
+    let offset = 0;
+    for (const length of plan.stringLengths) {
+        sourceOffsets.push(offset);
+        offset += length;
+    }
+    /** @type {Map<number, number>} */
+    const remap = new Map();
+    const expressions = [];
+    const readings = [];
+    /**
+     * @param {number} oldIndex
+     * @returns {number}
+     */
+    const intern = (oldIndex) => {
+        let index = remap.get(oldIndex);
+        if (typeof index === 'undefined') {
+            index = remap.size;
+            remap.set(oldIndex, index);
+        }
+        return index;
+    };
+    for (let row = start; row < start + count; ++row) {
+        const expression = plan.expressionIndexes[row];
+        expressions.push(intern(expression));
+        readings.push(intern(equal?.[row] === true || equal?.[row] === 1 ? expression : plan.readingIndexes[row]));
+    }
+    const keys = [...remap.keys()];
+    const outputOffsets = [];
+    const outputBytes = [];
+    for (const key of keys) {
+        outputOffsets.push(outputBytes.length);
+        for (let i = 0; i < plan.stringLengths[key]; ++i) {
+            outputBytes.push(plan.stringsBuffer[sourceOffsets[key] + i]);
+        }
+    }
+    return {
+        stringsBuffer: Uint8Array.from(outputBytes),
+        stringOffsets: Uint32Array.from(outputOffsets),
+        stringLengths: Uint16Array.from(keys, (key) => plan.stringLengths[key]),
+        stringHashes: plan.stringHashes ? Uint32Array.from(keys, (key) => /** @type {Uint32Array} */ (plan.stringHashes)[key]) : void 0,
+        expressionIndexes: Uint32Array.from(expressions),
+        readingIndexes: Uint32Array.from(readings),
+    };
+}
+
+/**
+ * @param {Plan} plan
+ * @param {number} start
+ * @param {number} count
+ * @param {boolean[]|Uint8Array} [equal]
+ * @returns {Plan|null}
+ */
+function check(plan, start, count, equal) {
+    const expected = referenceCompact(plan, start, count, equal);
+    const before = new Uint8Array(new Uint8Array(plan.stringsBuffer.buffer));
+    const scratch = new Uint32Array(plan.stringLengths.length);
+    const actual = compactTermRecordPreinternedPlan(plan, start, count, scratch, equal);
+    expect(actual).toStrictEqual(expected);
+    expect(actual?.stringsBuffer.buffer).not.toBe(plan.stringsBuffer.buffer);
+    expect(actual?.stringsBuffer.byteOffset).toBe(0);
+    expect(new Uint8Array(plan.stringsBuffer.buffer)).toStrictEqual(before);
+    expect(scratch.every((value) => value === 0)).toBe(true);
+    return actual;
+}
+
+describe('compacted term-plan contiguous copy runs', () => {
+    test('copies thousands of adjacent keys with a single source view', () => {
+        const keys = Array.from({length: 4096}, (_, i) => [i & 255, (i >>> 8) & 255, 0]);
+        const indexes = keys.map((_, i) => i);
+        const plan = createPlan(keys, indexes, indexes);
+        const subarray = vi.spyOn(plan.stringsBuffer, 'subarray');
+        check(plan, 0, indexes.length);
+        expect(subarray).toHaveBeenCalledTimes(1);
+        expect(subarray).toHaveBeenCalledWith(0, 4096 * 3);
+    });
+
+    test.each([
+        {name: 'gaps', order: [0, 2, 3], runs: 2},
+        {name: 'reverse order', order: [3, 2, 1, 0], runs: 4},
+        {name: 'repeated keys', order: [0, 0, 1, 1, 2, 3], runs: 1},
+        {name: 'initial and final omitted keys', order: [1, 2], runs: 1},
+        {name: 'one key', order: [2], runs: 1},
+        {name: 'empty selection', order: [], runs: 0},
+    ])('preserves $name without copying unreferenced ranges', ({order, runs}) => {
+        const plan = createPlan([[0, 1], [10, 11, 12], [20], [30, 31]], order, order);
+        const subarray = vi.spyOn(plan.stringsBuffer, 'subarray');
+        check(plan, 0, order.length);
+        expect(subarray).toHaveBeenCalledTimes(runs);
+    });
+
+    test('keeps first-reference expression/reading order, not source order', () => {
+        check(createPlan([[1], [2, 3], [4], [5, 6]], [2, 0], [3, 1]), 0, 2);
+    });
+
+    test.each([false, true])('supports shared=%s source slabs without borrowing the output', (shared) => {
+        const plan = createPlan([[1, 2], [3], [4, 5]], [0, 1, 2], [0, 1, 2], shared);
+        const compact = check(plan, 0, 3);
+        plan.stringsBuffer.fill(99);
+        expect(compact?.stringsBuffer).toStrictEqual(Uint8Array.from([1, 2, 3, 4, 5]));
+    });
+
+    test('coalesces through referenced and unreferenced zero-length keys', () => {
+        const plan = createPlan([[1], [], [2, 3], [], [4]], [1, 0, 2, 4], [1, 0, 2, 4]);
+        const subarray = vi.spyOn(plan.stringsBuffer, 'subarray');
+        check(plan, 0, 4);
+        expect(subarray).toHaveBeenCalledTimes(1);
+    });
+
+    test('preserves zero-byte referenced strings without copying', () => {
+        const plan = createPlan([[], [], []], [2, 0, 1], [1, 2, 0]);
+        const subarray = vi.spyOn(plan.stringsBuffer, 'subarray');
+        const compact = check(plan, 0, 3);
+        expect(compact?.stringLengths).toHaveLength(3);
+        expect(subarray).not.toHaveBeenCalled();
+    });
+
+    test.each([false, true])('supports optional offsets/hashes and nonzero row start, typed equality=%s', (typed) => {
+        const plan = createPlan([[1], [], [2, 3], [4]], [3, 0, 2], [0, 1, 3]);
+        Reflect.deleteProperty(plan, 'stringOffsets');
+        Reflect.deleteProperty(plan, 'stringHashes');
+        check(plan, 1, 2, typed ? Uint8Array.from([0, 1, 0]) : [false, true, false]);
+    });
+
+    test('retains full structural validation even for an unreferenced malformed key', () => {
+        const plan = createPlan([[1], [2], [3]], [0], [0]);
+        plan.stringOffsets = Uint32Array.from([0, 1, 1]);
+        const subarray = vi.spyOn(plan.stringsBuffer, 'subarray');
+        expect(() => compactTermRecordPreinternedPlan(plan, 0, 1, new Uint32Array(3))).toThrow('arena is out of bounds');
+        expect(subarray).not.toHaveBeenCalled();
+    });
+
+    test('preserves the maximum persisted key length', () => {
+        check(createPlan([new Array(65535).fill(65), [0], new Array(65535).fill(66)], [0, 2], [1, 2]), 0, 2);
+    });
+
+    test('matches independent per-key copying for 1000 deterministic uneven plans', () => {
+        let state = 0x13579bdf;
+        const next = () => {
+            state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+            return state;
+        };
+        for (let trial = 0; trial < 1000; ++trial) {
+            const keys = Array.from({length: 1 + next() % 40}, () => Array.from({length: next() % 21}, () => next() & 255));
+            const count = next() % 60;
+            const expressions = Array.from({length: count}, () => next() % keys.length);
+            const readings = Array.from({length: count}, () => next() % keys.length);
+            const plan = createPlan(keys, expressions, readings, trial % 7 === 0);
+            if (trial % 2 === 0) { Reflect.deleteProperty(plan, 'stringOffsets'); }
+            if (trial % 3 === 0) { Reflect.deleteProperty(plan, 'stringHashes'); }
+            const start = next() % (count + 1);
+            const size = next() % (count - start + 1);
+            const equal = Uint8Array.from({length: count}, () => next() % 2);
+            check(plan, start, size, equal);
+        }
+    });
+});


### PR DESCRIPTION
## Decision: keep draft — component reduction, not a confirmed general import-speed gain

This PR adds a new production optimization on #24. **The preliminary three-pair JMnedict result did not replicate in the larger local confirmation. Do not claim a general 10% gain or treat this as resolution of #24's JMnedict regression gate. Nothing was merged.**

Full source/validation notes: [`dev/perf/term-plan-copy-runs-20260909.md`](dev/perf/term-plan-copy-runs-20260909.md).

## What changes

`compactTermRecordPreinternedPlan` coalesces adjacent referenced source-byte ranges instead of creating a view and doing a typed-array copy for every key. Gaps or reordered nonempty keys terminate the run; zero-length keys keep metadata without empty copies. First-reference order, exact output bytes, independent output ownership, metadata, scratch cleanup and structural validation are preserved.

One runtime module, one new test file, plus documentation. No parser/WASM/ZIP, persistent format, compression level, source-budget, cache-bound, worker-default, or UI change. Not a slab-borrowing/cache-copy experiment. A 4,096-key contiguous fixture needs one source view instead of 4,096.

Baseline #24: `ff9cbf2e848a86d6bbfd281179a6d753349e52f4`.
Exact tested source/test commit: `3ef73a422410d2f0ac0be00fb8e618a4c7949416`, tree `75d9ba432ad37413b720ff2677a1dd8e6006040d`. Later documentation leaves tested code unchanged. Packaged arms differ in exactly the intended JavaScript payload; clean-tree and frozen package-identity gates remain enforced.

## Whole-import confirmation

Negative change means less time. Fixed adjacent AB/BA pairs, fresh profiles, pinned complete dictionaries, production defaults, excluded warmups; no import retries or removed outliers. Existing browser-event-to-post-UI-completion timing, without tracing/profiling/screenshots/process sampling during timing. Runners are not pooled.

| Environment | Dictionary | Pairs | Paired median change | Aggregate equal-work change | Faster pairs |
| --- | --- | ---: | ---: | ---: | ---: |
| Local | JMnedict | 6 | +1.47% | +1.82% | 2/6 |
| Local | JMdict | 6 | +1.43% | +0.92% | 2/6 |
| Local | Jitendex | 6 | -0.97% | -0.28% | 4/6 |
| Independent higher-memory | JMnedict | 4 | -1.71% | -1.36% | 3/4 |
| Independent higher-memory | JMdict | 4 | -2.15% | -2.02% | 3/4 |
| Independent higher-memory | Jitendex | 4 | -0.37% | -0.23% | 3/4 |

All six exploratory paired-median intervals include zero. Independent same-build control variation is comparable to these small effects. Compaction counters improve for JMnedict/Jitendex, but overlapping component times are not end-to-end gains. Constrained lanes are separate and receive no estimate without complete reports.

## Correctness and accounting

Two inspected independent validations of exact `3ef73a4...` passed **5,495 unit tests (46 existing skips), 25 options tests, all four strict TypeScript projects, new-test lint, all-target dry builds, and strict Chromium integration: 86 phases with no skipped verification**. Local checks also passed.

17 new tests cover ordering, gaps, repeated/zero/max-length keys, offset views, SharedArrayBuffer, output ownership, equality masks, optional metadata, malformed unreferenced strings, and 1,000 deterministic uneven plans against an independent per-key-copy oracle.

All **84 reports** from the complete local and higher-memory plans passed a repeated audit of locked metadata/row counts, full source-bank and compressed/decoded-byte accounting, pairwise dedup totals, errors/fallback checks, and 12 persisted-content probes each. Probes are sampled—not exhaustive database equivalence.

## Verification provenance and remaining gates

[Final independent workflow](https://github.com/ManabiIO/manabitan/actions/runs/34338285732), verification-only branch `verify/term-plan-copy-runs-20260909`, pins product source to `3ef73a4...`. The earlier inspected benchmark failures were in my audit script's assumption about the fixture-lock schema, not importer failures; their raw failures are preserved. Earlier overall matrices are not presented as green. The corrected audit was verified against all 42 local confirmation reports before accepting new comparisons.

This is separate from #26's replication and does not modify existing PRs, release branches, or vendor pointers. Firefox/ARM/mobile and inherited #24/#23/#20 release gates remain unqualified. Keep draft; no general import-speed or regression-free claim.