### PR TITLE
Speed up large constrained imports while preserving established single-batch transport

### DIFF
--- a/dev/perf/bounded-on-develop-20260909.md
+++ b/dev/perf/bounded-on-develop-20260909.md
@@ -1,0 +1,35 @@
+# Bounded compressed imports on accepted develop
+
+## Integration candidate, not a new speed claim
+
+This applies only the bounded source-planning/importer change and its tests from
+PR #24 (`ff9cbf2e848a86d6bbfd281179a6d753349e52f4`, relative to #23
+`b8d68458cde8788b5d5301ceaf36beae7a1363f9`) onto accepted develop
+`da8f7436d34e510441d30692c8d698806b70e13f`.
+
+The production parser stays at blob `836cb10f5aa52177bd82d6fbccb44dd5f3811e2b`.
+The accepted #22 inflater remains unchanged. The rejected #19 SIMD scanner,
+#23 composite-state experiment, custom ZIP splitter, and later copy/cache
+experiments are not imported. No old branch is rewritten or deleted.
+
+Low-memory plans retain the 64 MiB decoded-source budget, independently bound
+compressed inputs by 64 MiB, and retain the 80-file cap and ordinary fallback.
+These bound source batches, not whole-process memory. No worker defaults,
+compression level, persistent format, cache policy or release setting changes.
+
+## Acceptance
+
+Historical #24 percentages compare a different complete parser tree. They are
+not measurements of this candidate against accepted develop, and are not reused
+as release evidence. The earlier JMnedict slow-tail/equal-work concern remains
+open. A conflict-free patch and passing unit tests do not resolve it.
+
+Before promotion, execute full supported-browser correctness and fresh fixed
+A/B plans against this exact accepted baseline, with both constrained and
+higher-memory runtimes. Report paired changes, equal-work totals, all tails and
+same-binary controls separately for JMdict, JMnedict and Jitendex. Incomplete
+plans must receive no effect estimate. Verify actual parser/WASM/package and
+fixture identities; do not splice prior favorable results into this comparison.
+
+Keep draft until those gates pass. No general import-speed, Apple/phone,
+exhaustive persisted-database parity or release-readiness claim is made here.

--- a/dev/perf/bounded-on-develop-20260909.md
+++ b/dev/perf/bounded-on-develop-20260909.md
@@ -33,3 +33,9 @@ fixture identities; do not splice prior favorable results into this comparison.
 
 Keep draft until those gates pass. No general import-speed, Apple/phone,
 exhaustive persisted-database parity or release-readiness claim is made here.
+
+## Source and validation references
+
+[Original bounded-import comparison and limitations](https://github.com/ManabiIO/manabitan/pull/24).
+[Accepted inflater integration](https://github.com/ManabiIO/manabitan/pull/22).
+[Exact accepted-base source qualification](https://github.com/ManabiIO/manabitan/actions/runs/34395763103).

--- a/dev/perf/multibatch-admission-results-20260909.md
+++ b/dev/perf/multibatch-admission-results-20260909.md
@@ -1,0 +1,68 @@
+# Multi-batch compressed imports: measured gains on accepted develop
+
+## Decision and source
+
+The narrowed bounded-import candidate has repeatable local whole-import wins for JMdict and Jitendex. JMnedict has mixed small changes and no demonstrated improvement; no tight non-regression bound is claimed. Keep draft pending independent timing completion and final-head normal CI. Keep the unrelated rejected packing, parser and cache experiments out. This report qualifies the measured native 4 GiB Chromium configuration, not every device or dictionary. It is not a release merge or a universal non-regression guarantee.
+
+Performance baseline: accepted `develop` **da8f7436d34e510441d30692c8d698806b70e13f**. Parent review source: [PR #31](https://github.com/ManabiIO/manabitan/pull/31) at `03478be25506176610b2133be658ee697d9bb3f1`.
+
+Independently tested source/test commit: **`34839d51d9b2cda28806b4a3908cda88847de87d`**. Exact complete source/test tree: **`4035249c23197b72d8be9d4cca7ebd6476771ef1`**. The local reconstruction has a different commit identifier but exactly this Git tree. Documentation children do not change measured runtime code or tests.
+
+## What changes
+
+Use bounded compressed transport only when a low-memory import needs multiple ordinary source batches under the existing **64 MiB decoded-source / 80-file limits**. Imports fitting one ordinary batch keep the established decoded-source transport, including later planner calls after fallback. Small final batches of genuinely multi-batch imports remain eligible for compressed transport when the existing minimum bank count is met.
+
+The admission check is structural: there are no dictionary names, special-case fixture IDs, or new size thresholds. High/unknown-memory import-wide transport remains as inherited from PR #31; the new admission restriction is low-memory only. Claims here concern the constrained configuration, not a claim that every fallback path is byte-for-byte identical to accepted develop.
+
+The independent **64 MiB compressed-input bound**, integrity checks, cancellation/ownership rules, fallback paths and release-before-replan behavior remain. These are source-batch bounds, **not total process memory or WASM-heap bounds**. Parser/WASM, compression levels, cache capacities, worker defaults, storage formats, UI behavior and dependency locks are unchanged by this candidate. Packages built for the comparison differ in exactly two runtime JavaScript payloads: the dictionary importer and source pipeline. The parser and compression binaries are identical between arms within each environment.
+
+## Completed whole-import comparisons
+
+Negative change means less time. Each plan uses four fixed adjacent alternating A/B pairs per dictionary, one separately retained warmup pair, and baseline/candidate same-binary control pairs. The confirmation reverses initial ordering. Dictionary order rotates between pairs. Every observation uses a fresh browser profile and immutable, hash-checked fixtures. No retries, removed outliers, pooled environments or partial-plan effect estimates.
+
+Timing is the unchanged schema-3 browser **file-input change to current-operation post-UI completion** interval. It is not parser-only time, physical paint time, or browser startup time. Tracing, phase profiling, screenshots and process sampling are disabled during the measurements. Ordinary phase counters may overlap and are not added together as CPU time.
+
+| Plan                              | Dictionary | Baseline median ms | Candidate median ms | Median within-pair change | Equal-work total change | Faster pairs |
+| --------------------------------- | ---------- | -----------------: | ------------------: | ------------------------: | ----------------------: | -----------: |
+| Local fixed plan                  | jmnedict   |             1336.7 |              1309.8 |                    -1.83% |                  -1.83% |          3/4 |
+| Local fixed plan                  | jmdict     |             1685.5 |              1344.4 |                   -18.21% |                 -18.83% |          4/4 |
+| Local fixed plan                  | jitendex   |             3436.3 |              2696.9 |                   -20.78% |                 -20.89% |          4/4 |
+| Local reversed-order confirmation | jmnedict   |             1308.5 |              1345.7 |                    +2.46% |                  +1.22% |          1/4 |
+| Local reversed-order confirmation | jmdict     |             1697.7 |              1398.7 |                   -18.32% |                 -18.51% |          4/4 |
+| Local reversed-order confirmation | jitendex   |             3492.9 |              2690.3 |                   -23.27% |                 -22.54% |          4/4 |
+
+These are **84 successfully audited reports** across two separate local plans: 48 measured A/B imports, 12 excluded warmups, and 24 same-binary controls. The reports and full-precision values are retained separately. The final table was regenerated from every raw report and supersedes interim chat figures. JMnedict changes -1.83% and +2.46% by paired median, with -1.83% and +1.22% equal-work changes; its confidence intervals cross zero. Same-binary controls in these two plans range from -8.18% to +6.65%. Do not add these percentages to historical PR #24 gains: those used a different complete parser baseline.
+
+Local environment: Node 24.20.0, Chromium 153.0.8010.12, clang 17, Linux x64, native page/worker `deviceMemory=4`, four-core cgroup quota and 4 GiB memory limit. The observed browser hardware-concurrency value is recorded in the raw policy report; it is not overridden. Four pairs per cell are small samples. The same-binary controls and exploratory paired-median intervals are retained in the machine-readable results; they are not tight device-wide equivalence bounds.
+
+## Source accounting
+
+| Fixture  | Banks | Baseline source bytes transferred | Candidate source bytes transferred | Candidate route                   |
+| -------- | ----: | --------------------------------: | ---------------------------------: | --------------------------------- |
+| JMdict   |    53 |                         171092992 |                           15574114 | Three bounded compressed batches  |
+| JMnedict |    67 |                          45421175 |                           45421175 | Established ordinary single batch |
+| Jitendex |   218 |                         537538792 |                           33696215 | Nine bounded compressed batches   |
+
+Every report matches locked dictionary title, revision and row count; complete bank order/count and byte accounting; expected actual transport; identical pairwise deduplication totals; no import/settings errors or fallback storage; and at least twelve persisted-content readability probes. The probes are sampled, **not exhaustive database byte equivalence**. Fewer transferred source bytes are not a corresponding total-memory or elapsed-time reduction.
+
+## Correctness qualification
+
+Local and [independent source qualification](https://github.com/ManabiIO/manabitan/actions/runs/34423413945) passed **5,484 unit tests**, with 46 existing skips; **25 options tests**; all four strict TypeScript projects; repository JavaScript lint; library builds and all-target dry builds. Independent source publication occurred only after those checks and a clean-tree assertion. Its patch was downloaded and checked byte-for-byte against the locally tested patch.
+
+Thirteen new tests cover low-memory tiers, exact byte/file boundaries, ordinary prefetch/read ownership, later fallback positions, small final batches, unavailable raw reads, invalid metadata, high/unknown memory, and 1,000 deterministic uneven metadata archives. Existing compressed-budget/cancellation tests retain their assertions, with fixtures adjusted to exercise multi-batch admission. Local focused validation passes 50 tests.
+
+Local strict Chromium E2E passes **84 phases without skipped verification**, including interrupted-update recovery, restart persistence, concurrent lookups, batch imports, search/hover stress and deletion. [Independent exact-source browser qualification](https://github.com/ManabiIO/manabitan/actions/runs/34424007325) also passed: **85 Chromium phases and 65 Firefox phases**, both with `status=success` and `skippedVerification=false`. The downloaded artifacts identify the same source commit and tree. Firefox was Developer Edition 156.0b5; this is functional coverage, not a Firefox performance measurement. Parent PR CI does not establish final-head normal CI.
+
+## Independent performance attempts and retained failures
+
+The independent constrained matrix uses the same frozen source/test tree, unmodified timing harness, exact fixture lock and native memory policy. Only complete, inspected cohorts qualify for effect estimates. The JMnedict lane stopped at a zero-phase settings-selector timeout before a later import, after **eleven** successful audited observations. A 15,118.3 ms candidate same-binary control remains in that record. JMdict and Jitendex reached the runner job limit after **seven and nine** recorded successful observations respectively; neither completed its fourteen-observation plan. All three lanes have **no effect estimate** and are not spliced into another plan. The overall performance matrix failed; successful source and browser jobs do not turn it green. The archived successful observations include slow candidates as well as faster ones. A repeat was attempted but no started run was verified, so it provides no evidence.
+
+An earlier verification helper used an incorrect expected patch digest. The downloaded patch matches the tested patch exactly; correcting the digest preserves the complete Git-tree and parent checks. This was not an importer failure. The runtime source did not change between the accepted local measurements and independent qualification.
+
+The separate definition-content packing candidate was rejected after its completed six-pair plan showed Jitendex **+2.62% paired-median / +1.64% equal-work time**. It is absent from this source. Its negative observations remain in the delivered evidence rather than disappearing from the record.
+
+## Review and limits
+
+Keep the original PR #31 history and the tested source identity visible. Review this as the reconciled bounded-import implementation plus conservative admission, not a revival of the obsolete optimization stack. No `develop`, `main`, release branch or Reader vendor pointer was changed by this continuation.
+
+Final-head normal CI and independently completed timing cohorts remain separate review gates; the independent Firefox functional result above is complete. ARM, Android, smaller-memory devices and other dictionaries are not performance-qualified here. Dependency-audit warnings inherited from the unchanged lockfile are not resolved by this performance work.

--- a/ext/js/dictionary/dictionary-importer.js
+++ b/ext/js/dictionary/dictionary-importer.js
@@ -1727,8 +1727,14 @@ export class DictionaryImporter {
                 } else if (!this._disableTermBankWasmFastPath) {
                     try {
                         const termFileEntry = /** @type {import('@zip.js/zip.js').Entry} */ (termFile);
+                        // Constrained devices use the same compressed parser, but only
+                        // for one bounded source batch at a time. Re-plan after each
+                        // batch is released; never pin an import-wide low-memory slab.
+                        const compressedSourcePlan = importWideSourceRunEnabled ?
+                            (termFileIndex === 0 ? compressedImportRunPlan : termBankSourcePipeline.createCompressedImportRunPlan(termFileIndex)) :
+                            null;
                         const importRunPlan = importWideSourceRunEnabled ?
-                            (termFileIndex === 0 ? compressedImportRunPlan ?? uncompressedImportRunPlan : null) ?? termBankSourcePipeline.createImportRunPlan(termFileIndex) :
+                            compressedSourcePlan ?? (termFileIndex === 0 ? uncompressedImportRunPlan : null) ?? termBankSourcePipeline.createImportRunPlan(termFileIndex) :
                             null;
                         const usedImportWideSourceRun = importRunPlan !== null;
                         let sourceTermFileBatch = importRunPlan?.files ?? (termBankSourcePipeline.canPrefetch(termFile) ? termBankSourcePipeline.getBatch(termFileIndex) : []);
@@ -1738,7 +1744,7 @@ export class DictionaryImporter {
                             {
                                 loaders: importRunPlan.loaders,
                                 estimatedByteLengths: importRunPlan.estimatedByteLengths,
-                                compressed: importRunPlan === compressedImportRunPlan,
+                                compressed: importRunPlan === compressedSourcePlan,
                             };
                         sourceArchiveReadMs += Math.max(0, Date.now() - tSourceArchiveReadStart);
                         if (preloadedTermFileBytes === null) {

--- a/ext/js/dictionary/term-bank-source-pipeline.js
+++ b/ext/js/dictionary/term-bank-source-pipeline.js
@@ -381,20 +381,31 @@ export class TermBankSourcePipeline {
     }
 
     /**
-     * Builds an import-wide plan over raw ZIP payloads only when every source
-     * has complete central-directory metadata required for exact validation.
+     * Builds a lazy raw-ZIP plan with complete validation metadata. On a
+     * low-memory device, admit only the current bounded batch, never the
+     * entire import. The parser's independent source-size guard still applies.
      * @param {number} startIndex
      * @returns {{files: TermBankSourceFile[], loaders: Array<() => Promise<CompressedTermBankSource>>, estimatedByteLengths: number[]}|null}
      */
     createCompressedImportRunPlan(startIndex) {
-        if (!this._enabled || this._lowMemory || this._compressedReadPool === null) { return null; }
-        const files = this._termFiles.slice(startIndex);
+        if (!this._enabled || this._compressedReadPool === null) { return null; }
+        const boundedBatch = this._lowMemory ? this.getBatchPlan(startIndex) : null;
+        if (boundedBatch !== null && (
+            boundedBatch.unknownSizeCount !== 0 ||
+            boundedBatch.estimatedBytes > this._batchMaxBytes
+        )) { return null; }
+        const files = boundedBatch === null ? this._termFiles.slice(startIndex) : boundedBatch.files;
         if (files.length < 4) { return null; }
         /** @type {Array<{compressionMethod: 0|8, compressedSize: number, uncompressedSize: number, signature: number}>} */
         const metadata = [];
+        let compressedBytes = 0;
         for (const file of files) {
             const value = this._getCompressedSourceMetadata(file);
             if (value === null) { return null; }
+            // Bound compressed allocations independently of declared decoded
+            // sizes, including overlapping or adversarial ZIP entries.
+            if (this._lowMemory && value.compressedSize > this._batchMaxBytes - compressedBytes) { return null; }
+            compressedBytes += value.compressedSize;
             metadata.push(value);
         }
         const estimatedByteLengths = metadata.map(({uncompressedSize}) => uncompressedSize);

--- a/ext/js/dictionary/term-bank-source-pipeline.js
+++ b/ext/js/dictionary/term-bank-source-pipeline.js
@@ -382,13 +382,17 @@ export class TermBankSourcePipeline {
 
     /**
      * Builds a lazy raw-ZIP plan with complete validation metadata. On a
-     * low-memory device, admit only the current bounded batch, never the
-     * entire import. The parser's independent source-size guard still applies.
+     * low-memory device, preserve ordinary single-batch imports and admit only
+     * the current batch of multi-batch imports. The parser's independent source-size guard still applies.
      * @param {number} startIndex
      * @returns {{files: TermBankSourceFile[], loaders: Array<() => Promise<CompressedTermBankSource>>, estimatedByteLengths: number[]}|null}
      */
     createCompressedImportRunPlan(startIndex) {
         if (!this._enabled || this._compressedReadPool === null) { return null; }
+        // Keep the established transport when the archive needs only one
+        // ordinary batch. Inspect the whole import even after a fallback;
+        // small final batches of genuinely multi-batch imports remain eligible.
+        if (this._lowMemory && this.getBatchPlan(0).files.length === this._termFiles.length) { return null; }
         const boundedBatch = this._lowMemory ? this.getBatchPlan(startIndex) : null;
         if (boundedBatch !== null && (
             boundedBatch.unknownSizeCount !== 0 ||

--- a/test/dictionary-import-ownership.test.js
+++ b/test/dictionary-import-ownership.test.js
@@ -359,7 +359,8 @@ describe('TermBankSourcePipeline', () => {
         });
 
         expect(pipeline.createImportRunPlan(0)).toBeNull();
-        expect(pipeline.createCompressedImportRunPlan(0)).toBeNull();
+        expect(pipeline.createCompressedImportRunPlan(0)?.files).toEqual(files.slice(0, 16));
+        expect(pipeline.createCompressedImportRunPlan(16)?.files).toEqual(files.slice(16, 32));
         expect(pipeline.getBatch(0)).toEqual(files.slice(0, 16));
         await pipeline.dispose();
     });

--- a/test/term-bank-bounded-compressed-plan.test.js
+++ b/test/term-bank-bounded-compressed-plan.test.js
@@ -1,0 +1,209 @@
+/*
+ * Copyright (C) 2023-2026  Yomitan Authors
+ * Copyright (C) 2020-2022  Yomichan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+/* eslint @stylistic/semi: ["error", "never"] */
+
+import {describe, expect, test, vi} from 'vitest'
+import {TermBankSourcePipeline} from '../ext/js/dictionary/term-bank-source-pipeline.js'
+
+const MiB = 1024 * 1024
+
+/**
+ * Sizes describe metadata only: tests do not allocate the uncompressed banks.
+ * @param {number[]} sizes
+ * @returns {{filename: string, offset: number, compressionMethod: number, compressedSize: number, uncompressedSize: number, signature: number, getData: () => void}[]}
+ */
+function filesFor(sizes) {
+    return sizes.map((size, index) => ({
+        filename: `term_bank_${index + 1}.json`,
+        offset: index * 64,
+        compressionMethod: 8,
+        compressedSize: 4,
+        uncompressedSize: size,
+        signature: index + 100,
+        getData() {},
+    }))
+}
+
+/**
+ * @param {ReturnType<typeof filesFor>} files
+ * @param {number} [deviceMemory=4]
+ * @returns {{pipeline: TermBankSourcePipeline, read: import('vitest').Mock<() => Promise<Uint8Array>>, readCompressed: import('vitest').Mock<() => Promise<Uint8Array>>}}
+ */
+function setup(files, deviceMemory = 4) {
+    const read = vi.fn(async () => new Uint8Array([91, 93]))
+    const readCompressed = vi.fn(async () => new Uint8Array(4))
+    const pipeline = new TermBankSourcePipeline({termFiles: files, enabled: true, read, readCompressed, deviceMemory})
+    return {pipeline, read, readCompressed}
+}
+
+describe('bounded compressed term-bank plans', () => {
+    test.each([0.5, 1, 2, 4])('keeps every lazy run within the existing source budget; deviceMemory=%s', async (memory) => {
+        const files = filesFor(new Array(64).fill(4 * MiB))
+        const {pipeline, read, readCompressed} = setup(files, memory)
+        for (let start = 0; start < files.length; start += 16) {
+            const plan = pipeline.createCompressedImportRunPlan(start)
+            expect(plan?.files).toEqual(files.slice(start, start + 16))
+            expect(plan?.estimatedByteLengths.reduce((sum, size) => sum + size, 0)).toBe(64 * MiB)
+            expect(plan?.loaders).toHaveLength(16)
+        }
+        expect(pipeline.createCompressedImportRunPlan(files.length)).toBeNull()
+        expect(read).not.toHaveBeenCalled()
+        expect(readCompressed).not.toHaveBeenCalled()
+        expect(pipeline.prefetchMaxBytes).toBe(24 * MiB)
+        await pipeline.dispose()
+    })
+
+    test('accepts exactly the limit and splits the next byte into another batch', async () => {
+        const sizes = [16 * MiB, 16 * MiB, 16 * MiB, 16 * MiB, 2, 2, 2, 2]
+        const files = filesFor(sizes)
+        const {pipeline} = setup(files)
+        expect(pipeline.createCompressedImportRunPlan(0)?.files).toEqual(files.slice(0, 4))
+        expect(pipeline.createCompressedImportRunPlan(4)?.files).toEqual(files.slice(4))
+        await pipeline.dispose()
+    })
+
+    test.each([0, Number.NaN, Infinity, -1, 64 * MiB + 1, Number.MAX_SAFE_INTEGER])('does not bypass the budget for an invalid or oversized first bank: %s', async (size) => {
+        const {pipeline, readCompressed} = setup(filesFor([size, 2, 2, 2, 2]))
+        expect(pipeline.createCompressedImportRunPlan(0)).toBeNull()
+        expect(readCompressed).not.toHaveBeenCalled()
+        await pipeline.dispose()
+    })
+
+    test('also bounds compressed input when it is larger than the claimed output', async () => {
+        const files = filesFor([2, 2, 2, 2])
+        for (const file of files) { file.compressedSize = 16 * MiB }
+        const {pipeline, readCompressed} = setup(files)
+        expect(pipeline.createCompressedImportRunPlan(0)?.files).toEqual(files)
+        files[0].compressedSize += 1
+        expect(pipeline.createCompressedImportRunPlan(0)).toBeNull()
+        expect(readCompressed).not.toHaveBeenCalled()
+        await pipeline.dispose()
+    })
+
+    test('retains ordinary fallback for fewer than four banks and no raw reader', async () => {
+        const files = filesFor([2, 2, 2])
+        const {pipeline} = setup(files)
+        expect(pipeline.createCompressedImportRunPlan(0)).toBeNull()
+        await pipeline.dispose()
+        const noRaw = new TermBankSourcePipeline({termFiles: filesFor([2, 2, 2, 2]), enabled: true, read: async () => new Uint8Array(2), deviceMemory: 4})
+        expect(noRaw.createCompressedImportRunPlan(0)).toBeNull()
+        await noRaw.dispose()
+    })
+
+    test.each([8, Number.NaN])('does not change the larger/unknown-memory import-wide policy: %s', async (memory) => {
+        const files = filesFor(new Array(100).fill(4 * MiB))
+        const {pipeline} = setup(files, memory)
+        expect(pipeline.createCompressedImportRunPlan(0)?.files).toEqual(files)
+        expect(pipeline.createCompressedImportRunPlan(16)?.files).toEqual(files.slice(16))
+        await pipeline.dispose()
+    })
+
+    test('keeps the file-count cap and preserves ordering even for tiny banks', async () => {
+        const files = filesFor(new Array(164).fill(2))
+        const {pipeline} = setup(files)
+        for (const start of [0, 80, 160]) {
+            expect(pipeline.createCompressedImportRunPlan(start)?.files).toEqual(files.slice(start, start + 80))
+        }
+        await pipeline.dispose()
+    })
+
+    test('validates the current batch without eagerly reading later invalid metadata', async () => {
+        const files = filesFor(new Array(32).fill(4 * MiB))
+        files[20].compressionMethod = 12
+        const {pipeline, readCompressed} = setup(files)
+        expect(pipeline.createCompressedImportRunPlan(0)?.files).toEqual(files.slice(0, 16))
+        expect(pipeline.createCompressedImportRunPlan(16)).toBeNull()
+        expect(readCompressed).not.toHaveBeenCalled()
+        await pipeline.dispose()
+    })
+
+    test('shares reads within a run and releases ownership before a later retry', async () => {
+        const files = filesFor(new Array(32).fill(4 * MiB))
+        const {pipeline, read, readCompressed} = setup(files)
+        const plan = pipeline.createCompressedImportRunPlan(0)
+        if (plan === null) { throw new Error('Expected bounded plan') }
+        await Promise.all([plan.loaders[0](), plan.loaders[0]()])
+        expect(readCompressed).toHaveBeenCalledTimes(1)
+        pipeline.releaseBatch(plan.files)
+        await plan.loaders[0]()
+        expect(readCompressed).toHaveBeenCalledTimes(2)
+        expect(read).not.toHaveBeenCalled()
+        await pipeline.dispose()
+        await expect(plan.loaders[0]()).rejects.toThrow('disposed')
+    })
+
+    test('joins cancelled raw reads before fallback without starting unclaimed loaders', async () => {
+        const files = filesFor(new Array(32).fill(4 * MiB))
+        /** @type {AbortSignal[]} */
+        const signals = []
+        /** @type {Array<() => void>} */
+        const finish = []
+        const pipeline = new TermBankSourcePipeline({
+            termFiles: files,
+            enabled: true,
+            deviceMemory: 4,
+            read: async () => new Uint8Array([91, 93]),
+            readCompressed: async (_file, signal) => {
+                signals.push(signal)
+                await new Promise((resolve) => { finish.push(() => resolve(void 0)) })
+                signal.throwIfAborted()
+                return new Uint8Array(4)
+            },
+        })
+        const plan = pipeline.createCompressedImportRunPlan(0)
+        if (plan === null) { throw new Error('Expected bounded plan') }
+        const reading = expect(plan.loaders[0]()).rejects.toThrow()
+        let joined = false
+        const aborting = pipeline.abortAndJoin().then(() => { joined = true })
+        expect(signals).toHaveLength(1)
+        expect(signals[0].aborted).toBe(true)
+        await Promise.resolve()
+        expect(joined).toBe(false)
+        finish[0]()
+        await Promise.all([reading, aborting])
+        expect(joined).toBe(true)
+        await expect(pipeline.read(files[0])).resolves.toEqual(new Uint8Array([91, 93]))
+        await pipeline.dispose()
+    })
+
+    test('never exceeds byte or file limits across deterministic uneven source plans', async () => {
+        let seed = 0x91271215
+        const random = () => {
+            seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0
+            return seed
+        }
+        for (let trial = 0; trial < 100; ++trial) {
+            const files = filesFor(Array.from({length: 200}, () => 2 + random() % (25 * MiB)))
+            const {pipeline} = setup(files)
+            for (let start = 0; start < files.length;) {
+                const ordinary = pipeline.getBatch(start)
+                const compressed = pipeline.createCompressedImportRunPlan(start)
+                if (compressed !== null) {
+                    expect(compressed.files).toEqual(ordinary)
+                    expect(compressed.files.length).toBeGreaterThanOrEqual(4)
+                    expect(compressed.files.length).toBeLessThanOrEqual(80)
+                    expect(compressed.estimatedByteLengths.reduce((a, b) => a + b, 0)).toBeLessThanOrEqual(64 * MiB)
+                } else {
+                    expect(ordinary.length).toBeLessThan(4)
+                }
+                start += ordinary.length
+            }
+            await pipeline.dispose()
+        }
+    })
+})

--- a/test/term-bank-bounded-compressed-plan.test.js
+++ b/test/term-bank-bounded-compressed-plan.test.js
@@ -85,10 +85,10 @@ describe('bounded compressed term-bank plans', () => {
     })
 
     test('also bounds compressed input when it is larger than the claimed output', async () => {
-        const files = filesFor([2, 2, 2, 2])
+        const files = filesFor([2, 2, 2, 2, 64 * MiB])
         for (const file of files) { file.compressedSize = 16 * MiB }
         const {pipeline, readCompressed} = setup(files)
-        expect(pipeline.createCompressedImportRunPlan(0)?.files).toEqual(files)
+        expect(pipeline.createCompressedImportRunPlan(0)?.files).toEqual(files.slice(0, 4))
         files[0].compressedSize += 1
         expect(pipeline.createCompressedImportRunPlan(0)).toBeNull()
         expect(readCompressed).not.toHaveBeenCalled()

--- a/test/term-bank-bounded-compressed.test.js
+++ b/test/term-bank-bounded-compressed.test.js
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2026 Manabitan authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+/* eslint @stylistic/semi: ["error", "never"] */
+
+import {describe, expect, test, vi} from 'vitest'
+import {TermBankSourcePipeline} from '../ext/js/dictionary/term-bank-source-pipeline.js'
+
+const mib = 1024 * 1024
+
+/**
+ * @param {number} count
+ * @param {number} [decodedBytes]
+ * @returns {Array<{filename: string, offset: number, compressionMethod: number, compressedSize: number, uncompressedSize: number, signature: number, getData: () => void}>}
+ */
+function filesFor(count, decodedBytes = 4 * mib) {
+    return Array.from({length: count}, (_, index) => ({
+        filename: `term_bank_${index + 1}.json`,
+        offset: index * 64,
+        compressionMethod: 8,
+        compressedSize: 4,
+        uncompressedSize: decodedBytes,
+        signature: index + 100,
+        getData() {},
+    }))
+}
+
+/**
+ * @param {ReturnType<typeof filesFor>} files
+ * @param {number} [deviceMemory]
+ * @returns {{pipeline: TermBankSourcePipeline, read: import('vitest').Mock<() => Promise<Uint8Array>>, readCompressed: import('vitest').Mock<() => Promise<Uint8Array>>}}
+ */
+function createPipeline(files, deviceMemory = 4) {
+    const read = vi.fn(async () => new Uint8Array([91, 93]))
+    const readCompressed = vi.fn(async () => new Uint8Array(4))
+    const pipeline = new TermBankSourcePipeline({termFiles: files, enabled: true, read, readCompressed, deviceMemory})
+    return {pipeline, read, readCompressed}
+}
+
+describe('bounded compressed source plans', () => {
+    test.each([0.5, 1, 2, 4])('keeps every lazy batch within both byte budgets at deviceMemory=%s', async (memory) => {
+        const files = filesFor(64)
+        const {pipeline, read, readCompressed} = createPipeline(files, memory)
+        try {
+            expect(pipeline.createImportRunPlan(0)).toBeNull()
+            for (const start of [0, 16, 32, 48]) {
+                const plan = pipeline.createCompressedImportRunPlan(start)
+                expect(plan?.files).toEqual(files.slice(start, start + 16))
+                if (plan === null) { throw new Error('Missing bounded plan') }
+                expect(plan.estimatedByteLengths.reduce((a, b) => a + b, 0)).toBe(64 * mib)
+                expect(readCompressed).toHaveBeenCalledTimes(start / 16)
+                await expect(plan.loaders[0]()).resolves.toMatchObject({
+                    filename: files[start].filename, uncompressedSize: 4 * mib, signature: files[start].signature,
+                })
+                pipeline.releaseBatch(plan.files)
+            }
+            expect(read).not.toHaveBeenCalled()
+            expect(pipeline.createCompressedImportRunPlan(files.length)).toBeNull()
+        } finally {
+            await pipeline.dispose()
+        }
+    })
+
+    test('keeps the existing import-wide plan on unconstrained devices', async () => {
+        const files = filesFor(64)
+        const {pipeline, readCompressed} = createPipeline(files, 8)
+        try {
+            expect(pipeline.createCompressedImportRunPlan(0)?.files).toEqual(files)
+            expect(readCompressed).not.toHaveBeenCalled()
+        } finally { await pipeline.dispose() }
+    })
+
+    test('rejects a compressed allocation budget overflow even with tiny decoded sizes', async () => {
+        const files = filesFor(4, 1024)
+        for (const file of files) { file.compressedSize = 17 * mib }
+        const {pipeline, readCompressed} = createPipeline(files)
+        try {
+            expect(pipeline.createCompressedImportRunPlan(0)).toBeNull()
+            expect(readCompressed).not.toHaveBeenCalled()
+        } finally { await pipeline.dispose() }
+    })
+
+    test('accepts exact compressed and decoded limits without reading ahead', async () => {
+        const files = filesFor(5, 16 * mib)
+        for (const file of files) { file.compressedSize = 16 * mib }
+        const {pipeline, readCompressed} = createPipeline(files)
+        try {
+            expect(pipeline.createCompressedImportRunPlan(0)?.files).toEqual(files.slice(0, 4))
+            expect(readCompressed).not.toHaveBeenCalled()
+        } finally { await pipeline.dispose() }
+    })
+
+    test.each([64 * mib + 1, Number.MAX_SAFE_INTEGER])('does not admit an oversized first bank: %s', async (size) => {
+        const files = filesFor(4, size)
+        const {pipeline, readCompressed} = createPipeline(files)
+        try {
+            expect(pipeline.createCompressedImportRunPlan(0)).toBeNull()
+            expect(readCompressed).not.toHaveBeenCalled()
+        } finally { await pipeline.dispose() }
+    })
+
+    test.each([0, -1, 1.5, Number.NaN, Infinity])('falls back for unknown or invalid decoded size %s', async (size) => {
+        const files = filesFor(4, size)
+        const {pipeline} = createPipeline(files)
+        try {
+            expect(pipeline.createCompressedImportRunPlan(0)).toBeNull()
+        } finally {
+            await pipeline.dispose()
+        }
+    })
+
+    test('does not reject a valid earlier batch because a later batch has invalid metadata', async () => {
+        const files = filesFor(32)
+        files[17].signature = -1
+        const {pipeline} = createPipeline(files)
+        try {
+            expect(pipeline.createCompressedImportRunPlan(0)?.files).toEqual(files.slice(0, 16))
+            expect(pipeline.createCompressedImportRunPlan(16)).toBeNull()
+        } finally { await pipeline.dispose() }
+    })
+
+    test('releases old reads before reopening the next bounded plan', async () => {
+        const files = filesFor(4)
+        const {pipeline, readCompressed} = createPipeline(files)
+        try {
+            const first = pipeline.createCompressedImportRunPlan(0)
+            if (first === null) { throw new Error('Missing source plan') }
+            const a = await first.loaders[0]()
+            const b = await first.loaders[0]()
+            expect(a.bytes).toBe(b.bytes)
+            expect(readCompressed).toHaveBeenCalledTimes(1)
+            pipeline.releaseBatch(first.files)
+            const second = pipeline.createCompressedImportRunPlan(0)
+            if (second === null) { throw new Error('Missing source plan') }
+            const c = await second.loaders[0]()
+            expect(c.bytes).not.toBe(a.bytes)
+            expect(readCompressed).toHaveBeenCalledTimes(2)
+        } finally { await pipeline.dispose() }
+    })
+
+    test('still cancels and joins every outstanding raw payload read', async () => {
+        const files = filesFor(4)
+        let aborted = 0
+        const pipeline = new TermBankSourcePipeline({
+            termFiles: files,
+            enabled: true,
+            deviceMemory: 4,
+            read: async () => new Uint8Array(),
+            readCompressed: (_file, signal) => new Promise((_resolve, reject) => {
+                signal.addEventListener('abort', () => {
+                    ++aborted
+                    reject(signal.reason)
+                }, {once: true})
+            }),
+        })
+        const plan = pipeline.createCompressedImportRunPlan(0)
+        if (plan === null) { throw new Error('Missing source plan') }
+        const reads = plan.loaders.map((load) => load())
+        const settled = Promise.allSettled(reads)
+        await pipeline.abortAndJoin()
+        expect(aborted).toBe(4)
+        expect((await settled).map(({status}) => status)).toEqual(new Array(4).fill('rejected'))
+        await pipeline.dispose()
+    })
+})

--- a/test/term-bank-bounded-compressed.test.js
+++ b/test/term-bank-bounded-compressed.test.js
@@ -84,7 +84,8 @@ describe('bounded compressed source plans', () => {
     })
 
     test('rejects a compressed allocation budget overflow even with tiny decoded sizes', async () => {
-        const files = filesFor(4, 1024)
+        const files = filesFor(5, 1024)
+        files[4].uncompressedSize = 64 * mib
         for (const file of files) { file.compressedSize = 17 * mib }
         const {pipeline, readCompressed} = createPipeline(files)
         try {
@@ -133,7 +134,7 @@ describe('bounded compressed source plans', () => {
     })
 
     test('releases old reads before reopening the next bounded plan', async () => {
-        const files = filesFor(4)
+        const files = filesFor(5, 16 * mib)
         const {pipeline, readCompressed} = createPipeline(files)
         try {
             const first = pipeline.createCompressedImportRunPlan(0)
@@ -152,7 +153,7 @@ describe('bounded compressed source plans', () => {
     })
 
     test('still cancels and joins every outstanding raw payload read', async () => {
-        const files = filesFor(4)
+        const files = filesFor(5, 16 * mib)
         let aborted = 0
         const pipeline = new TermBankSourcePipeline({
             termFiles: files,

--- a/test/term-bank-multibatch-admission.test.js
+++ b/test/term-bank-multibatch-admission.test.js
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2026 Manabitan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import {describe, expect, test, vi} from 'vitest';
+import {TermBankSourcePipeline} from '../ext/js/dictionary/term-bank-source-pipeline.js';
+
+const MiB = 1024 * 1024;
+
+/**
+ * These are metadata fixtures; they do not allocate the declared payloads.
+ * @param {number[]} sizes
+ * @returns {Array<{filename: string, offset: number, compressionMethod: number, compressedSize: number, uncompressedSize: number, signature: number, getData: () => void}>}
+ */
+function filesFor(sizes) {
+    return sizes.map((uncompressedSize, index) => ({
+        filename: `term_bank_${index + 1}.json`,
+        offset: index * 64,
+        compressionMethod: 8,
+        compressedSize: 4,
+        uncompressedSize,
+        signature: index,
+        getData() {},
+    }));
+}
+
+/**
+ * @param {ReturnType<typeof filesFor>} files
+ * @param {number} [deviceMemory]
+ * @returns {{pipeline: TermBankSourcePipeline, read: ReturnType<typeof vi.fn>, readCompressed: ReturnType<typeof vi.fn>}}
+ */
+function setup(files, deviceMemory = 4) {
+    const read = vi.fn(async () => new Uint8Array([91, 93]));
+    const readCompressed = vi.fn(async () => new Uint8Array(4));
+    return {
+        pipeline: new TermBankSourcePipeline({termFiles: files, enabled: true, read, readCompressed, deviceMemory}),
+        read,
+        readCompressed,
+    };
+}
+
+describe('compressed transport admission follows the ordinary batch boundary', () => {
+    test.each([0.5, 1, 2, 4])('preserves one-pass imports at deviceMemory=%s, including later fallback positions', async (memory) => {
+        for (const size of [1, MiB, 16 * MiB]) {
+            const files = filesFor(new Array(4).fill(size));
+            const {pipeline, read, readCompressed} = setup(files, memory);
+            expect(pipeline.getBatch(0)).toEqual(files);
+            for (let start = 0; start <= files.length; ++start) {
+                expect(pipeline.createCompressedImportRunPlan(start)).toBeNull();
+            }
+            expect(read).not.toHaveBeenCalled();
+            expect(readCompressed).not.toHaveBeenCalled();
+            await pipeline.dispose();
+        }
+    });
+
+    test('does not switch to raw reads halfway through a single-pass import', async () => {
+        const files = filesFor(new Array(12).fill(MiB));
+        const {pipeline, readCompressed} = setup(files);
+        // At index 4 there are still enough banks for compressed parsing. The
+        // decision must describe the whole import, not just its first call.
+        expect(pipeline.createCompressedImportRunPlan(4)).toBeNull();
+        const first = await pipeline.read(files[0]);
+        expect(await pipeline.read(files[0])).toBe(first);
+        pipeline.releaseBatch(files.slice(0, 4));
+        expect(pipeline.createCompressedImportRunPlan(4)).toBeNull();
+        expect(readCompressed).not.toHaveBeenCalled();
+        await pipeline.dispose();
+    });
+
+    test('preserves prefetch ownership and laziness on the ordinary one-pass route', async () => {
+        const files = filesFor(new Array(4).fill(16 * MiB));
+        const {pipeline, read, readCompressed} = setup(files);
+        expect(pipeline.createCompressedImportRunPlan(0)).toBeNull();
+        expect(pipeline.prefetchNext(0)).toEqual({fileCount: 1, estimatedBytes: 16 * MiB});
+        expect(read).toHaveBeenCalledTimes(1);
+        const batch = await pipeline.readBatch(pipeline.getBatch(0));
+        if (batch === null || Array.isArray(batch) || batch instanceof Uint8Array) {
+            throw new Error('Expected an ordinary lazy decoded batch');
+        }
+        expect(await Promise.all(batch.promises)).toEqual(new Array(4).fill(new Uint8Array([91, 93])));
+        expect(read).toHaveBeenCalledTimes(4);
+        expect(readCompressed).not.toHaveBeenCalled();
+        pipeline.releaseBatch(files);
+        await pipeline.dispose();
+    });
+
+    test('admits exactly 64 MiB when one additional byte requires another ordinary batch', async () => {
+        const files = filesFor([16 * MiB, 16 * MiB, 16 * MiB, 16 * MiB, 1]);
+        const {pipeline, readCompressed} = setup(files);
+        const first = pipeline.createCompressedImportRunPlan(0);
+        expect(first?.files).toEqual(files.slice(0, 4));
+        expect(first?.estimatedByteLengths.reduce((a, b) => a + b, 0)).toBe(64 * MiB);
+        expect(pipeline.createCompressedImportRunPlan(4)).toBeNull();
+        expect(readCompressed).not.toHaveBeenCalled();
+        await pipeline.dispose();
+    });
+
+    test('uses the existing 80-file limit even for tiny banks', async () => {
+        const files = filesFor(new Array(84).fill(1));
+        const onePass = setup(files.slice(0, 80));
+        for (const start of [0, 1, 40, 76]) {
+            expect(onePass.pipeline.createCompressedImportRunPlan(start)).toBeNull();
+        }
+        await onePass.pipeline.dispose();
+        const {pipeline} = setup(files);
+        expect(pipeline.createCompressedImportRunPlan(0)?.files).toEqual(files.slice(0, 80));
+        expect(pipeline.createCompressedImportRunPlan(80)?.files).toEqual(files.slice(80));
+        await pipeline.dispose();
+    });
+
+    test('keeps a small final batch eligible without requiring an earlier successful raw read', async () => {
+        const files = filesFor([...new Array(16).fill(4 * MiB), 2, 2, 2, 2]);
+        const {pipeline, read, readCompressed} = setup(files);
+        const last = pipeline.createCompressedImportRunPlan(16);
+        if (last === null) { throw new Error('Expected the final batch of a large import'); }
+        expect(last.files).toEqual(files.slice(16));
+        expect(readCompressed).not.toHaveBeenCalled();
+        const first = await last.loaders[0]();
+        expect((await last.loaders[0]()).bytes).toBe(first.bytes);
+        expect(readCompressed).toHaveBeenCalledTimes(1);
+        pipeline.releaseBatch(last.files);
+        expect((await last.loaders[0]()).bytes).not.toBe(first.bytes);
+        expect(readCompressed).toHaveBeenCalledTimes(2);
+        expect(read).not.toHaveBeenCalled();
+        await pipeline.dispose();
+    });
+
+    test.each([8, Number.NaN])('leaves small import-wide plans unchanged on larger or unknown memory: %s', async (memory) => {
+        const files = filesFor(new Array(4).fill(1));
+        const {pipeline, readCompressed} = setup(files, memory);
+        expect(pipeline.createCompressedImportRunPlan(0)?.files).toEqual(files);
+        expect(readCompressed).not.toHaveBeenCalled();
+        await pipeline.dispose();
+    });
+
+    test('retains fallback for disabled pipelines, absent raw readers, and malformed metadata', async () => {
+        const files = filesFor(new Array(20).fill(4 * MiB));
+        for (const enabled of [false, true]) {
+            const pipeline = new TermBankSourcePipeline({termFiles: files, enabled, deviceMemory: 4, read: async () => new Uint8Array(2)});
+            expect(pipeline.createCompressedImportRunPlan(0)).toBeNull();
+            await pipeline.dispose();
+        }
+        files[17].signature = -1;
+        const {pipeline, readCompressed} = setup(files);
+        expect(pipeline.createCompressedImportRunPlan(0)?.files).toEqual(files.slice(0, 16));
+        expect(pipeline.createCompressedImportRunPlan(16)).toBeNull();
+        expect(readCompressed).not.toHaveBeenCalled();
+        await pipeline.dispose();
+    });
+
+    test('matches an independent admission oracle over 1000 uneven metadata-only archives', async () => {
+        let state = 0x281ac71;
+        /** @returns {number} */
+        const random = () => {
+            state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+            return state;
+        };
+        for (let trial = 0; trial < 1000; ++trial) {
+            const sizes = Array.from({length: random() % 161}, () => 1 + random() % (18 * MiB));
+            let bytes = 0;
+            let count = 0;
+            for (const size of sizes) {
+                if (count === 80 || (count > 0 && bytes + size > 64 * MiB)) { break; }
+                bytes += size;
+                ++count;
+            }
+            const {pipeline, read, readCompressed} = setup(filesFor(sizes));
+            const plan = pipeline.createCompressedImportRunPlan(0);
+            const eligible = count >= 4 && count < sizes.length;
+            expect(plan !== null).toBe(eligible);
+            if (plan !== null) {
+                expect(plan.estimatedByteLengths).toEqual(sizes.slice(0, count));
+                expect(plan.files.length).toBeLessThanOrEqual(80);
+                expect(plan.estimatedByteLengths.reduce((a, b) => a + b, 0)).toBeLessThanOrEqual(64 * MiB);
+            }
+            expect(read).not.toHaveBeenCalled();
+            expect(readCompressed).not.toHaveBeenCalled();
+            await pipeline.dispose();
+        }
+    });
+});


### PR DESCRIPTION
## Measured local wins; conservative admission; no release merge

This PR now includes the tested multi-batch admission refinement, not just the earlier reconciliation. Source/test commit **34839d51d9b2cda28806b4a3908cda88847de87d**, complete source/test tree **4035249c23197b72d8be9d4cca7ebd6476771ef1**. Head **d5dd9cb0072059b326f333ef425018ce1227a756** adds the report only. Both are normal descendants of the previous #31 head; no force push.

[Full report, exact timing boundaries, source accounting and retained failures](https://github.com/ManabiIO/manabitan/blob/fix/bounded-import-accepted-base-20260909/dev/perf/multibatch-admission-results-20260909.md)

### What earns inclusion

Compared with accepted develop **da8f7436d34e510441d30692c8d698806b70e13f**, two separately completed fixed local comparisons reproduce substantial whole-import gains for JMdict and Jitendex. This does **not** reuse or add old #24 percentages from the rejected parser stack.

Negative means less elapsed time; percentages are medians of within-pair ratios, not ratios of separate medians.

| Dictionary | First four-pair plan | Reversed-order four-pair confirmation | Faster pairs |
|---|---:|---:|---:|
| JMdict | **-18.21%** | **-18.32%** | **4/4 in each plan** |
| Jitendex | **-20.78%** | **-23.27%** | **4/4 in each plan** |
| JMnedict | -1.83% | +2.46% | 3/4 and 1/4 |

Equal-work total changes: JMdict **-18.83% / -18.51%**; Jitendex **-20.89% / -22.54%**; JMnedict **-1.83% / +1.22%**. JMnedict has no demonstrated improvement or tight non-regression bound. Its intervals cross zero, and same-binary controls vary from -8.18% to +6.65% across the local plans. All unfavorable observations remain included. The committed table is regenerated from raw reports and supersedes interim chat figures.

Local Linux x64, Node 24.20.0, Chromium 153.0.8010.12, clang 17, native page AND worker deviceMemory=4, four-core quota / 4 GiB cgroup limit. Fixed alternating adjacent A/B pairs, rotated dictionaries, fresh profiles, separately excluded warmups and interleaved same-binary controls. Unchanged browser file-input-change to current-operation post-UI completion timing. No retries, outlier deletion, cross-run pooling or tracing during timing. Small four-pair cells are not cross-device guarantees.

### Runtime scope

On low-memory devices, admit compressed-source transport only when the import needs multiple ordinary batches under the existing **64 MiB decoded-source / 80-file limits**. Imports fitting one batch keep the established ordinary transport even after later planner calls; small final batches of larger imports remain eligible. No dictionary-name exceptions or new tuned threshold.

JMdict transfers 15,574,114 compressed bytes instead of 171,092,992 expanded bytes across three batches. Jitendex transfers 33,696,215 instead of 537,538,792 across nine. JMnedict retains ordinary single-batch transport and the same 45,421,175 transferred bytes on both sides.

Keep the independent 64 MiB compressed-input bound, integrity validation, cancellation/ownership, release-before-replan and fallbacks. These are source-batch limits, NOT whole-process or WASM-heap bounds. High/unknown-memory behavior stays inherited from #31. Parser/WASM, compression levels, storage formats, cache capacities, worker defaults, UI and dependencies are unchanged. Compared packages differ in exactly the importer and source-pipeline JavaScript modules.

The #18 production parser and accepted #22 miniz remain; rejected SIMD/composite, custom ZIP splitter, cache/copy and the new unsuccessful packing experiment are excluded. Existing history and negative evidence are preserved.

### Completed correctness

Local and independent exact-source qualification: **5,484 unit tests passed, 46 existing skips; 25 options tests; all four strict TypeScript projects; repository JavaScript lint; library and all-target dry builds**. Thirteen new tests include 1,000 deterministic uneven metadata archives and byte/file/ownership/fallback boundaries. Existing assertions remain; no lint or type rule was weakened.

Local strict Chromium integration: **84 phases, no skipped verification**. Downloaded and inspected [independent exact-source browser qualification](https://github.com/ManabiIO/manabitan/actions/runs/34424007325): **85 Chromium phases and 65 Firefox phases**, both success with skippedVerification=false. Firefox Developer Edition 156.0b5 is functional coverage, not a Firefox performance result.

All **84 reports from the complete local plans** were independently re-audited for exact metadata/rows, complete bank order/count/byte accounting, actual transport, pairwise dedup totals, frozen source/package/harness identities, errors/fallback storage and at least 12 persisted-content readability probes each. Probes are sampled, not exhaustive database equivalence.

### Remaining review gates and failures

Keep draft. The [independent constrained timing matrix](https://github.com/ManabiIO/manabitan/actions/runs/34423413945) is **not green**: JMnedict stopped on a later pre-import settings-selector timeout after 11 accepted observations (including a 15,118.3 ms same-binary candidate control); JMdict and Jitendex reached the job limit after 7 and 9 recorded accepted observations. None completed its fixed plan; no effect estimates or spliced cohorts are used. Independent source tests succeeded in that same run, but do not erase timing failures.

An earlier verification-helper patch-digest check was mistyped; downloading and comparing the exact patch established source identity before correcting the check. It was not a product regression. The new definition-content packing experiment was discarded after Jitendex +2.62% paired / +1.64% equal-work time; it is not in this PR.

Final-head normal PR CI must be read for this new head; old #31 CI is not relabeled as current. Independent complete timing, broader devices/dictionaries and ARM/mobile performance remain unqualified. No develop/main/release branch or Reader vendor pin was advanced.